### PR TITLE
IRStructurizer: Align API of `code_structured` with `code_typed`

### DIFF
--- a/IRStructurizer/README.md
+++ b/IRStructurizer/README.md
@@ -10,15 +10,16 @@ julia> using IRStructurizer
 julia> f(x) = x > 0 ? x + 1 : x - 1
 
 julia> code_structured(f, Tuple{Int})
-StructuredCodeInfo(
-│   %1 = intrinsic Base.slt_int(0, x)::Bool
-└── if %1 -> Nothing
-    ├ then:
-    │   %3 = intrinsic Base.add_int(x, 1)::Int64
-    │   return %3
-    ├ else:
-    │   %5 = intrinsic Base.sub_int(x, 1)::Int64
-    └   return %5
+1-element Vector{Pair{StructuredCodeInfo, DataType}}:
+ StructuredCodeInfo(
+│ %1 = intrinsic Base.slt_int(0, x)::Bool
+│ %2 = if %1 -> Nothing
+│ ├ then:
+│ │   %3 = intrinsic Base.add_int(x, 1)::Int64
+│ │   return %3
+│ ├ else:
+│ │   %5 = intrinsic Base.sub_int(x, 1)::Int64
+│ └   return %5
 ) => Int64
 ```
 

--- a/IRStructurizer/test/runtests.jl
+++ b/IRStructurizer/test/runtests.jl
@@ -27,7 +27,7 @@ using Core: SSAValue
     @test any(x -> x isa IfOp, statements(sci.entry.body))
 
     # code_structured does both steps
-    sci2, _ = code_structured(g, Tuple{Int})
+    sci2, _ = code_structured(g, Tuple{Int}) |> only
     @test any(x -> x isa IfOp, statements(sci2.entry.body))
 end
 
@@ -62,7 +62,7 @@ end
             i += 1
         end
         return i
-    end
+    end |> only
 
     # Counting loop should produce ForOp
     loop_ops = filter(x -> x isa ControlFlowOp, collect(statements(sci.entry.body)))
@@ -74,7 +74,7 @@ end
     # Verify display shows proper structure
     sci, _ = code_structured(Tuple{Bool}) do x::Bool
         x ? 1 : 2
-    end
+    end |> only
 
     io = IOBuffer()
     show(io, MIME"text/plain"(), sci)
@@ -281,7 +281,7 @@ end  # CFG analysis
             i += 1
         end
         return i
-    end
+    end |> only
     for_ops = filter(x -> x isa ForOp, collect(statements(sci.entry.body)))
     @test length(for_ops) == 1
 
@@ -316,7 +316,7 @@ end
             i += 1
         end
         return acc
-    end
+    end |> only
     for_ops = filter(x -> x isa ForOp, collect(statements(sci.entry.body)))
     @test length(for_ops) == 1
 
@@ -346,7 +346,7 @@ end
             acc += i
         end
         return acc
-    end
+    end |> only
     validate_scf(sci)
 
     # Verify IR is valid (LoopOp is nested inside IfOps from iterator protocol)
@@ -417,7 +417,7 @@ end  # WhileOp detection
             step += 1
         end
         return i
-    end
+    end |> only
     @test sci isa StructuredCodeInfo
 
     # Should have some loop op (not ForOp since step changes)
@@ -503,7 +503,7 @@ end
 @testset "type preservation" begin
     sci, _ = code_structured(Tuple{Float64}) do x::Float64
         x + 1.0
-    end
+    end |> only
 
     # Float64 type should be preserved in ssavaluetypes
     @test !isempty(sci.code.ssavaluetypes)
@@ -513,7 +513,7 @@ end
 @testset "multiple arguments" begin
     sci, _ = code_structured(Tuple{Int, Float64}) do x::Int, y::Float64
         x + y
-    end
+    end |> only
     @test sci.entry.terminator isa Core.ReturnNode
 end
 
@@ -536,7 +536,7 @@ end
             x, y = y, x
         end
         return x
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -548,7 +548,7 @@ end
         while x > 0
         end
         return x
-    end
+    end |> only
     validate_scf(sci)
 
     # Find the loop in the structure
@@ -569,7 +569,7 @@ end
             count += 1
         end
         return count
-    end
+    end |> only
     validate_scf(sci)
 
     while_idx = findfirst(stmt -> stmt isa WhileOp, collect(statements(sci.entry.body)))
@@ -598,7 +598,7 @@ end
             i += 1
         end
         return acc
-    end
+    end |> only
     validate_scf(sci_while)
     for_ops = filter(x -> x isa ForOp, collect(statements(sci_while.entry.body)))
     @test length(for_ops) == 1
@@ -611,7 +611,7 @@ end
             acc += i
         end
         return acc
-    end
+    end |> only
     validate_scf(sci_for)
     # LoopOp will be nested inside IfOps, just verify the IR is valid
     @test sci_for isa StructuredCodeInfo
@@ -638,7 +638,7 @@ end
             state += 1
         end
         return acc
-    end
+    end |> only
 
     # Should produce valid structured IR (no unstructured control flow)
     validate_scf(sci)
@@ -673,7 +673,7 @@ end  # regression
             acc += i
         end
         return acc
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -696,7 +696,7 @@ end
             acc *= i
         end
         return acc
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -723,7 +723,7 @@ end
             end
         end
         return count
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -751,7 +751,7 @@ end
             count += 1
         end
         return sum, count
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -780,7 +780,7 @@ end
             end
         end
         return acc
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -802,7 +802,7 @@ end
             x, y = y, x
         end
         return x
-    end
+    end |> only
     validate_scf(sci)
 end
 
@@ -825,7 +825,7 @@ end
             last = i
         end
         return last
-    end
+    end |> only
     validate_scf(sci)
 end
 


### PR DESCRIPTION
The API for `code_structured` diverges from `code_typed` and co.

A query of a function and types can have multiple matches, and as such, `code_typed` always returns a vector of all answers that match that query.

Makes it a bit annoying if you only work with a single method (hence the sprinkle of only),
but makes it easier if you want to do something like:

```julia
julia> using IRStructurizer

julia> f(x::Int32) = x - 1
f (generic function with 1 method)

julia> f(x::Int) = x - 1
f (generic function with 2 methods)

julia> code_structured(f, Tuple{Signed})
2-element Vector{Pair{StructuredCodeInfo, DataType}}:
                                                 StructuredCodeInfo(
│ %1 = intrinsic Base.sub_int(x, 1)::Int64
└ return %1
) => Int64
 StructuredCodeInfo(
│ %1 = intrinsic Base.sext_int(Int64, x)::Int64
│ %2 = intrinsic Base.sub_int(%1, 1)::Int64
└ return %2
) => Int64
```

Altough someting is off with the formating of the first StructuredCodeInfo.
