### PR TITLE
Add UInt8 support to julia_to_tile_dtype

### DIFF
--- a/src/bytecode/types.jl
+++ b/src/bytecode/types.jl
@@ -179,7 +179,7 @@ end
 function julia_to_tile_dtype!(table::TypeTable, ::Type{T}) where T
     if T === Bool
         I1(table)
-    elseif T === Int8
+    elseif T === Int8 || T === UInt8
         I8(table)
     elseif T === Int16 || T === UInt16
         I16(table)


### PR DESCRIPTION
- Map UInt8 to I8 tile dtype alongside Int8
- Fixes missing UInt8 type support for Tile operations

This is possible oversight during initial development.