### PR TITLE
Fix FFT example and add benchmark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Benchmarks comparing cuTile.jl against cuTile Python on an RTX 5080:
 | Matrix Multiplication | 48.3 TFLOPS | 48.6 TFLOPS | OK (=) |
 | Layer Normalization | 254 GB/s | 683 GB/s | https://github.com/JuliaGPU/cuTile.jl/issues/1 (-63%) |
 | Batch Matrix Multiply | 31.7 TFLOPS | 31.6 TFLOPS | OK (=) |
+| FFT (3-stage Cooley-Tukey) | 508 μs | 230 μs | (-55%) |
 
 Compute-intensive kernels (matmul, batch matmul) perform identically to Python. Memory-bound
 kernels (vadd, transpose) are within ~3% of Python. The layernorm kernel is slower due to

--- a/examples/benchmarks.jl
+++ b/examples/benchmarks.jl
@@ -7,6 +7,7 @@
 using CUDA
 using LinearAlgebra
 using CUDA: GPUArrays
+using FFTW
 import cuTile as ct
 
 #=============================================================================
@@ -375,6 +376,14 @@ const BATCHMATMUL_TM = 128
 const BATCHMATMUL_TN = 256
 const BATCHMATMUL_TK = 64
 
+# FFT sizes
+# Tile size is (D, BS, N2D), limited by tileiras compiler.
+# Current kernel loads all batches per block, limiting scalability.
+const FFT_BATCH = 64
+const FFT_SIZE = 512
+const FFT_FACTORS = (8, 8, 8)
+const FFT_ATOM_PACKING_DIM = 2
+
 # SIMT naive kernel (2-pass: compute mean/var, then normalize)
 function layernorm_simt_kernel!(X, W, B, Y, Mean, Rstd, N, eps)
     m = blockIdx().x
@@ -604,6 +613,228 @@ function benchmark_batchmatmul()
 end
 
 #=============================================================================
