### PR TITLE
Add bindings for more math ops

### DIFF
--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -746,6 +746,26 @@ function encode_MulIOp!(cb::CodeBuilder, result_type::TypeId, lhs::Value, rhs::V
 end
 
 """
+    encode_FmaOp!(cb, result_type, lhs, rhs, acc; kwargs...) -> Value
+
+Float multiply-add operation: result = lhs * rhs + acc.
+Opcode: 40
+"""
+function encode_FmaOp!(cb::CodeBuilder, result_type::TypeId,
+                       lhs::Value, rhs::Value, acc::Value;
+                       rounding_mode::RoundingMode=RoundingNearestEven,
+                       flush_to_zero::Bool=false)
+    encode_varint!(cb.buf, Opcode.FmaOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_varint!(cb.buf, flush_to_zero ? 1 : 0)
+    encode_enum!(cb.buf, rounding_mode)
+    encode_operand!(cb.buf, lhs)
+    encode_operand!(cb.buf, rhs)
+    encode_operand!(cb.buf, acc)
+    return new_op!(cb)
+end
+
+"""
     encode_PowOp!(cb, result_type, base, exponent) -> Value
 
 Floating-point power operation (base^exponent).
@@ -775,6 +795,32 @@ function encode_TruncIOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
 end
 
 """
+    encode_CeilOp!(cb, result_type, source) -> Value
+
+Ceiling operation.
+Opcode: 13
+"""
+function encode_CeilOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.CeilOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_FloorOp!(cb, result_type, source) -> Value
+
+Floor operation.
+Opcode: 39
+"""
+function encode_FloorOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.FloorOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
     encode_DivFOp!(cb, result_type, lhs, rhs; rounding_mode, flush_to_zero) -> Value
 
 Floating-point division.
@@ -793,6 +839,20 @@ function encode_DivFOp!(cb::CodeBuilder, result_type::TypeId, lhs::Value, rhs::V
 end
 
 """
+    encode_RemFOp!(cb, result_type, lhs, rhs) -> Value
+
+Floating-point remainder.
+Opcode: 89
+"""
+function encode_RemFOp!(cb::CodeBuilder, result_type::TypeId, lhs::Value, rhs::Value)
+    encode_varint!(cb.buf, Opcode.RemFOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, lhs)
+    encode_operand!(cb.buf, rhs)
+    return new_op!(cb)
+end
+
+"""
     encode_SqrtOp!(cb, result_type, source; rounding_mode, flush_to_zero) -> Value
 
 Square root operation.
@@ -805,6 +865,21 @@ function encode_SqrtOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
     encode_typeid!(cb.buf, result_type)
     encode_varint!(cb.buf, flush_to_zero ? 1 : 0)
     encode_enum!(cb.buf, rounding_mode)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_RsqrtOp!(cb, result_type, source; flush_to_zero) -> Value
+
+Reciprocal square root operation.
+Opcode: 93
+"""
+function encode_RsqrtOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
+                         flush_to_zero::Bool=false)
+    encode_varint!(cb.buf, Opcode.RsqrtOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_varint!(cb.buf, flush_to_zero ? 1 : 0)
     encode_operand!(cb.buf, source)
     return new_op!(cb)
 end
@@ -830,6 +905,138 @@ Opcode: 79
 """
 function encode_NegFOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
     encode_varint!(cb.buf, Opcode.NegFOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_ExpOp!(cb, result_type, source) -> Value
+
+Exponential operation.
+Opcode: 23
+"""
+function encode_ExpOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.ExpOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_Exp2Op!(cb, result_type, source) -> Value
+
+Base-2 exponential operation.
+Opcode: 24
+"""
+function encode_Exp2Op!(cb::CodeBuilder, result_type::TypeId, source::Value;
+                        flush_to_zero::Bool=false)
+    encode_varint!(cb.buf, Opcode.Exp2Op)
+    encode_typeid!(cb.buf, result_type)
+    encode_varint!(cb.buf, flush_to_zero ? 1 : 0)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_LogOp!(cb, result_type, source) -> Value
+
+Natural logarithm operation.
+Opcode: 63
+"""
+function encode_LogOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.LogOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_Log2Op!(cb, result_type, source) -> Value
+
+Base-2 logarithm operation.
+Opcode: 64
+"""
+function encode_Log2Op!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.Log2Op)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_SinOp!(cb, result_type, source) -> Value
+
+Sine operation.
+Opcode: 98
+"""
+function encode_SinOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.SinOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_SinHOp!(cb, result_type, source) -> Value
+
+Hyperbolic sine operation.
+Opcode: 99
+"""
+function encode_SinHOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.SinHOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_CosOp!(cb, result_type, source) -> Value
+
+Cosine operation.
+Opcode: 18
+"""
+function encode_CosOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.CosOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_CosHOp!(cb, result_type, source) -> Value
+
+Hyperbolic cosine operation.
+Opcode: 19
+"""
+function encode_CosHOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.CosHOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_TanOp!(cb, result_type, source) -> Value
+
+Tangent operation.
+Opcode: 105
+"""
+function encode_TanOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.TanOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, source)
+    return new_op!(cb)
+end
+
+"""
+    encode_TanHOp!(cb, result_type, source) -> Value
+
+Hyperbolic tangent operation.
+Opcode: 106
+"""
+function encode_TanHOp!(cb::CodeBuilder, result_type::TypeId, source::Value)
+    encode_varint!(cb.buf, Opcode.TanHOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, source)
     return new_op!(cb)

--- a/src/compiler/intrinsics/math.jl
+++ b/src/compiler/intrinsics/math.jl
@@ -4,31 +4,195 @@
 ## TODO: cuda_tile.atan2
 
 
-## TODO: cuda_tile.ceil
+## cuda_tile.ceil
+
+@eval Intrinsics begin
+    """Element-wise ceiling. Compiled to cuda_tile.ceil."""
+    @noinline function ceil(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.ceil), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for ceil()")
+
+    result = encode_CeilOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.cosh
+## cuda_tile.cosh
+
+@eval Intrinsics begin
+    """Element-wise hyperbolic cosine. Compiled to cuda_tile.cosh."""
+    @noinline function cosh(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.cosh), args)
+    cb = ctx.cb
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for cosh()")
+
+    result = encode_CosHOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.cos
+## cuda_tile.cos
+
+@eval Intrinsics begin
+    """Element-wise cosine. Compiled to cuda_tile.cos."""
+    @noinline function cos(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.cos), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for cos()")
+
+    result = encode_CosOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.exp2
+## cuda_tile.exp2
+
+@eval Intrinsics begin
+    """Element-wise base-2 exponential. Compiled to cuda_tile.exp2."""
+    @noinline function exp2(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.exp2), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for exp2()")
+
+    result = encode_Exp2Op!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.exp
+## cuda_tile.exp
+
+@eval Intrinsics begin
+    """Element-wise exponential. Compiled to cuda_tile.exp."""
+    @noinline function exp(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.exp), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for exp()")
+
+    result = encode_ExpOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.floor
+## cuda_tile.floor
+
+@eval Intrinsics begin
+    """Element-wise floor. Compiled to cuda_tile.floor."""
+    @noinline function floor(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.floor), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for floor()")
+
+    result = encode_FloorOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.fma
+## cuda_tile.fma
 
+@eval Intrinsics begin
+    """Element-wise fused multiply-add. Compiled to cuda_tile.fma."""
+    @noinline function fma(a::Tile{T, S}, b::Tile{T, S}, c::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(a, b, c)
+        Tile{T, S}()
+    end
+end
 
-## TODO: cuda_tile.log2
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.fma), args)
+    cb = ctx.cb
 
