### PR TITLE
Support runtime values in ct.full (Intrinsics.constant)

### DIFF
--- a/src/compiler/intrinsics/core.jl
+++ b/src/compiler/intrinsics/core.jl
@@ -187,31 +187,15 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.constant), args)
     dtype = julia_to_tile_dtype!(tt, elem_type)
     tile_type = tile_type!(tt, dtype, tile_shape)
 
-    # Extract value - may be compile-time constant or runtime value (e.g. loop-carried variable)
-    value = get_constant(ctx, args[2])
-
-    if value !== nothing
+    tv = emit_value!(ctx, args[2])
+    tv === nothing && throw(IRError("full() value must be a constant or a runtime scalar"))
+    if tv.constant !== nothing
         # Compile-time constant: use ConstantOp directly
-        value_bytes = constant_to_bytes(value, elem_type)
+        value_bytes = constant_to_bytes(something(tv.constant), elem_type)
         result = encode_ConstantOp!(cb, tile_type, value_bytes)
     else
-        # Runtime value (e.g. from while loop carry): emit scalar, reshape to (1,1,...), broadcast to tile shape
-        scalar_val = emit_value!(ctx, args[2])
-        scalar_val === nothing && throw(IRError("full() value must be a constant or a runtime scalar"))
-
-        # Create a scalar tile type (all dimensions = 1)
-        scalar_shape = fill(1, length(tile_shape))
-        scalar_tile_type = tile_type!(tt, dtype, scalar_shape)
-
-        # Reshape scalar to (1, 1, ..., 1) tile
-        reshaped = encode_ReshapeOp!(cb, scalar_tile_type, scalar_val.v)
-
-        # Broadcast (1, 1, ..., 1) to target tile shape
-        if scalar_shape == tile_shape
-            result = reshaped
-        else
-            result = encode_BroadcastOp!(cb, tile_type, reshaped)
-        end
+        # Runtime value: broadcast 0D tile to the target shape
+        result = broadcast_tile_to_shape!(cb, tt, tv, tile_shape, dtype)
     end
 
     CGVal(result, tile_type, Tile{elem_type, Tuple{tile_shape...}}, tile_shape)

--- a/src/compiler/intrinsics/julia.jl
+++ b/src/compiler/intrinsics/julia.jl
@@ -64,5 +64,5 @@ function emit_intrinsic!(ctx::CGCtx, func::Type{<:Tile}, args)
 
     # Return as 0D tile type with element type from the constructor
     result_jltype = Tile{elem_type, Tuple{}}
-    CGVal(source.v, source.type_id, result_jltype, source.shape)
+    CGVal(source.v, source.type_id, result_jltype, source.shape, nothing, source.constant, nothing)
 end

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -434,8 +434,10 @@ Create a tile filled with a constant value.
 ones_tile = ct.full((32, 32), 1.0f0, Float32)
 ```
 """
+@inline full(shape::NTuple{N, Int}, value::Tile, ::Type{T}) where {N, T} =
+    Intrinsics.constant(shape, convert(Tile{T}, value), T)
 @inline full(shape::NTuple{N, Int}, value, ::Type{T}) where {N, T} =
-    Intrinsics.constant(shape, value, T)
+    Intrinsics.constant(shape, Tile(T(value)), T)
 
 """
     zeros(shape::NTuple{N, Int}, dtype::Type{T}) -> Tile{T, shape}

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -428,6 +428,21 @@
             end
         end
 
+        @testset "constant with runtime value" begin
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32}) do a, val
+                    pid = ct.bid(1)
+                    @check "itof"
+                    @check "reshape"
+                    @check "broadcast"
+                    tile = ct.full((16,), val, Float32)
+                    ct.store(a, pid, tile)
+                    return
+                end
+            end
+        end
+
         @testset "get_num_tile_blocks" begin
             @test @filecheck begin
                 @check_label "entry"

--- a/test/execution/basic.jl
+++ b/test/execution/basic.jl
@@ -1058,6 +1058,25 @@ const _EXEC_TEST_GLOBAL_CONST = Float32(1 / log(2))
     @test Array(b) ≈ Array(a) .* (scale * _EXEC_TEST_GLOBAL_CONST)
 end
 
+@testset "full with runtime value" begin
+    function full_runtime_kernel(src::ct.TileArray{Float32,1}, dst::ct.TileArray{Float32,1})
+        # Load a single-element tile to get a runtime scalar
+        val = ct.load(src, 1, (1,))
+        pid = ct.bid(1)
+        tile = ct.full((16,), val, Float32)
+        ct.store(dst, pid, tile)
+        return
+    end
+
+    n = 1024
+    src = CUDA.fill(3.14f0, 1)
+    dst = CUDA.zeros(Float32, n)
+
+    ct.launch(full_runtime_kernel, cld(n, 16), src, dst)
+
+    @test all(Array(dst) .≈ 3.14f0)
+end
+
 @testset "kernel name with !" begin
     function kernel!()
         return


### PR DESCRIPTION
Partial fix for #99 (Bug 2).

`ct.full()` required the value argument to be a compile-time constant. Loop-carried variables (e.g. accumulator from a `while` loop) would fail with `IRError: full() value must be a compile-time constant`.

When `get_constant()` returns `nothing`, fall back to: emit scalar → `ReshapeOp` to `(1,1,...,1)` → `BroadcastOp` to target tile shape. Compile-time constant path unchanged.

Bug 1 (nested while BlockArg collision) is addressed by maleadt/IRStructurizer.jl#4.