### PR TITLE
Fix codegen crash when SSAValue appears as a statement

### DIFF
--- a/src/compiler/codegen/statements.jl
+++ b/src/compiler/codegen/statements.jl
@@ -22,6 +22,8 @@ function emit_statement!(ctx::CGCtx, @nospecialize(stmt), ssa_idx::Int, @nospeci
         tv = emit_constant!(ctx, stmt.value, result_type)
     elseif stmt isa SlotNumber
         tv = ctx[stmt]
+    elseif stmt isa SSAValue
+        tv = emit_value!(ctx, stmt)
     elseif stmt isa PiNode
         # PiNode is a type narrowing assertion - store the resolved value
         tv = emit_value!(ctx, stmt)


### PR DESCRIPTION
When Julia's optimizer produces a statement that is just a reference to another SSA value (a copy/alias), emit_statement! fell through to the else branch which tried to treat it as a literal constant, causing `Int32(::Core.SSAValue)` MethodErrors. Handle SSAValue explicitly by looking up the referenced value via emit_value!.

Triggered by upcoming IRStructurizer.jl changes.