+    lhs = emit_value!(ctx, args[1])
+    rhs = emit_value!(ctx, args[2])
+    acc = emit_value!(ctx, args[3])
 
-## TODO: cuda_tile.log
+    (lhs === nothing || rhs === nothing || acc === nothing) && error("Cannot resolve operands for fma")
+
+    result = encode_FmaOp!(cb, lhs.type_id, lhs.v, rhs.v, acc.v)
+    CGVal(result, lhs.type_id, lhs.jltype, lhs.shape)
+end
+
+## cuda_tile.log2
+
+@eval Intrinsics begin
+    """Element-wise base-2 logarithm. Compiled to cuda_tile.log2."""
+    @noinline function log2(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.log2), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for log2()")
+
+    result = encode_Log2Op!(cb, source.type_id, source.v)
+
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
+
+## cuda_tile.log
+
+@eval Intrinsics begin
+    """Element-wise natural logarithm. Compiled to cuda_tile.log."""
+    @noinline function log(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.log), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for log()")
+
+    result = encode_LogOp!(cb, source.type_id, source.v)
+
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
 ## cuda_tile.maxf
@@ -80,8 +244,28 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.pow), args)
 end
 
 
-## TODO: cuda_tile.remf
+## cuda_tile.remf
 
+@eval Intrinsics begin
+    """Element-wise remainder. Compiled to cuda_tile.remf."""
+    @noinline function remf(a::Tile{T, S}, b::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(a, b)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.remf), args)
+    cb = ctx.cb
+
+    lhs = emit_value!(ctx, args[1])
+    rhs = emit_value!(ctx, args[2])
+
+    (lhs === nothing || rhs === nothing) && error("Cannot resolve operands for remf")
+
+    result = encode_RemFOp!(cb, lhs.type_id, lhs.v, rhs.v)
+
+    CGVal(result, lhs.type_id, lhs.jltype, lhs.shape)
+end
 
 ## cuda_tile.rsqrt
 
