### PR TITLE
BFloat16 scalar support

### DIFF
--- a/src/compiler/codegen/utils.jl
+++ b/src/compiler/codegen/utils.jl
@@ -310,6 +310,8 @@ function _tile_type_for_julia!(tt::TypeTable, @nospecialize(T::Type))
         return tile_type!(tt, I64(tt), Int[])
     elseif T === Float16
         return tile_type!(tt, F16(tt), Int[])
+    elseif T === BFloat16
+        return tile_type!(tt, BF16(tt), Int[])
     elseif T === Float32
         return tile_type!(tt, F32(tt), Int[])
     elseif T === Float64


### PR DESCRIPTION
Since BFloat16 is an arithmetic type, and one may sometimes do `one(T)` or `zero(T)`, even though `1` and `0` works just fine in such scenarios, this was a tiny footgun, and perhaps negligence on my part in #34.