### PR TITLE
Generic support for ghost types in `launch`

### DIFF
--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -113,8 +113,7 @@ function cuTile.launch(@nospecialize(f), grid, args...;
 
     # Unwrap Constant{T,V} → T for MI lookup (kernel sees plain types)
     unwrapped_types = map(tile_args) do arg
-        arg isa Constant ? constant_eltype(typeof(arg)) :
-        arg isa Type ? Type{arg} : typeof(arg)
+        arg isa Constant ? constant_eltype(typeof(arg)) : typeof(arg)
     end
     argtypes = Tuple{unwrapped_types...}
 

--- a/src/compiler/codegen/utils.jl
+++ b/src/compiler/codegen/utils.jl
@@ -374,7 +374,6 @@ end
 Check if a type is a ghost type (zero-size singleton).
 """
 function is_ghost_type(@nospecialize(T))
-    T isa Type && T <: Type && return true
     try
         isbitstype(T) && sizeof(T) == 0
     catch

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -1127,7 +1127,7 @@ end
 @testset "Non-Constant Ghost Type Arguments" begin
     spec = ct.ArraySpec{1}(16, true)
 
-    @testset "Nothing argument is skipped" begin
+    @testset "Nothing argument" begin
         @test @filecheck begin
             @check_label "entry"
             @check "load_view_tko"
@@ -1141,26 +1141,12 @@ end
         end
     end
 
-    @testset "Val argument is skipped" begin
+    @testset "Val argument" begin
         @test @filecheck begin
             @check_label "entry"
             @check "load_view_tko"
             @check "store_view_tko"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Val{16}}) do a, b, _
-                pid = ct.bid(1)
-                tile = ct.load(a, pid, (16,))
-                ct.store(b, pid, tile)
-                return
-            end
-        end
-    end
-
-    @testset "Type argument is skipped" begin
-        @test @filecheck begin
-            @check_label "entry"
-            @check "load_view_tko"
-            @check "store_view_tko"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Type{Float32}}) do a, b, _
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 ct.store(b, pid, tile)

--- a/test/execution/basic.jl
+++ b/test/execution/basic.jl
@@ -1098,20 +1098,3 @@ end
 
     @test Array(b) ≈ Array(a)
 end
-
-@testset "non-Constant ghost type argument (Type)" begin
-    function ghost_type_kernel(a::ct.TileArray{Float16,1}, b::ct.TileArray{Float32,1}, ::Type{T}) where T
-        pid = ct.bid(1)
-        tile = ct.load(a, pid, (16,))
-        ct.store(b, pid, convert(ct.Tile{T}, tile))
-        return
-    end
-
-    n = 256
-    a = CUDA.rand(Float16, n)
-    b = CUDA.zeros(Float32, n)
-
-    ct.launch(ghost_type_kernel, cld(n, 16), a, b, Float32)
-
-    @test Array(b) ≈ Float32.(Array(a))
-end


### PR DESCRIPTION
Replace the hardcoded `Constant` check in flatten with a generic `is_ghost_type` check so non-`Constant` ghost types like `Nothing` and `Val` work as kernel arguments.

I previously considered supporting `::Type` dispatch in `launch` (without having to wrap the type in `Constant`) but this turned out to be tricky (because `typeof(::Type)` is `DataType`) so it's not in this PR.