@@ -99,16 +283,52 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.rsqrt), args)
     source = emit_value!(ctx, args[1])
     source === nothing && error("Cannot resolve operand for rsqrt()")
 
-    result = encode_RSqrtOp!(cb, source.type_id, source.v)
+    result = encode_RsqrtOp!(cb, source.type_id, source.v)
 
     CGVal(result, source.type_id, source.jltype, source.shape)
 end
 
 
-## TODO: cuda_tile.sinh
+## cuda_tile.sinh
+
+@eval Intrinsics begin
+    """Element-wise hyperbolic sine. Compiled to cuda_tile.sinh."""
+    @noinline function sinh(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.sinh), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for sinh()")
+
+    result = encode_SinHOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.sin
+## cuda_tile.sin
+
+@eval Intrinsics begin
+    """Element-wise sine. Compiled to cuda_tile.sin."""
+    @noinline function sin(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.sin), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for sin()")
+
+    result = encode_SinOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
 ## cuda_tile.sqrt
@@ -133,7 +353,42 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.sqrt), args)
 end
 
 
-## TODO: cuda_tile.tanh
+## cuda_tile.tanh
+
+@eval Intrinsics begin
+    """Element-wise hyperbolic tangent. Compiled to cuda_tile.tanh."""
+    @noinline function tanh(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.tanh), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for tanh()")
+
+    result = encode_TanHOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end
 
 
-## TODO: cuda_tile.tan
+## cuda_tile.tan
+
+@eval Intrinsics begin
+    """Element-wise tangent. Compiled to cuda_tile.tan."""
+    @noinline function tan(tile::Tile{T, S}) where {T <: AbstractFloat, S}
+        Base.donotdelete(tile)
+        Tile{T, S}()
+    end
+end
+
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.tan), args)
+    cb = ctx.cb
+
+    source = emit_value!(ctx, args[1])
+    source === nothing && error("Cannot resolve operand for tan()")
+
+    result = encode_TanOp!(cb, source.type_id, source.v)
+    CGVal(result, source.type_id, source.jltype, source.shape)
+end

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -611,7 +611,7 @@ br = ct.extract(tile, (2, 2), (4, 4))  # Bottom-right (rows 5-8, cols 5-8)
  Math
 =============================================================================#
 