+ FFT (3-stage Cooley-Tukey) - Column-Major Version
+=============================================================================#
+
+# FFT kernel - 3-stage Cooley-Tukey decomposition (column-major)
+# Uses swapped dimensions and right-multiply for column-major compatibility.
+# Input/output layout: (D, BS, N2D) where D=2 for real/imag interleaving.
+function fft_kernel(
+    x_packed_in::ct.TileArray{Float32, 3},
+    y_packed_out::ct.TileArray{Float32, 3},
+    W0::ct.TileArray{Float32, 3},
+    W1::ct.TileArray{Float32, 3},
+    W2::ct.TileArray{Float32, 3},
+    T0::ct.TileArray{Float32, 3},
+    T1::ct.TileArray{Float32, 3},
+    n_const::ct.Constant{Int},
+    f0_const::ct.Constant{Int},
+    f1_const::ct.Constant{Int},
+    f2_const::ct.Constant{Int},
+    f0f1_const::ct.Constant{Int},
+    f1f2_const::ct.Constant{Int},
+    f0f2_const::ct.Constant{Int},
+    bs_const::ct.Constant{Int},
+    d_const::ct.Constant{Int},
+    n2d_const::ct.Constant{Int}
+)
+    N = n_const[]
+    F0 = f0_const[]
+    F1 = f1_const[]
+    F2 = f2_const[]
+    F0F1 = f0f1_const[]
+    F1F2 = f1f2_const[]
+    F0F2 = f0f2_const[]
+    BS = bs_const[]
+    D = d_const[]
+    N2D = n2d_const[]
+
+    bid = ct.bid(1)
+
+    # Load input (D, BS, N2D) and reshape to (2, BS, N)
+    X_ri = ct.reshape(ct.load(x_packed_in, (1, bid, 1), (D, BS, N2D)), (2, BS, N))
+    X_r = ct.reshape(ct.extract(X_ri, (1, 1, 1), (1, BS, N)), (BS, F1F2, F0))
+    X_i = ct.reshape(ct.extract(X_ri, (2, 1, 1), (1, BS, N)), (BS, F1F2, F0))
+
+    # Load DFT matrices
+    W0_ri = ct.reshape(ct.load(W0, (1, 1, 1), (F0, F0, 2)), (F0, F0, 2))
+    W0_r = ct.broadcast_to(ct.reshape(ct.extract(W0_ri, (1, 1, 1), (F0, F0, 1)), (1, F0, F0)), (BS, F0, F0))
+    W0_i = ct.broadcast_to(ct.reshape(ct.extract(W0_ri, (1, 1, 2), (F0, F0, 1)), (1, F0, F0)), (BS, F0, F0))
+
+    W1_ri = ct.reshape(ct.load(W1, (1, 1, 1), (F1, F1, 2)), (F1, F1, 2))
+    W1_r = ct.broadcast_to(ct.reshape(ct.extract(W1_ri, (1, 1, 1), (F1, F1, 1)), (1, F1, F1)), (BS, F1, F1))
+    W1_i = ct.broadcast_to(ct.reshape(ct.extract(W1_ri, (1, 1, 2), (F1, F1, 1)), (1, F1, F1)), (BS, F1, F1))
+
+    W2_ri = ct.reshape(ct.load(W2, (1, 1, 1), (F2, F2, 2)), (F2, F2, 2))
+    W2_r = ct.broadcast_to(ct.reshape(ct.extract(W2_ri, (1, 1, 1), (F2, F2, 1)), (1, F2, F2)), (BS, F2, F2))
+    W2_i = ct.broadcast_to(ct.reshape(ct.extract(W2_ri, (1, 1, 2), (F2, F2, 1)), (1, F2, F2)), (BS, F2, F2))
+
+    # Load twiddle factors (column-major layout)
+    T0_ri = ct.reshape(ct.load(T0, (1, 1, 1), (F1F2, F0, 2)), (F1F2, F0, 2))
+    T0_r = ct.reshape(ct.extract(T0_ri, (1, 1, 1), (F1F2, F0, 1)), (1, N))
+    T0_i = ct.reshape(ct.extract(T0_ri, (1, 1, 2), (F1F2, F0, 1)), (1, N))
+
+    T1_ri = ct.reshape(ct.load(T1, (1, 1, 1), (F0F2, F1, 2)), (F0F2, F1, 2))
+    T1_r = ct.reshape(ct.extract(T1_ri, (1, 1, 1), (F0F2, F1, 1)), (1, F0F2 * F1))
+    T1_i = ct.reshape(ct.extract(T1_ri, (1, 1, 2), (F0F2, F1, 1)), (1, F0F2 * F1))
+
+    # Stage 0: F0-point DFT via right-multiply
+    X_r_ = X_r * W0_r - X_i * W0_i
+    X_i_ = X_r * W0_i + X_i * W0_r
+
+    # Twiddle & Permute 0
+    X_r_flat = ct.reshape(X_r_, (BS, N))
+    X_i_flat = ct.reshape(X_i_, (BS, N))
+    X_r2 = T0_r .* X_r_flat .- T0_i .* X_i_flat
+    X_i2 = T0_i .* X_r_flat .+ T0_r .* X_i_flat
+
+    X_r3 = ct.reshape(X_r2, (BS, F2, F1, F0))
+    X_i3 = ct.reshape(X_i2, (BS, F2, F1, F0))
+    X_r4 = ct.permute(X_r3, (1, 2, 4, 3))
+    X_i4 = ct.permute(X_i3, (1, 2, 4, 3))
+    X_r5 = ct.reshape(X_r4, (BS, F0F2, F1))
+    X_i5 = ct.reshape(X_i4, (BS, F0F2, F1))
+
+    # Stage 1: F1-point DFT
+    X_r6 = X_r5 * W1_r - X_i5 * W1_i
+    X_i6 = X_r5 * W1_i + X_i5 * W1_r
+
+    # Twiddle & Permute 1
+    X_r_flat2 = ct.reshape(X_r6, (BS, N))
+    X_i_flat2 = ct.reshape(X_i6, (BS, N))
+    X_r7 = T1_r .* X_r_flat2 .- T1_i .* X_i_flat2
+    X_i7 = T1_i .* X_r_flat2 .+ T1_r .* X_i_flat2
+
+    X_r8 = ct.reshape(X_r7, (BS, F2, F0, F1))
+    X_i8 = ct.reshape(X_i7, (BS, F2, F0, F1))
+    X_r9 = ct.permute(X_r8, (1, 3, 4, 2))
+    X_i9 = ct.permute(X_i8, (1, 3, 4, 2))
+    X_r10 = ct.reshape(X_r9, (BS, F0F1, F2))
+    X_i10 = ct.reshape(X_i9, (BS, F0F1, F2))
+
+    # Stage 2: F2-point DFT
+    X_r11 = X_r10 * W2_r - X_i10 * W2_i
+    X_i11 = X_r10 * W2_i + X_i10 * W2_r
+
+    # Final output
+    X_r_final = ct.reshape(X_r11, (1, BS, N))
+    X_i_final = ct.reshape(X_i11, (1, BS, N))
+
+    # Concatenate and Store
+    Y_ri = ct.reshape(ct.cat((X_r_final, X_i_final), 1), (D, BS, N2D))
+    ct.store(y_packed_out, (1, bid, 1), Y_ri)
+
+    return
+end
+
+# Helper: Generate DFT matrix
+function fft_dft_matrix(size::Int)
+    W = zeros(ComplexF32, size, size)
+    for i in 0:size-1, j in 0:size-1
+        W[i+1, j+1] = exp(-2π * im * i * j / size)
+    end
+    result = zeros(Float32, size, size, 2)
+    result[:, :, 1] = Float32.(real.(W))
+    result[:, :, 2] = Float32.(imag.(W))
+    return result
+end
+
+# Twiddle factors T0 for column-major layout (F1F2, F0)
+function fft_make_twiddles_T0(F0::Int, F1F2::Int, N::Int)
+    T0 = zeros(Float32, F1F2, F0, 2)
+    for j in 0:F1F2-1, i in 0:F0-1
+        val = exp(-2π * im * i * j / N)
+        T0[j+1, i+1, 1] = Float32(real(val))
+        T0[j+1, i+1, 2] = Float32(imag(val))
+    end
+    return T0
+end
+
+# Twiddle factors T1 for column-major layout (F0F2, F1)
+function fft_make_twiddles_T1(F0::Int, F1::Int, F2::Int)
+    F0F2 = F0 * F2
+    F1F2 = F1 * F2
+    T1 = zeros(Float32, F0F2, F1, 2)
+    for k in 0:F0F2-1, j in 0:F1-1
+        f2 = k % F2
+        val = exp(-2π * im * j * f2 / F1F2)
+        T1[k+1, j+1, 1] = Float32(real(val))
+        T1[k+1, j+1, 2] = Float32(imag(val))
+    end
+    return T1
+end
+
+function fft_make_twiddles(factors::NTuple{3, Int})
+    F0, F1, F2 = factors
+    N = F0 * F1 * F2
+    F1F2 = F1 * F2
+    W0 = fft_dft_matrix(F0)
+    W1 = fft_dft_matrix(F1)
+    W2 = fft_dft_matrix(F2)
+    T0 = fft_make_twiddles_T0(F0, F1F2, N)
+    T1 = fft_make_twiddles_T1(F0, F1, F2)
+    return (W0, W1, W2, T0, T1)
+end
+
+function benchmark_fft()
+    println("\nBenchmarking FFT...")
+    BS, N = FFT_BATCH, FFT_SIZE
+    F0, F1, F2 = FFT_FACTORS
+    D = FFT_ATOM_PACKING_DIM
+    println("  Size: $BS batches × $N FFT ($(BS * N * 8 / 1e6) MB)")
+
+    # Create complex input
+    CUDA.seed!(42)
+    input = CUDA.randn(ComplexF32, BS, N)
+
+    # Reference result (FFTW)
+    reference = FFTW.fft(Array(input), 2)
+
+    results = BenchmarkResult[]
+
+    # Pre-compute twiddles (one-time CPU cost)
+    W0, W1, W2, T0, T1 = fft_make_twiddles(FFT_FACTORS)
+    W0_gpu, W1_gpu, W2_gpu = CuArray(W0), CuArray(W1), CuArray(W2)
+    T0_gpu, T1_gpu = CuArray(T0), CuArray(T1)
+
+    # Pre-pack input (zero-copy)
+    N2D = N * 2 ÷ D
+    x_packed = reinterpret(reshape, Float32, input)
+    y_packed = CUDA.zeros(Float32, D, BS, N2D)
+
+    # Kernel launch parameters
+    F0F1, F1F2, F0F2 = F0 * F1, F1 * F2, F0 * F2
+    grid = (BS, 1, 1)
+
+    # Kernel-only timing function
+    cutile_kernel_f = () -> ct.launch(fft_kernel, grid,
+        x_packed, y_packed,
+        W0_gpu, W1_gpu, W2_gpu, T0_gpu, T1_gpu,
+        ct.Constant(N), ct.Constant(F0), ct.Constant(F1), ct.Constant(F2),
+        ct.Constant(F0F1), ct.Constant(F1F2), ct.Constant(F0F2),
+        ct.Constant(BS), ct.Constant(D), ct.Constant(N2D))
+
+    # Verify correctness
+    cutile_kernel_f()
+    CUDA.synchronize()
+    y_complex = reinterpret(reshape, ComplexF32, y_packed)
+    output = copy(y_complex)
+    @assert isapprox(Array(output), reference, rtol=1e-3) "cuTile FFT incorrect!"
+
+    # Benchmark kernel only
+    min_t, mean_t = benchmark_kernel(cutile_kernel_f)
+    push!(results, BenchmarkResult("cuTile.jl", min_t, mean_t))
+
+    # Performance metric: GFLOPS (5 * N * log2(N) per complex FFT)
+    flops_per_fft = 5.0 * N * log2(N)
+    total_flops = BS * flops_per_fft
+    gflops = [string(round(total_flops / (r.min_ms * 1e-3) / 1e9, digits=1), " GFLOPS") for r in results]
+
+    print_table("FFT (ComplexF32)", results; extra_col=("Performance", gflops))
+    return results
+end
+
+#=============================================================================
  Main
 =============================================================================#
 
