### PR TITLE
Permute during reshape to support column-major storage.

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -23,12 +23,13 @@
         # TODO: unpack - unpack tiles
 
         @testset "reshape" begin
-            # 2D -> 1D reshape
+            # 2D -> 1D reshape (emits pre-permute for column-major conversion)
             @test @filecheck begin
                 @check_label "entry"
                 code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 8))
+                    @check "permute"   # pre-permute for 2D source
                     @check "reshape"
                     reshaped = ct.reshape(tile, (32,))
                     ct.store(b, pid, reshaped)
@@ -36,28 +37,60 @@
                 end
             end
 
-            # 1D -> 2D reshape
+            # 1D -> 2D reshape (emits post-permute for column-major conversion)
             @test @filecheck begin
                 @check_label "entry"
                 code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,2,spec2d}}) do a, b
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (64,))
                     @check "reshape"
+                    @check "permute"   # post-permute for 2D result
                     reshaped = ct.reshape(tile, (8, 8))
                     ct.store(b, pid, reshaped)
                     return
                 end
             end
 
-            # 3D -> 2D reshape (for FFT-like patterns)
+            # 3D -> 2D reshape (emits pre-permute and post-permute)
             @test @filecheck begin
                 @check_label "entry"
                 code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,2,spec2d}}) do a, b
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (2, 4, 8))
+                    @check "permute"   # pre-permute for 3D source
                     @check "reshape"
+                    @check "permute"   # post-permute for 2D result
                     reshaped = ct.reshape(tile, (2, 32))
                     ct.store(b, pid, reshaped)
+                    return
+                end
+            end
+
+            # 1D -> 1D reshape (no permutes needed - optimization)
+            @test @filecheck begin
+                @check_label "entry"
+                @check_not "permute"   # should NOT have permute for 1D->1D
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (32,))
+                    @check "reshape"
+                    reshaped = ct.reshape(tile, (32,))
+                    ct.store(a, pid, reshaped)
+                    return
+                end
+            end
+
+            # 2D -> 2D reshape (different shape, emits both permutes)
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (4, 8))
+                    @check "permute"   # pre-permute
+                    @check "reshape"
+                    @check "permute"   # post-permute
+                    reshaped = ct.reshape(tile, (8, 4))
+                    ct.store(a, pid, reshaped)
                     return
                 end
             end


### PR DESCRIPTION
Reshape in Tile IR assumes row major storage order, so permute the tile surrounding it.