### PR TITLE
Allow `transpose` on 1D tiles, disallow on >2D

### DIFF
--- a/src/compiler/intrinsics/core.jl
+++ b/src/compiler/intrinsics/core.jl
@@ -435,41 +435,6 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.permute), args)
     CGVal(result, output_tile_type, Tile{elem_type, Tuple{output_shape...}}, output_shape)
 end
 
-# cuda_tile.transpose
-@intrinsic transpose(tile)
-function tfunc(𝕃, ::typeof(Intrinsics.transpose), @nospecialize(tile_lat))
-    tile_type = CC.widenconst(tile_lat)
-    tile_type <: Tile || return nothing
-    s = size(tile_type)
-    isempty(s) && return nothing
-    T = eltype(tile_type)
-    return Tile{T, Tuple{reverse(s)...}}
-end
-function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.transpose), args)
-    cb = ctx.cb
-    tt = ctx.tt
-
-    source = emit_value!(ctx, args[1])
-    source === nothing && throw(IRError("Cannot resolve operand for transpose()"))
-
-    input_shape = source.shape
-    isempty(input_shape) && throw(IRError("Cannot determine tile shape for transpose()"))
-
-    output_shape = reverse(input_shape)
-
-    elem_type = eltype(CC.widenconst(source.jltype))
-
-    dtype = julia_to_tile_dtype!(tt, elem_type)
-    output_tile_type = tile_type!(tt, dtype, output_shape)
-
-    ndim = length(output_shape)
-    permutation = collect(ndim-1:-1:0)
-
-    result = encode_PermuteOp!(cb, output_tile_type, source.v, permutation)
-
-    CGVal(result, output_tile_type, Tile{elem_type, Tuple{output_shape...}}, output_shape)
-end
-
 
 # cuda_tile.reduce
 @intrinsic reduce(tiles, axis, f, identities)

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -545,8 +545,7 @@ permuted = permutedims(tile, (3, 1, 2))    # Shape (4, 2, 3)
 
 Permute a 2D tile, swapping its dimensions. Defaults to permutation `(2, 1)`.
 
-Differs from `transpose` in that the operation is not recursive. For tiles
-of numeric element types, the two operations are equivalent.
+Equivalent to `transpose`.
 
 ---
 
@@ -554,7 +553,7 @@ of numeric element types, the two operations are equivalent.
 
 Reshape a 1D tile into a `1 × N` row tile.
 
-Differs from `transpose` in that the operation is not recursive.
+Equivalent to `transpose`.
 """
 @generated function Base.permutedims(tile::T) where {T <: Tile}
     n = ndims(T)
@@ -573,10 +572,27 @@ end
     transpose(tile::Tile{T, (M, N)}) -> Tile{T, (N, M)}
 
 Transpose a 2D tile, swapping its dimensions.
-Equivalent to `permute(tile, (2, 1))`.
+
+---
+
+    transpose(tile::Tile{T, (N,)}) -> Tile{T, (1, N)}
+
+Reshape a 1D tile into a `1 × N` row tile.
+
+Equivalent to single-arg `permutedims`.
 """
-@inline Base.transpose(tile::Tile{T}) where {T} =
-    Intrinsics.transpose(tile)
+@generated function Base.transpose(tile::T) where {T <: Tile}
+    n = ndims(T)
+    first_dim = n >= 1 ? size(T, 1) : nothing
+
+    if n == 2
+        return :(Intrinsics.permute(tile, (1, 0)))
+    elseif n == 1
+        return :(Intrinsics.reshape(tile, (1, $first_dim)))
+    else
+        return :(throw(ArgumentError("transpose(tile) only works for 1D or 2D tiles")))
+    end
+end
 
 @inline Base.convert(::Type{Tile{T2}}, tile::Tile{T1, Shape}) where {T1, T2, Shape} =
     map(T2, tile)


### PR DESCRIPTION
Closes #114

`transpose` would previously reverse the dims, and be a no-op for 1D tiles. The old behavior is still possible to do with something like `permutedims(tile, ntuple(i -> ndims(tile) - i + 1, Val(ndims(tile))))`.