### PR TITLE
Compiler simplifications.

### DIFF
--- a/src/compiler/codegen/control_flow.jl
+++ b/src/compiler/codegen/control_flow.jl
@@ -65,7 +65,7 @@ function emit_if_op!(ctx::CGCtx, op::IfOp, @nospecialize(parent_result_type), n_
 
     # Get condition value
     cond_tv = emit_value!(ctx, op.condition)
-    cond_tv === nothing && error("Cannot resolve condition for IfOp")
+    cond_tv === nothing && throw(IRError("Cannot resolve condition for IfOp"))
 
     # Determine result types from parent_result_type
     result_types = TypeId[]
@@ -130,11 +130,11 @@ function emit_for_op!(ctx::CGCtx, op::ForOp, @nospecialize(parent_result_type), 
     iv_arg = op.iv_arg
 
     (lower_tv === nothing || upper_tv === nothing || step_tv === nothing) &&
-        error("Cannot resolve ForOp bounds")
+        throw(IRError("Cannot resolve ForOp bounds"))
 
     # Assert all bounds have the same type
     lower_tv.jltype === upper_tv.jltype === step_tv.jltype ||
-        error("ForOp bounds must all have the same type: lower=$(lower_tv.jltype), upper=$(upper_tv.jltype), step=$(step_tv.jltype)")
+        throw(IRError("ForOp bounds must all have the same type: lower=$(lower_tv.jltype), upper=$(upper_tv.jltype), step=$(step_tv.jltype)"))
         iv_jl_type = lower_tv.jltype
         iv_type = tile_type_for_julia!(ctx, iv_jl_type)
 
@@ -142,7 +142,7 @@ function emit_for_op!(ctx::CGCtx, op::ForOp, @nospecialize(parent_result_type), 
     init_values = Value[]
     for init_val in op.init_values
         tv = emit_value!(ctx, init_val)
-        (tv === nothing || tv.v === nothing) && error("Cannot resolve ForOp init value")
+        (tv === nothing || tv.v === nothing) && throw(IRError("Cannot resolve ForOp init value"))
         push!(init_values, tv.v)
     end
     # Add token as additional init value (for memory ordering)
@@ -208,7 +208,7 @@ function emit_loop_op!(ctx::CGCtx, op::LoopOp, @nospecialize(parent_result_type)
     init_values = Value[]
     for init_val in op.init_values
         tv = emit_value!(ctx, init_val)
-        (tv === nothing || tv.v === nothing) && error("Cannot resolve LoopOp init value")
+        (tv === nothing || tv.v === nothing) && throw(IRError("Cannot resolve LoopOp init value"))
         push!(init_values, tv.v)
     end
     # Add token as additional init value (for memory ordering)
@@ -279,7 +279,7 @@ function emit_while_op!(ctx::CGCtx, op::WhileOp, @nospecialize(parent_result_typ
     init_values = Value[]
     for init_val in op.init_values
         tv = emit_value!(ctx, init_val)
-        (tv === nothing || tv.v === nothing) && error("Cannot resolve WhileOp init value: $init_val")
+        (tv === nothing || tv.v === nothing) && throw(IRError("Cannot resolve WhileOp init value: $init_val"))
         push!(init_values, tv.v)
     end
     # Add token as additional init value (for memory ordering)
@@ -327,10 +327,10 @@ function emit_while_op!(ctx::CGCtx, op::WhileOp, @nospecialize(parent_result_typ
 
         # Get condition from ConditionOp terminator
         cond_op = before_blk.terminator
-        cond_op isa ConditionOp || error("WhileOp before region must end with ConditionOp")
+        cond_op isa ConditionOp || throw(IRError("WhileOp before region must end with ConditionOp"))
 
         cond_tv = emit_value!(ctx, cond_op.condition)
-        (cond_tv === nothing || cond_tv.v === nothing) && error("Cannot resolve WhileOp condition: $(cond_op.condition)")
+        (cond_tv === nothing || cond_tv.v === nothing) && throw(IRError("Cannot resolve WhileOp condition: $(cond_op.condition)"))
 
         # Emit conditional break: if (cond) { yield } else { break }
         # This keeps nested loops in "after" at LoopOp body level

--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -311,7 +311,7 @@ function emit_subprogram!(ctx::CGCtx, func, arg_types::Vector,
         results = Value[]
         for ref in tv.tuple
             component = emit_value!(sub_ctx, ref)
-            component === nothing && error("Cannot resolve tuple component in subprogram return")
+            component === nothing && throw(IRError("Cannot resolve tuple component in subprogram return"))
             push!(results, component.v::Value)
         end
     else

--- a/src/compiler/codegen/values.jl
+++ b/src/compiler/codegen/values.jl
@@ -8,7 +8,7 @@ Emit/resolve a value reference to a CGVal using multiple dispatch.
 function emit_value!(ctx::CGCtx, ssa::SSAValue)
     tv = ctx[ssa]
     tv !== nothing && return tv
-    error("SSAValue %$(ssa.id) not found in context")
+    throw(IRError("SSAValue %$(ssa.id) not found in context"))
 end
 emit_value!(ctx::CGCtx, arg::Argument) = ctx[arg]
 emit_value!(ctx::CGCtx, slot::SlotNumber) = ctx[slot]
@@ -112,8 +112,7 @@ function emit_value!(ctx::CGCtx, @nospecialize(val))
     if T <: Constant && length(T.parameters) >= 2
         return ghost_value(T, T.parameters[2])
     end
-    @warn "Unhandled value type in emit_value!" typeof(val)
-    nothing
+    throw(IRError("Unhandled value type in emit_value!: $(typeof(val))"))
 end
 
 
@@ -153,6 +152,6 @@ function constant_to_bytes(@nospecialize(value), @nospecialize(T::Type))
     elseif T === Float64
         return collect(reinterpret(UInt8, [Float64(value)]))
     else
-        error("Cannot convert $T to constant bytes")
+        throw(IRError("Cannot convert $T to constant bytes"))
     end
 end

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -229,7 +229,7 @@ function code_ircode(mi::MethodInstance; world::UInt=Base.get_world_counter(),
     result = CC.typeinf_ircode(interp, mi, nothing)
 
     if result === nothing
-        error("Type inference failed for $mi")
+        throw(ErrorException("Type inference failed for $mi"))
     end
 
     ir, rettype = result
@@ -387,7 +387,7 @@ function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
                     world::UInt=Base.get_world_counter())
     tt = Base.signature_type(f, argtypes)
     if !Base.isdispatchtuple(tt)
-        error("code_tiled requires a dispatch tuple, got non-concrete signature")
+        throw(ArgumentError("code_tiled requires a dispatch tuple, got non-concrete signature"))
     end
     mi = @something(method_instance(f, argtypes; world, method_table=cuTileMethodTable),
                     method_instance(f, argtypes; world),
@@ -413,7 +413,7 @@ This is a convenience macro that extracts the function and argument types.
 """
 macro code_tiled(call)
     if !(call isa Expr && call.head === :call)
-        error("@code_tiled requires a function call expression")
+        throw(ArgumentError("@code_tiled requires a function call expression"))
     end
     f = call.args[1]
     args = call.args[2:end]

--- a/src/compiler/intrinsics.jl
+++ b/src/compiler/intrinsics.jl
@@ -25,7 +25,7 @@ emit_intrinsic!(ctx::CGCtx, @nospecialize(func), args) = missing
 # Shared helper for creating load/store optimization hints
 function create_optimization_hints(ctx::CGCtx, latency::Union{Int, Nothing}, allow_tma::Bool=true)
     isnothing(latency) && allow_tma && return nothing
-    isnothing(latency) || 1 <= latency <= 10 || error("latency must be between 1 and 10, got $latency")
+    isnothing(latency) || 1 <= latency <= 10 || throw(ArgumentError("latency must be between 1 and 10, got $latency"))
     hints = LoadStoreHints(; latency, allow_tma)
     return make_load_store_hints(ctx.sm_arch, hints)
 end

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -57,24 +57,24 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.atomic_cas), args)
     is_tilearray = arg_idx !== nothing && is_destructured_arg(ctx, arg_idx)
 
     if !is_tilearray
-        error("atomic_cas requires a TileArray argument")
+        throw(IRError("atomic_cas requires a TileArray argument"))
     end
 
     ptr_vals = get_arg_flat_values(ctx, arg_idx, :ptr)
-    isempty(ptr_vals) && error("Cannot get ptr from TileArray argument")
+    isempty(ptr_vals) && throw(IRError("Cannot get ptr from TileArray argument"))
     array_val = ptr_vals[1]
     tilearray_type = get_arg_type(ctx, arg_idx)
     elem_type = eltype(tilearray_type)
 
     # Get expected and desired values
     expected_tv = emit_value!(ctx, args[3])
-    expected_tv === nothing && error("atomic_cas requires expected value")
+    expected_tv === nothing && throw(IRError("atomic_cas requires expected value"))
     desired_tv = emit_value!(ctx, args[4])
-    desired_tv === nothing && error("atomic_cas requires desired value")
+    desired_tv === nothing && throw(IRError("atomic_cas requires desired value"))
 
     # Get memory order and scope from args
-    memory_order = @something get_constant(ctx, args[5]) error("atomic_cas requires constant memory_order")
-    memory_scope = @something get_constant(ctx, args[6]) error("atomic_cas requires constant memory_scope")
+    memory_order = @something get_constant(ctx, args[5]) throw(IRError("atomic_cas requires constant memory_order"))
+    memory_scope = @something get_constant(ctx, args[6]) throw(IRError("atomic_cas requires constant memory_scope"))
 
     # Create result type (0D tile of element type)
     dtype = julia_to_tile_dtype!(tt, elem_type)
@@ -117,22 +117,22 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode)
     is_tilearray = arg_idx !== nothing && is_destructured_arg(ctx, arg_idx)
 
     if !is_tilearray
-        error("atomic operations require a TileArray argument")
+        throw(IRError("atomic operations require a TileArray argument"))
     end
 
     ptr_vals = get_arg_flat_values(ctx, arg_idx, :ptr)
-    isempty(ptr_vals) && error("Cannot get ptr from TileArray argument")
+    isempty(ptr_vals) && throw(IRError("Cannot get ptr from TileArray argument"))
     array_val = ptr_vals[1]
     tilearray_type = get_arg_type(ctx, arg_idx)
     elem_type = eltype(tilearray_type)
 
     # Get update value
     val_tv = emit_value!(ctx, args[3])
-    val_tv === nothing && error("atomic operation requires value")
+    val_tv === nothing && throw(IRError("atomic operation requires value"))
 
     # Get memory order and scope from args
-    memory_order = @something get_constant(ctx, args[4]) error("atomic operation requires constant memory_order")
-    memory_scope = @something get_constant(ctx, args[5]) error("atomic operation requires constant memory_scope")
+    memory_order = @something get_constant(ctx, args[4]) throw(IRError("atomic operation requires constant memory_order"))
+    memory_scope = @something get_constant(ctx, args[5]) throw(IRError("atomic operation requires constant memory_scope"))
 
     # Create result type (0D tile of element type)
     dtype = julia_to_tile_dtype!(tt, elem_type)

--- a/src/compiler/intrinsics/math.jl
+++ b/src/compiler/intrinsics/math.jl
@@ -42,7 +42,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.exp2), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for exp2()")
+    source === nothing && throw(IRError("Cannot resolve operand for exp2()"))
 
     flush_to_zero = length(args) > 1 ? args[2]::Bool : false
 
@@ -61,7 +61,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.exp), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for exp()")
+    source === nothing && throw(IRError("Cannot resolve operand for exp()"))
 
     result = encode_ExpOp!(cb, source.type_id, source.v)
 
@@ -91,7 +91,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.fma), args)
     b = emit_value!(ctx, args[2])
     c = emit_value!(ctx, args[3])
 
-    (a === nothing || b === nothing || c === nothing) && error("Cannot resolve operands for fma")
+    (a === nothing || b === nothing || c === nothing) && throw(IRError("Cannot resolve operands for fma"))
 
     result_v = encode_FmaOp!(cb, a.type_id, a.v, b.v, c.v)
 
@@ -108,7 +108,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.log2), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for log2()")
+    source === nothing && throw(IRError("Cannot resolve operand for log2()"))
 
     result = encode_Log2Op!(cb, source.type_id, source.v)
 
@@ -125,7 +125,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.log), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for log()")
+    source === nothing && throw(IRError("Cannot resolve operand for log()"))
 
     result = encode_LogOp!(cb, source.type_id, source.v)
 
@@ -180,7 +180,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.rsqrt), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for rsqrt()")
+    source === nothing && throw(IRError("Cannot resolve operand for rsqrt()"))
 
     flush_to_zero = length(args) > 1 ? args[2]::Bool : false
 
@@ -219,7 +219,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.sqrt), args)
     cb = ctx.cb
 
     source = emit_value!(ctx, args[1])
-    source === nothing && error("Cannot resolve operand for sqrt()")
+    source === nothing && throw(IRError("Cannot resolve operand for sqrt()"))
 
     result = encode_SqrtOp!(cb, source.type_id, source.v)
 

--- a/src/compiler/intrinsics/memory.jl
+++ b/src/compiler/intrinsics/memory.jl
@@ -29,7 +29,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_ptr_tko), args)
     # args: (ptrs, latency, mask?, padding?)
     # Get pointer tile (arg 1)
     ptrs_tv = emit_value!(ctx, args[1])
-    ptrs_tv === nothing && error("load_ptr_tko: cannot resolve pointer tile")
+    ptrs_tv === nothing && throw(IRError("load_ptr_tko: cannot resolve pointer tile"))
     pointers = ptrs_tv.v
     tile_shape = ptrs_tv.shape
 
@@ -53,12 +53,12 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_ptr_tko), args)
     if has_mask
         # Get mask tile (arg 3)
         mask_tv = emit_value!(ctx, args[3])
-        mask_tv === nothing && error("load_ptr_tko: cannot resolve mask tile")
+        mask_tv === nothing && throw(IRError("load_ptr_tko: cannot resolve mask tile"))
         mask = mask_tv.v
 
         # Get padding tile (arg 4)
         padding_tv = emit_value!(ctx, args[4])
-        padding_tv === nothing && error("load_ptr_tko: cannot resolve padding tile")
+        padding_tv === nothing && throw(IRError("load_ptr_tko: cannot resolve padding tile"))
         padding = padding_tv.v
 
         # Load with mask and padding
@@ -107,12 +107,12 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.store_ptr_tko), args)
     # args: (ptrs, values, latency, mask?)
     # Get pointer tile (arg 1)
     ptrs_tv = emit_value!(ctx, args[1])
-    ptrs_tv === nothing && error("store_ptr_tko: cannot resolve pointer tile")
+    ptrs_tv === nothing && throw(IRError("store_ptr_tko: cannot resolve pointer tile"))
     pointers = ptrs_tv.v
 
     # Get value tile (arg 2)
     values_tv = emit_value!(ctx, args[2])
-    values_tv === nothing && error("store_ptr_tko: cannot resolve values tile")
+    values_tv === nothing && throw(IRError("store_ptr_tko: cannot resolve values tile"))
     values = values_tv.v
 
     token_type = Token(tt)
@@ -129,7 +129,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.store_ptr_tko), args)
     if has_mask
         # Get mask tile (arg 4)
         mask_tv = emit_value!(ctx, args[4])
-        mask_tv === nothing && error("store_ptr_tko: cannot resolve mask tile")
+        mask_tv === nothing && throw(IRError("store_ptr_tko: cannot resolve mask tile"))
         mask = mask_tv.v
 
         # Store with mask

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -288,6 +288,7 @@ Base.eltype(::Tile{T, Shape}) where {T, Shape} = T
 tile_shape(::Type{Tile{T, Shape}}) where {T, Shape} = Shape
 tile_shape(::Tile{T, Shape}) where {T, Shape} = Shape
 replace_eltype(::Type{Tile{T, Shape}}, ::Type{U}) where {T, Shape, U} = Tile{U, Shape}
+replace_eltype(::Type, ::Type{T}) where {T} = T  # fallback for non-Tile types
 
 
 """

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -1827,9 +1827,9 @@ end
         spec = ct.ArraySpec{1}(16, true)
 
         @testset "binary op type mismatch errors in Julia" begin
-            # This should fail with a Julia error (not tileiras), since the intrinsic
+            # This should fail with an IRError, since the intrinsic
             # is invoked with mismatched types (Int32 + Int64)
-            @test_throws ErrorException code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+            @test_throws ct.IRError code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
                 pid = ct.bid(1)  # Int32
                 # Force type mismatch by calling addi with different types
                 result = ct.Intrinsics.addi(pid, Int64(1))
@@ -1857,7 +1857,7 @@ end
             @test_throws "Unsupported function call during Tile IR compilation" begin
                 code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
                     tile = ct.load(a, ct.bid(1), (16,))
-                    println(tile)
+                    print(tile)
                     return
                 end
             end


### PR DESCRIPTION
- Introduced `IRError` exception type for compiler errors with custom showerror
- Replaced 100+ bare error() calls with `throw(IRError(...))` for consistent error handling
- Removed `resolve_function` in favor of existing get_constant
- Removed `_collect_argtypes` helper, inlined as `argextype.(Ref(ctx), ...)`
- Simplified null checks using @something `emit_value!(...) throw(...)` pattern
- Removed redundant `isa CGVal` guards since `emit_value!` always returns `CGVal` or `nothing`
- Added `replace_eltype` fallback for non-Tile types, simplifying conversion intrinsics