### PR TITLE
replace unsigned only  and float only varint calls with `encode_varint!`

### DIFF
--- a/src/bytecode/writer.jl
+++ b/src/bytecode/writer.jl
@@ -264,7 +264,7 @@ function encode_tagged_float!(cb::CodeBuilder, identity::FloatIdentity)
     encode_typeid!(cb.buf, identity.type_id)
     # Value as bits (using signed varint encoding for values <= 64 bits)
     bits = float_to_bits(identity.value, identity.dtype)
-    encode_signed_varint!(cb.buf, bits)
+    encode_varint!(cb.buf, bits)
 end
 
 """
@@ -288,17 +288,6 @@ end
 function float_to_bits(value::Float64, ::Type{T}) where T
     # Fallback to Float32 for special types like TFloat32
     reinterpret(UInt32, Float32(value))
-end
-
-"""
-    encode_signed_varint!(buf, value)
-
-Encode a signed integer as a variable-length integer.
-Uses zigzag encoding for signed values.
-"""
-function encode_signed_varint!(buf::Vector{UInt8}, value::Union{UInt16, UInt32, UInt64})
-    # For float bits, encode as unsigned varint
-    encode_varint!(buf, UInt64(value))
 end
 
 """
@@ -544,7 +533,7 @@ function finalize_function!(func_buf::Vector{UInt8}, cb::CodeBuilder,
 end
 
 #=============================================================================
- Optimization Hints 
+ Optimization Hints
 =============================================================================#
 
 """


### PR DESCRIPTION
- Replace encode_signed_varint with encode_varint for FloatIdentityOp bits since float_to_bits returns unsigned values

Also: Remove redundant encode_signed_varint overload in writer.jl that just wrapped encode_varint anyway

https://github.com/JuliaGPU/cuTile.jl/blob/2c52a5349b8314c499b79fa6ce15757284884159/src/bytecode/writer.jl#L293-L302