### PR TITLE
Remove Int64 from `encode_signed_varint!` signature

### DIFF
--- a/src/bytecode/writer.jl
+++ b/src/bytecode/writer.jl
@@ -296,7 +296,7 @@ end
 Encode a signed integer as a variable-length integer.
 Uses zigzag encoding for signed values.
 """
-function encode_signed_varint!(buf::Vector{UInt8}, value::Union{UInt16, UInt32, UInt64, Int64})
+function encode_signed_varint!(buf::Vector{UInt8}, value::Union{UInt16, UInt32, UInt64})
     # For float bits, encode as unsigned varint
     encode_varint!(buf, UInt64(value))
 end


### PR DESCRIPTION
- Int64 causes InexactError when passed because of call to UInt64(value) in the body of function.
- Zigzag-encoded values and float bits are always unsigned integers but might be reachable from a variant of same function in basic.jl.
- Fixes potential runtime error in bytecode encoding

https://github.com/JuliaGPU/cuTile.jl/blob/e5e1fa5ff66018a9d77971fb2a9599bdd262848b/src/bytecode/writer.jl#L299-L302

Fixes #41 