### PR TITLE
Emit GlobalRef constants eagerly (#77)

### DIFF
--- a/src/compiler/codegen/utils.jl
+++ b/src/compiler/codegen/utils.jl
@@ -103,16 +103,6 @@ ghost_value(@nospecialize(jltype)) = CGVal(nothing, TypeId(-1), jltype, Int[], n
 ghost_value(@nospecialize(jltype), constant) = CGVal(nothing, TypeId(-1), jltype, Int[], nothing, Some(constant), nothing)
 
 """
-    constant_value(jltype, type_id, constant) -> CGVal
-
-Deferred constant: has a Tile IR type but no bytecode value yet.
-Materialized (ConstantOp emitted) on demand at SSA lookup time.
-Parallel to Julia's non-ghost cgval from mark_julia_const.
-"""
-constant_value(@nospecialize(jltype), type_id::TypeId, constant) =
-    CGVal(nothing, type_id, jltype, Int[], nothing, Some(constant), nothing)
-
-"""
     tuple_value(jltype, component_refs, component_constants) -> CGVal
 
 Create a tuple value with tracked component refs. Derives constant if all components have constants.


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/cuTile.jl/issues/77#issuecomment-3867463389

The deferred emission was probably too fancy for what it was worth (both the Julia optimizer and back-end compiler are expected to do DCE), and didn't fix all of the issues involving constants.