@@ -622,6 +853,7 @@ function main()
     matmul_results = benchmark_matmul()
     layernorm_results = benchmark_layernorm()
     batchmatmul_results = benchmark_batchmatmul()
+    fft_results = benchmark_fft()
 
     println()
     println("=" ^ 60)

--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -9,7 +9,8 @@ import cupy as cp
 import numpy as np
 import torch
 import cuda.tile as ct
-from math import ceil
+import math
+from math import ceil, log2
 
 #=============================================================================
 # Configuration
@@ -22,6 +23,12 @@ WARMUP = 3
 VADD_SIZE = 2**27           # 512 MB (128M elements)
 TRANSPOSE_DIM = 8192        # 8192x8192 = 268 MB
 MATMUL_DIM = 4096           # 4096x4096x4096
+
+# FFT sizes - must match Julia configuration
+FFT_BATCH = 64
+FFT_SIZE = 512
+FFT_FACTORS = (8, 8, 8)
+FFT_ATOM_PACKING_DIM = 2
 
 # Tile sizes
 VADD_TILE = 1024
@@ -573,6 +580,157 @@ def benchmark_batchmatmul():
 
 
 #=============================================================================
+# FFT (3-stage Cooley-Tukey)
+#=============================================================================
+
+@ct.kernel
+def fft_kernel(x_packed_in, y_packed_out,
+               W0, W1, W2, T0, T1,
+               N: ct.Constant[int], F0: ct.Constant[int], F1: ct.Constant[int], F2: ct.Constant[int],
+               BS: ct.Constant[int], D: ct.Constant[int]):
+    """cuTile kernel for 3-stage Cooley-Tukey FFT."""
+    F0F1 = F0 * F1
+    F1F2 = F1 * F2
+    F0F2 = F0 * F2
+
+    bid = ct.bid(0)
+
+    # Load input, reshape to separate real/imag
+    X_ri = ct.reshape(ct.load(x_packed_in, index=(bid, 0, 0), shape=(BS, N * 2 // D, D)), (BS, N, 2))
+    X_r = ct.reshape(ct.extract(X_ri, index=(0, 0, 0), shape=(BS, N, 1)), (BS, F0, F1, F2))
+    X_i = ct.reshape(ct.extract(X_ri, index=(0, 0, 1), shape=(BS, N, 1)), (BS, F0, F1, F2))
+
+    # Load W matrices (rotation matrices)
+    W0_ri = ct.reshape(ct.load(W0, index=(0, 0, 0), shape=(F0, F0, 2)), (F0, F0, 2))
+    W0_r = ct.reshape(ct.extract(W0_ri, index=(0, 0, 0), shape=(F0, F0, 1)), (1, F0, F0))
+    W0_i = ct.reshape(ct.extract(W0_ri, index=(0, 0, 1), shape=(F0, F0, 1)), (1, F0, F0))
+
+    W1_ri = ct.reshape(ct.load(W1, index=(0, 0, 0), shape=(F1, F1, 2)), (F1, F1, 2))
+    W1_r = ct.reshape(ct.extract(W1_ri, index=(0, 0, 0), shape=(F1, F1, 1)), (1, F1, F1))
+    W1_i = ct.reshape(ct.extract(W1_ri, index=(0, 0, 1), shape=(F1, F1, 1)), (1, F1, F1))
+
+    W2_ri = ct.reshape(ct.load(W2, index=(0, 0, 0), shape=(F2, F2, 2)), (F2, F2, 2))
+    W2_r = ct.reshape(ct.extract(W2_ri, index=(0, 0, 0), shape=(F2, F2, 1)), (1, F2, F2))
+    W2_i = ct.reshape(ct.extract(W2_ri, index=(0, 0, 1), shape=(F2, F2, 1)), (1, F2, F2))
+
+    # Load T matrices (twiddle factors)
+    T0_ri = ct.reshape(ct.load(T0, index=(0, 0, 0), shape=(F0, F1F2, 2)), (F0, F1F2, 2))
+    T0_r = ct.reshape(ct.extract(T0_ri, index=(0, 0, 0), shape=(F0, F1F2, 1)), (N, 1))
+    T0_i = ct.reshape(ct.extract(T0_ri, index=(0, 0, 1), shape=(F0, F1F2, 1)), (N, 1))
+
+    T1_ri = ct.reshape(ct.load(T1, index=(0, 0, 0), shape=(F1, F2, 2)), (F1, F2, 2))
+    T1_r = ct.reshape(ct.extract(T1_ri, index=(0, 0, 0), shape=(F1, F2, 1)), (F1F2, 1))
+    T1_i = ct.reshape(ct.extract(T1_ri, index=(0, 0, 1), shape=(F1, F2, 1)), (F1F2, 1))
+
+    # CT0: Contract over F0 dimension
+    X_r = ct.reshape(X_r, (BS, F0, F1F2))
+    X_i = ct.reshape(X_i, (BS, F0, F1F2))
+    X_r_ = ct.reshape(ct.matmul(W0_r, X_r) - ct.matmul(W0_i, X_i), (BS, N, 1))
+    X_i_ = ct.reshape(ct.matmul(W0_i, X_r) + ct.matmul(W0_r, X_i), (BS, N, 1))
+
+    # Twiddle & Permute 0
+    X_r = T0_r * X_r_ - T0_i * X_i_
+    X_i = T0_i * X_r_ + T0_r * X_i_
+    X_r = ct.permute(ct.reshape(X_r, (BS, F0, F1, F2)), (0, 2, 3, 1))
+    X_i = ct.permute(ct.reshape(X_i, (BS, F0, F1, F2)), (0, 2, 3, 1))
+
+    # CT1: Contract over F1 dimension
+    X_r = ct.reshape(X_r, (BS, F1, F0F2))
+    X_i = ct.reshape(X_i, (BS, F1, F0F2))
+    X_r_ = ct.reshape(ct.matmul(W1_r, X_r) - ct.matmul(W1_i, X_i), (BS, F1F2, F0))
+    X_i_ = ct.reshape(ct.matmul(W1_i, X_r) + ct.matmul(W1_r, X_i), (BS, F1F2, F0))
+
+    # Twiddle & Permute 1
+    X_r = T1_r * X_r_ - T1_i * X_i_
+    X_i = T1_i * X_r_ + T1_r * X_i_
+    X_r = ct.permute(ct.reshape(X_r, (BS, F1, F2, F0)), (0, 2, 3, 1))
+    X_i = ct.permute(ct.reshape(X_i, (BS, F1, F2, F0)), (0, 2, 3, 1))
+
+    # CT2: Contract over F2 dimension
+    X_r = ct.reshape(X_r, (BS, F2, F0F1))
+    X_i = ct.reshape(X_i, (BS, F2, F0F1))
+    X_r_ = ct.matmul(W2_r, X_r) - ct.matmul(W2_i, X_i)
+    X_i_ = ct.matmul(W2_i, X_r) + ct.matmul(W2_r, X_i)
+
+    # Final Permutation
+    X_r = ct.permute(ct.reshape(X_r_, (BS, F2, F0, F1)), (0, 1, 3, 2))
+    X_i = ct.permute(ct.reshape(X_i_, (BS, F2, F0, F1)), (0, 1, 3, 2))
+    X_r = ct.reshape(X_r, (BS, N, 1))
+    X_i = ct.reshape(X_i, (BS, N, 1))
+
+    # Concatenate and Store
+    Y_ri = ct.reshape(ct.cat((X_r, X_i), axis=-1), (BS, N * 2 // D, D))
+    ct.store(y_packed_out, index=(bid, 0, 0), tile=Y_ri)
+
+
+def fft_twiddles(rows: int, cols: int, factor: int, device, precision):
+    """Generate DFT twiddle factors."""
+    I, J = torch.meshgrid(torch.arange(rows, device=device),
+                          torch.arange(cols, device=device), indexing='ij')
+    W_complex = torch.exp(-2 * math.pi * 1j * (I * J) / factor)
+    return torch.view_as_real(W_complex).to(precision).contiguous()
+
+
+def fft_make_twiddles(factors, precision, device):
+    """Generate W and T matrices for FFT."""
+    F0, F1, F2 = factors
+    N = F0 * F1 * F2
+    F1F2 = F1 * F2
+    W0 = fft_twiddles(F0, F0, F0, device, precision)
+    W1 = fft_twiddles(F1, F1, F1, device, precision)
+    W2 = fft_twiddles(F2, F2, F2, device, precision)
+    T0 = fft_twiddles(F0, F1F2, N, device, precision)
+    T1 = fft_twiddles(F1, F2, F1F2, device, precision)
+    return (W0, W1, W2, T0, T1)
+
+
+def benchmark_fft():
+    print("\nBenchmarking FFT...")
+    BS, N = FFT_BATCH, FFT_SIZE
+    F0, F1, F2 = FFT_FACTORS
+    D = FFT_ATOM_PACKING_DIM
+    print(f"  Size: {BS} batches × {N} FFT ({BS * N * 8 / 1e6} MB)")
+
+    # PyTorch complex input
+    input_torch = torch.randn(BS, N, dtype=torch.complex64, device='cuda')
+
+    # Reference result
+    reference = torch.fft.fft(input_torch, dim=-1)
+    torch.cuda.synchronize()
+
+    results = []
+
+    # Pre-compute everything outside timing loop
+    x_ri = torch.view_as_real(input_torch)
+    x_packed = x_ri.reshape(BS, N * 2 // D, D).contiguous()
+    W0, W1, W2, T0, T1 = fft_make_twiddles(FFT_FACTORS, input_torch.real.dtype, input_torch.device)
+    y_packed = torch.empty_like(x_packed)
+    grid = (BS, 1, 1)
+
+    # Kernel launch function
+    def fft_launch():
+        ct.launch(torch.cuda.current_stream(), grid, fft_kernel,
+                  (x_packed, y_packed, W0, W1, W2, T0, T1, N, F0, F1, F2, BS, D))
+
+    # Verify correctness
+    fft_launch()
+    torch.cuda.synchronize()
+    output = torch.view_as_complex(y_packed.reshape(BS, N, 2))
+    assert torch.allclose(output, reference, rtol=1e-3, atol=1e-3), "cuTile FFT incorrect!"
+
+    min_t, mean_t = benchmark_torch(fft_launch)
+    results.append(BenchmarkResult("cuTile Python", min_t, mean_t))
+
+    # Calculate GFLOPS (5 * N * log2(N) ops per complex FFT)
+    flops_per_fft = 5.0 * N * log2(N)
+    total_flops = BS * flops_per_fft
+    gflops = [f"{total_flops / (r.min_ms * 1e-3) / 1e9:.1f} GFLOPS" for r in results]
+
+    print_table("FFT (ComplexF32)", results, extra_col=("Performance", gflops))
+    return results
+
+
+#=============================================================================
 # Main
 #=============================================================================
 
@@ -591,6 +749,7 @@ def main():
     matmul_results = benchmark_matmul()
     layernorm_results = benchmark_layernorm()
     batchmatmul_results = benchmark_batchmatmul()
+    fft_results = benchmark_fft()
 
     print()
     print("=" * 60)

--- a/examples/fft.jl
+++ b/examples/fft.jl
@@ -3,6 +3,10 @@
 # This implements a 3-stage Cooley-Tukey FFT decomposition. The FFT of size N is decomposed
 # as N = F0 * F1 * F2, allowing efficient tensor factorization.
 #
+# Key difference from Python: Julia uses column-major storage, so reshape dimensions are
+# swapped and right-multiply (X @ W) is used instead of left-multiply (W @ X) to process
+# rows instead of columns, achieving the same strided element access pattern.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 using CUDA
@@ -10,20 +14,21 @@ import cuTile as ct
 using Test
 using FFTW
 
-# FFT kernel - 3-stage Cooley-Tukey decomposition
-# Matches the Python cuTile FFT kernel in res/cutile-python/samples/FFT.py
+# FFT kernel - 3-stage Cooley-Tukey decomposition (column-major version)
 #
-# Uses ct.Constant{Int} parameters with [] access to get compile-time constants.
-# The Constant type is Constant{T,V} where T is the type and V is the value.
-# Access via const_param[] extracts V as a compile-time constant.
+# The key insight: In Python row-major, reshape (F0, F1F2) puts stride-F1F2 elements
+# in columns. In Julia column-major, reshape (F1F2, F0) puts stride-F0 elements in rows.
+# We use right-multiply X @ W instead of W @ X to process rows instead of columns.
+#
+# Input/output layout: (D, BS, N2D) where D=2 for real/imag interleaving.
 function fft_kernel(
-    x_packed_in::ct.TileArray{Float32, 3},   # Input (BS, N2D, D) packed
-    y_packed_out::ct.TileArray{Float32, 3},  # Output (BS, N2D, D) packed
-    W0::ct.TileArray{Float32, 3},            # W0 (F0, F0, 2) real/imag interleaved
+    x_packed_in::ct.TileArray{Float32, 3},   # Input (D, BS, N2D) - natural Julia complex layout
+    y_packed_out::ct.TileArray{Float32, 3},  # Output (D, BS, N2D)
+    W0::ct.TileArray{Float32, 3},            # W0 (F0, F0, 2) DFT matrix
     W1::ct.TileArray{Float32, 3},            # W1 (F1, F1, 2)
     W2::ct.TileArray{Float32, 3},            # W2 (F2, F2, 2)
-    T0::ct.TileArray{Float32, 3},            # T0 (F0, F1*F2, 2)
-    T1::ct.TileArray{Float32, 3},            # T1 (F1, F2, 2)
+    T0::ct.TileArray{Float32, 3},            # T0 (F1F2, F0, 2) twiddle factors
+    T1::ct.TileArray{Float32, 3},            # T1 (F0F2, F1, 2) twiddle factors
     n_const::ct.Constant{Int},
     f0_const::ct.Constant{Int},
     f1_const::ct.Constant{Int},
@@ -50,108 +55,158 @@ function fft_kernel(
     bid = ct.bid(1)
 
     # --- Load Input Data ---
-    # Load packed input, reshape to (BS, N, 2) to separate real/imag
-    X_ri = ct.reshape(ct.load(x_packed_in, (bid, 1, 1), (BS, N2D, D)), (BS, N, 2))
+    # Input is (D, BS, N2D) where D=2 for real/imag. Load and reshape to (2, BS, N).
+    X_ri = ct.reshape(ct.load(x_packed_in, (1, bid, 1), (D, BS, N2D)), (2, BS, N))
 
-    # Split real and imaginary parts using slice indices (1-indexed)
-    # Shape (BS, N, 2) → (BS, N, 1), then reshape to (BS, F0, F1, F2)
-    X_r = ct.reshape(ct.extract(X_ri, (1, 1, 1), (BS, N, 1)), (BS, F0, F1, F2))
-    X_i = ct.reshape(ct.extract(X_ri, (1, 1, 2), (BS, N, 1)), (BS, F0, F1, F2))
+    # Split real and imaginary parts (extract from first dimension)
+    X_r = ct.reshape(ct.extract(X_ri, (1, 1, 1), (1, BS, N)), (BS, F1F2, F0))
+    X_i = ct.reshape(ct.extract(X_ri, (2, 1, 1), (1, BS, N)), (BS, F1F2, F0))
 
-    # --- Load Rotation (W) and Twiddle (T) Matrices ---
-    # W0 (F0 x F0) - broadcast to (BS, F0, F0) for batched matmul
+    # --- Load DFT Matrices ---
+    # W0 (F0 x F0) - for right-multiply X @ W0
     W0_ri = ct.reshape(ct.load(W0, (1, 1, 1), (F0, F0, 2)), (F0, F0, 2))
     W0_r = ct.broadcast_to(ct.reshape(ct.extract(W0_ri, (1, 1, 1), (F0, F0, 1)), (1, F0, F0)), (BS, F0, F0))
     W0_i = ct.broadcast_to(ct.reshape(ct.extract(W0_ri, (1, 1, 2), (F0, F0, 1)), (1, F0, F0)), (BS, F0, F0))
 
-    # W1 (F1 x F1) - broadcast to (BS, F1, F1)
+    # W1 (F1 x F1)
     W1_ri = ct.reshape(ct.load(W1, (1, 1, 1), (F1, F1, 2)), (F1, F1, 2))
     W1_r = ct.broadcast_to(ct.reshape(ct.extract(W1_ri, (1, 1, 1), (F1, F1, 1)), (1, F1, F1)), (BS, F1, F1))
     W1_i = ct.broadcast_to(ct.reshape(ct.extract(W1_ri, (1, 1, 2), (F1, F1, 1)), (1, F1, F1)), (BS, F1, F1))
 
-    # W2 (F2 x F2) - broadcast to (BS, F2, F2)
+    # W2 (F2 x F2)
     W2_ri = ct.reshape(ct.load(W2, (1, 1, 1), (F2, F2, 2)), (F2, F2, 2))
     W2_r = ct.broadcast_to(ct.reshape(ct.extract(W2_ri, (1, 1, 1), (F2, F2, 1)), (1, F2, F2)), (BS, F2, F2))
     W2_i = ct.broadcast_to(ct.reshape(ct.extract(W2_ri, (1, 1, 2), (F2, F2, 1)), (1, F2, F2)), (BS, F2, F2))
 
-    # T0 (F0 x F1F2)
-    T0_ri = ct.reshape(ct.load(T0, (1, 1, 1), (F0, F1F2, 2)), (F0, F1F2, 2))
-    T0_r = ct.reshape(ct.extract(T0_ri, (1, 1, 1), (F0, F1F2, 1)), (N, 1))
-    T0_i = ct.reshape(ct.extract(T0_ri, (1, 1, 2), (F0, F1F2, 1)), (N, 1))
+    # --- Load Twiddle Factors ---
+    # T0 (F1F2, F0) - note swapped from Python's (F0, F1F2)
+    T0_ri = ct.reshape(ct.load(T0, (1, 1, 1), (F1F2, F0, 2)), (F1F2, F0, 2))
+    T0_r = ct.reshape(ct.extract(T0_ri, (1, 1, 1), (F1F2, F0, 1)), (1, N))
+    T0_i = ct.reshape(ct.extract(T0_ri, (1, 1, 2), (F1F2, F0, 1)), (1, N))
 
-    # T1 (F1 x F2)
-    T1_ri = ct.reshape(ct.load(T1, (1, 1, 1), (F1, F2, 2)), (F1, F2, 2))
-    T1_r = ct.reshape(ct.extract(T1_ri, (1, 1, 1), (F1, F2, 1)), (F1F2, 1))
-    T1_i = ct.reshape(ct.extract(T1_ri, (1, 1, 2), (F1, F2, 1)), (F1F2, 1))
+    # T1 (F0F2, F1) - note swapped from Python's (F1, F2)
+    T1_ri = ct.reshape(ct.load(T1, (1, 1, 1), (F0F2, F1, 2)), (F0F2, F1, 2))
+    T1_r = ct.reshape(ct.extract(T1_ri, (1, 1, 1), (F0F2, F1, 1)), (1, F0F2 * F1))
+    T1_i = ct.reshape(ct.extract(T1_ri, (1, 1, 2), (F0F2, F1, 1)), (1, F0F2 * F1))
 
-    # --- CT0: Contract over F0 dimension ---
-    X_r = ct.reshape(X_r, (BS, F0, F1F2))
-    X_i = ct.reshape(X_i, (BS, F0, F1F2))
-    # Complex matmul: (A+iB)(C+iD) = (AC-BD) + i(AD+BC)
-    X_r_ = ct.reshape(W0_r * X_r - W0_i * X_i, (BS, N, 1))
-    X_i_ = ct.reshape(W0_i * X_r + W0_r * X_i, (BS, N, 1))
+    # --- Stage 0: F0-point DFT ---
+    # X is (BS, F1F2, F0), W0 is (BS, F0, F0)
+    # Right-multiply: X @ W0 processes each row (F1F2 rows, each with F0 elements)
+    # Each row has elements at stride F1F2 in the original array - exactly what we need!
+    X_r_ = X_r * W0_r - X_i * W0_i  # (BS, F1F2, F0) @ (BS, F0, F0) → (BS, F1F2, F0)
+    X_i_ = X_r * W0_i + X_i * W0_r
 
     # --- Twiddle & Permute 0 ---
-    X_r2 = T0_r .* X_r_ .- T0_i .* X_i_
-    X_i2 = T0_i .* X_r_ .+ T0_r .* X_i_
-    X_r3 = ct.permute(ct.reshape(X_r2, (BS, F0, F1, F2)), (1, 3, 4, 2))
-    X_i3 = ct.permute(ct.reshape(X_i2, (BS, F0, F1, F2)), (1, 3, 4, 2))
+    # Reshape to (BS, N) for element-wise twiddle multiply
+    X_r_flat = ct.reshape(X_r_, (BS, N))
+    X_i_flat = ct.reshape(X_i_, (BS, N))
+    X_r2 = T0_r .* X_r_flat .- T0_i .* X_i_flat
+    X_i2 = T0_i .* X_r_flat .+ T0_r .* X_i_flat
 
-    # --- CT1: Contract over F1 dimension ---
-    X_r4 = ct.reshape(X_r3, (BS, F1, F0F2))
-    X_i4 = ct.reshape(X_i3, (BS, F1, F0F2))
-    X_r5 = ct.reshape(W1_r * X_r4 - W1_i * X_i4, (BS, F1F2, F0))
-    X_i5 = ct.reshape(W1_i * X_r4 + W1_r * X_i4, (BS, F1F2, F0))
+    # Reshape and permute for stage 1
+    # Current logical layout after reshape (BS, F1F2, F0): data at (bs, f1*F2+f2, f0)
+    # Reshape to (BS, F2, F1, F0) then permute to (BS, F0F2, F1) for stage 1
+    X_r3 = ct.reshape(X_r2, (BS, F2, F1, F0))
+    X_i3 = ct.reshape(X_i2, (BS, F2, F1, F0))
+    X_r4 = ct.permute(X_r3, (1, 2, 4, 3))  # (BS, F2, F0, F1)
+    X_i4 = ct.permute(X_i3, (1, 2, 4, 3))
+    X_r5 = ct.reshape(X_r4, (BS, F0F2, F1))
+    X_i5 = ct.reshape(X_i4, (BS, F0F2, F1))
+
+    # --- Stage 1: F1-point DFT ---
+    # X is (BS, F0F2, F1), W1 is (BS, F1, F1)
+    X_r6 = X_r5 * W1_r - X_i5 * W1_i
+    X_i6 = X_r5 * W1_i + X_i5 * W1_r
 
     # --- Twiddle & Permute 1 ---
-    X_r6 = T1_r .* X_r5 .- T1_i .* X_i5
-    X_i6 = T1_i .* X_r5 .+ T1_r .* X_i5
-    X_r7 = ct.permute(ct.reshape(X_r6, (BS, F1, F2, F0)), (1, 3, 4, 2))
-    X_i7 = ct.permute(ct.reshape(X_i6, (BS, F1, F2, F0)), (1, 3, 4, 2))
+    X_r_flat2 = ct.reshape(X_r6, (BS, N))
+    X_i_flat2 = ct.reshape(X_i6, (BS, N))
+    X_r7 = T1_r .* X_r_flat2 .- T1_i .* X_i_flat2
+    X_i7 = T1_i .* X_r_flat2 .+ T1_r .* X_i_flat2
 
-    # --- CT2: Contract over F2 dimension ---
-    X_r8 = ct.reshape(X_r7, (BS, F2, F0F1))
-    X_i8 = ct.reshape(X_i7, (BS, F2, F0F1))
-    X_r9 = W2_r * X_r8 - W2_i * X_i8
-    X_i9 = W2_i * X_r8 + W2_r * X_i8
+    # Reshape and permute for stage 2
+    X_r8 = ct.reshape(X_r7, (BS, F2, F0, F1))
+    X_i8 = ct.reshape(X_i7, (BS, F2, F0, F1))
+    X_r9 = ct.permute(X_r8, (1, 3, 4, 2))  # (BS, F0, F1, F2)
+    X_i9 = ct.permute(X_i8, (1, 3, 4, 2))
+    X_r10 = ct.reshape(X_r9, (BS, F0F1, F2))
+    X_i10 = ct.reshape(X_i9, (BS, F0F1, F2))
 
-    # --- Final Permutation ---
-    X_r_out = ct.permute(ct.reshape(X_r9, (BS, F2, F0, F1)), (1, 2, 4, 3))
-    X_i_out = ct.permute(ct.reshape(X_i9, (BS, F2, F0, F1)), (1, 2, 4, 3))
-    X_r_final = ct.reshape(X_r_out, (BS, N, 1))
-    X_i_final = ct.reshape(X_i_out, (BS, N, 1))
+    # --- Stage 2: F2-point DFT ---
+    # X is (BS, F0F1, F2), W2 is (BS, F2, F2)
+    X_r11 = X_r10 * W2_r - X_i10 * W2_i
+    X_i11 = X_r10 * W2_i + X_i10 * W2_r
+
+    # --- Final Output ---
+    # After stage 2, data is in (BS, F0F1, F2) layout
+    # Reshape to (BS, F0, F1, F2) - output is already in frequency order
+    X_r_final = ct.reshape(X_r11, (1, BS, N))
+    X_i_final = ct.reshape(X_i11, (1, BS, N))
 
     # --- Concatenate and Store ---
-    Y_ri = ct.reshape(ct.cat((X_r_final, X_i_final), -1), (BS, N2D, D))
-    ct.store(y_packed_out, (bid, 1, 1), Y_ri)
+    Y_ri = ct.reshape(ct.cat((X_r_final, X_i_final), 1), (D, BS, N2D))
+    ct.store(y_packed_out, (1, bid, 1), Y_ri)
 
     return
 end
 
-# Helper: Generate DFT twiddle factors W_n^{ij} = exp(-2πi * ij / n)
-function twiddles(rows::Int, cols::Int, factor::Int)
-    W = zeros(ComplexF32, rows, cols)
-    for i in 0:rows-1, j in 0:cols-1
-        W[i+1, j+1] = exp(-2π * im * i * j / factor)
+# Helper: Generate DFT matrix W_n^{ij} = exp(-2πi * ij / n)
+function dft_matrix(size::Int)
+    W = zeros(ComplexF32, size, size)
+    for i in 0:size-1, j in 0:size-1
+        W[i+1, j+1] = exp(-2π * im * i * j / size)
     end
-    # Return as (rows, cols, 2) with real/imag interleaved
-    result = zeros(Float32, rows, cols, 2)
+    result = zeros(Float32, size, size, 2)
     result[:, :, 1] = Float32.(real.(W))
     result[:, :, 2] = Float32.(imag.(W))
     return result
 end
 
-# Generate all W and T matrices
+# Generate twiddle factors T0 for column-major layout (F1F2, F0)
+# In Julia column-major, position (j, i) in (F1F2, F0) has linear index j + i*F1F2
+# This corresponds to Python's position (i, j) in (F0, F1F2) with linear index i*F1F2 + j
+# The twiddle value is ω_N^{i * j}
+function make_twiddles_T0(F0::Int, F1F2::Int, N::Int)
+    T0 = zeros(Float32, F1F2, F0, 2)
+    for j in 0:F1F2-1, i in 0:F0-1
+        val = exp(-2π * im * i * j / N)
+        T0[j+1, i+1, 1] = Float32(real(val))
+        T0[j+1, i+1, 2] = Float32(imag(val))
+    end
+    return T0
+end
+
+# Generate twiddle factors T1 for column-major layout (F0F2, F1)
+# After stage 0 and permute, data is in (F0F2, F1) layout
+# The twiddle value is ω_{F1F2}^{j * k} where j is F1 index and k is F2 index within F0F2
+function make_twiddles_T1(F0::Int, F1::Int, F2::Int)
+    F0F2 = F0 * F2
+    F1F2 = F1 * F2
+    T1 = zeros(Float32, F0F2, F1, 2)
+    for k in 0:F0F2-1, j in 0:F1-1
+        # k encodes (f0, f2) = (k ÷ F2, k % F2) after permute
+        f2 = k % F2
+        val = exp(-2π * im * j * f2 / F1F2)
+        T1[k+1, j+1, 1] = Float32(real(val))
+        T1[k+1, j+1, 2] = Float32(imag(val))
+    end
+    return T1
+end
+
+# Generate all W and T matrices for column-major algorithm
 function make_twiddles(factors::NTuple{3, Int})
     F0, F1, F2 = factors
     N = F0 * F1 * F2
     F1F2 = F1 * F2
 
-    W0 = twiddles(F0, F0, F0)
-    W1 = twiddles(F1, F1, F1)
-    W2 = twiddles(F2, F2, F2)
-    T0 = twiddles(F0, F1F2, N)
-    T1 = twiddles(F1, F2, F1F2)
+    # DFT matrices (same for row/column-major since symmetric)
+    W0 = dft_matrix(F0)
+    W1 = dft_matrix(F1)
+    W2 = dft_matrix(F2)
+
+    # Column-major twiddle factors
+    T0 = make_twiddles_T0(F0, F1F2, N)
+    T1 = make_twiddles_T1(F0, F1, F2)
 
     return (W0, W1, W2, T0, T1)
 end
@@ -167,7 +222,7 @@ function cutile_fft(x::CuMatrix{ComplexF32}, factors::NTuple{3, Int}; atom_packi
 
     D = atom_packing_dim
 
-    # Generate W and T matrices
+    # Generate W and T matrices (CPU, one-time cost)
     W0, W1, W2, T0, T1 = make_twiddles(factors)
 
     # Upload to GPU
@@ -177,21 +232,17 @@ function cutile_fft(x::CuMatrix{ComplexF32}, factors::NTuple{3, Int}; atom_packi
     T0_gpu = CuArray(T0)
     T1_gpu = CuArray(T1)
 
-    # Pack input: complex (BS, N) → real (BS, N, 2) → packed (BS, N*2/D, D)
-    x_cpu = Array(x)
-    x_ri = zeros(Float32, BS, N, 2)
-    x_ri[:, :, 1] = Float32.(real.(x_cpu))
-    x_ri[:, :, 2] = Float32.(imag.(x_cpu))
-    x_packed = CuArray(reshape(x_ri, BS, N * 2 ÷ D, D))
+    # Pack input: complex (BS, N) → real (D, BS, N2D) - zero-copy view
+    N2D = N * 2 ÷ D
+    x_packed = reinterpret(reshape, Float32, x)  # (2, BS, N) = (D, BS, N2D)
 
     # Allocate output
-    y_packed = CUDA.zeros(Float32, BS, N * 2 ÷ D, D)
+    y_packed = CUDA.zeros(Float32, D, BS, N2D)
 
     # Launch kernel
     F0F1 = F0 * F1
     F1F2 = F1 * F2
     F0F2 = F0 * F2
-    N2D = N * 2 ÷ D
     grid = (BS, 1, 1)
     ct.launch(fft_kernel, grid,
               x_packed, y_packed,
@@ -200,11 +251,10 @@ function cutile_fft(x::CuMatrix{ComplexF32}, factors::NTuple{3, Int}; atom_packi
               ct.Constant(F0F1), ct.Constant(F1F2), ct.Constant(F0F2),
               ct.Constant(BS), ct.Constant(D), ct.Constant(N2D))
 
-    # Unpack output
-    y_ri = reshape(Array(y_packed), BS, N, 2)
-    y_complex = ComplexF32.(y_ri[:, :, 1]) .+ im .* ComplexF32.(y_ri[:, :, 2])
+    # Unpack output: real (D, BS, N2D) → complex (BS, N) - zero-copy view
+    y_complex = reinterpret(reshape, ComplexF32, y_packed)
 
-    return CuArray(y_complex)
+    return copy(y_complex)
 end
 
 # Validation and example


### PR DESCRIPTION
The example was only working with FFT_ATOM_PACKING_DIM=2 because of a confused implementation expecting row-major operations, conflicting with #18. This actually makes it fully column-major.

Not sure where the performance difference comes from. We obviously do a whole bunch of additional permutes surrounding the reshape, but temporarily removing those doesn't improve performance. Maybe it's because of the lmul/rmul, but naively trying to replace those runs into a `tileiras` bug. Will need some investigation.