### PR TITLE
Update execution requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ julia> Pkg.add("cuTile")
 Execution of cuTile kernels requires CUDA.jl to be installed and imported.
 cuTile generates kernels based on [Tile IR](https://docs.nvidia.com/cuda/tile-ir/), which requires an NVIDIA Driver that supports CUDA 13 (580 or later).
 CUDA.jl automatically downloads the appropriate CUDA toolkit artifacts, so no manual CUDA installation is needed.
-Only Ampere, Ada, and Blackwell GPUs are supported at this time (with Hopper support planned).
+Only Ampere, Ada, and Blackwell GPUs are supported at this time, with Hopper support coming in a later release of CUDA 13.
 
 ## Quick Start
 


### PR DESCRIPTION
See #109. Also includes a note about Hopper support planned. The most concrete evidence being in the [README](https://github.com/NVIDIA/cutile-python/blob/eaad4888ea77c2eb470efca2f76a03c100518b63/README.md) of cutile-python:

> cuTile Python generates kernels based on [Tile IR](https://docs.nvidia.com/cuda/tile-ir/) which requries NVIDIA Driver r580 or later to run. Furthermore, the `tileiras` compiler (version 13.2) only supports Blackwell GPU and Ampere/Ada GPU. Hopper GPU will be supported in the coming versions. Checkout the [prerequisites](https://docs.nvidia.com/cuda/cutile-python/quickstart.html#prerequisites) for full list of requirements.

I also try to distinguish between CUDA and the NVIDIA Driver, though there are some nuances with the runtime version in CUDA.jl where you can configure it to use a local toollkit, and then it might not use the latest 13.1 or 13.2, but in such a case the error messages about architecture support should be clear.