### PR TITLE
Allow broadcasting of more integer ops

### DIFF
--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -29,6 +29,7 @@
 @overlay Base.div(x::T, y::T, ::typeof(RoundUp)) where {T <: Unsigned} = Intrinsics.cldi(x, y, SignednessUnsigned)
 @overlay Base.rem(x::T, y::T) where {T <: Signed} = Intrinsics.remi(x, y, SignednessSigned)
 @overlay Base.rem(x::T, y::T) where {T <: Unsigned} = Intrinsics.remi(x, y, SignednessUnsigned)
+@overlay Base.mod1(x::T, y::T) where {T <: ScalarInt} = (m = mod(x, y); m == zero(m) ? y : m)
 
 # float
 @overlay Base.:+(x::T, y::T) where {T <: ScalarFloat} = Intrinsics.addf(x, y)
@@ -77,7 +78,7 @@
 @inline Base.:(-)(a::Tile{T, S}, b::Tile{T, S}) where {T <: Integer, S} = Intrinsics.subi(a, b)
 
 # broadcasted arithmetic (float)
-for (op, intrinsic) in ((:+, :addf), (:-, :subf), (:*, :mulf), (:/, :divf))
+for (op, intrinsic) in ((:+, :addf), (:-, :subf), (:*, :mulf), (:/, :divf), (:max, :maxf), (:min, :minf))
     @eval @inline function Base.Broadcast.broadcasted(::TileStyle, ::typeof($op), a::Tile{T,S1}, b::Tile{T,S2}) where {T<:AbstractFloat,S1,S2}
         S = broadcast_shape(S1, S2)
         Intrinsics.$intrinsic(broadcast_to(a, S), broadcast_to(b, S))
@@ -157,7 +158,7 @@ end
 @inline Base.:(/)(a::Tile{T, S}, b::Number) where {T <: AbstractFloat, S} = Intrinsics.divf(a, broadcast_to(Tile(T(b)), S))
 
 # broadcasted arithmetic (float)
-for (op, intrinsic) in ((:+, :addf), (:-, :subf), (:*, :mulf), (:/, :divf))
+for (op, intrinsic) in ((:+, :addf), (:-, :subf), (:*, :mulf), (:/, :divf), (:max, :maxf), (:min, :minf))
     @eval begin
         @inline Base.Broadcast.broadcasted(::TileStyle, ::typeof($op), a::Tile{T,S}, b::Number) where {T<:AbstractFloat,S} =
             Intrinsics.$intrinsic(a, broadcast_to(Tile(T(b)), S))


### PR DESCRIPTION
- Adds broadcasting of `min`, `max`.
- Adds `mod1` overlay.

There are other operators like `fld1`, `fldmod1` that currently fail. It seems `Base.fld1` is equivalent to `Base.cld`, but marks a slightly different intent, and pairs well with `mod1`. I'm also not sure what `mod` falls back to, so the current `mod1` implementation might not be as efficient as it could be. It differs from the Base method in that it uses `?` for the conditional, because `ifelse` fails.