-public cdiv, floordiv, sqrt, rsqrt
+public cdiv, floordiv, sqrt, rsqrt, exp, exp2, log, log2, ceil, floor, sin, sinh, cos, cosh, tan, tanh, fma, rem
 
 """
     cdiv(a::Integer, b::Integer)
@@ -647,6 +647,119 @@ Compute element-wise reciprocal square root (1/sqrt(x)) of a tile.
 """
 @inline rsqrt(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
     Intrinsics.rsqrt(tile)
+
+"""
+    exp(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise exponential of a tile.
+"""
+@inline Base.exp(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.exp(tile)
+
+"""
+    exp2(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise base-2 exponential of a tile.
+"""
+@inline Base.exp2(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.exp2(tile)
+
+"""
+    log(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise natural logarithm of a tile.
+"""
+@inline Base.log(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.log(tile)
+
+"""
+    log2(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise base-2 logarithm of a tile.
+"""
+@inline Base.log2(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.log2(tile)
+
+"""
+    ceil(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise ceiling of a tile.
+"""
+@inline Base.ceil(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.ceil(tile)
+
+"""
+    floor(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise floor of a tile.
+"""
+@inline Base.floor(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.floor(tile)
+
+"""
+    sin(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise sine of a tile.
+"""
+@inline Base.sin(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.sin(tile)
+
+"""
+    sinh(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise hyperbolic sine of a tile.
+"""
+@inline Base.sinh(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.sinh(tile)
+
+"""
+    cos(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise cosine of a tile.
+"""
+@inline Base.cos(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.cos(tile)
+
+"""
+    cosh(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise hyperbolic cosine of a tile.
+"""
+@inline Base.cosh(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.cosh(tile)
+
+"""
+    tan(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise tangent of a tile.
+"""
+@inline Base.tan(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.tan(tile)
+
+"""
+    tanh(tile::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise hyperbolic tangent of a tile.
+"""
+@inline Base.tanh(tile::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.tanh(tile)
+
+"""
+    fma(a::Tile{T, S}, b::Tile{T, S}, c::Tile{T, S}) -> Tile{T, S}
+
+Fused multiply-add: a * b + c.
+Compute element-wise fused multiply-add of a tile.
+"""
+@inline Base.fma(a::Tile{T, S}, b::Tile{T, S}, c::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.fma(a, b, c)
+
+"""
+    rem(a::Tile{T, S}, b::Tile{T, S}) -> Tile{T, S}
+
+Compute element-wise remainder of a tile.
+"""
+@inline Base.rem(a::Tile{T, S}, b::Tile{T, S}) where {T <: AbstractFloat, S} =
+    Intrinsics.remf(a, b)
 
 # Broadcasting arithmetic - different shapes, broadcast then call intrinsic
 @inline function tile_add(a::Tile{T, S1}, b::Tile{T, S2}) where {T <: AbstractFloat, S1, S2}

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -539,25 +539,25 @@
     @testset "Floating Point" begin
         # TODO: absf - absolute value
         # TODO: atan2 - two-argument arctangent
-        # TODO: ceil - ceiling
-        # TODO: cos - cosine
-        # TODO: cosh - hyperbolic cosine
-        # TODO: exp - exponential
-        # TODO: exp2 - base-2 exponential
-        # TODO: floor - floor
-        # TODO: fma - fused multiply-add
-        # TODO: log - natural logarithm
-        # TODO: log2 - base-2 logarithm
         # TODO: maxf - element-wise maximum
         # TODO: minf - element-wise minimum
         # TODO: negf - negation
         # TODO: pow - power
-        # TODO: remf - floating-point remainder
-        # TODO: rsqrt - reciprocal square root
-        # TODO: sin - sine
-        # TODO: sinh - hyperbolic sine
-        # TODO: tan - tangent
-        # TODO: tanh - hyperbolic tangent
+
+        @testset "remf" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c
+                    pid = ct.bid(1)
+                    tile_a = ct.load(a, pid, (16,))
+                    tile_b = ct.load(b, pid, (16,))
+                    @check "remf"
+                    result = rem(tile_a, tile_b)
+                    ct.store(c, pid, result)
+                    return
+                end
+            end
+        end
 
         @testset "addf" begin
             @test @filecheck begin
@@ -628,6 +628,205 @@
                     @check "sqrt"
                     result = sqrt(tile)
                     ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "rsqrt" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "rsqrt"
+                    result = ct.rsqrt(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "exp" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "exp"
+                    result = exp(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "exp2" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "exp2"
+                    result = exp2(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "log" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "log"
+                    result = log(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "log2" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "log2"
+                    result = log2(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "ceil" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "ceil"
+                    result = ceil(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "floor" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "floor"
+                    result = floor(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "sin" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "sin"
+                    result = sin(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "sinh" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "sinh"
+                    result = sinh(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "cos" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "cos"
+                    result = cos(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "cosh" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "cosh"
+                    result = cosh(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "tan" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "tan"
+                    result = tan(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "tanh" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "tanh"
+                    result = tanh(tile)
+                    ct.store(b, pid, result)
+                    return
+                end
+            end
+        end
+
+        @testset "fma" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d},
+                                ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c, d
+                    pid = ct.bid(1)
+                    tile_a = ct.load(a, pid, (16,))
+                    tile_b = ct.load(b, pid, (16,))
+                    tile_c = ct.load(c, pid, (16,))
+                    @check "fma"
+                    result = fma(tile_a, tile_b, tile_c)
+                    ct.store(d, pid, result)
                     return
                 end
             end


### PR DESCRIPTION
Adds encodings and element-wise tile methods for:
- `rsqrt`
- `exp`
- `exp2`
- `log`
- `log2`
- `ceil`
- `floor`
- `sin`
- `sinh`
- `cos`
- `cosh`
- `tan`
- `tanh`
- `fma`
- `rem`

I used https://github.com/NVIDIA/cutile-python/blob/9db6438f2beea52f9ae3632c9a6815061eb1c761/src/cuda/tile/_bytecode/encodings.py for reference.

It's not clear if any or all of these should have corresponding methods in overlay.jl for scalars.

Still on the todo in math.jl is `atan2`, which I couldn't find an op for, and can't seem to find any mention of it in the python repo.

The methods don't really have a consistent ordering. It's vaguely grouped by add/mul/transcendental ops.