### PR TITLE
Register ghost CGVals for ghost-type kernel arguments

### DIFF
--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -43,6 +43,13 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
     for (i, argtype) in enumerate(sci.argtypes)
         argtype_unwrapped = CC.widenconst(argtype)
         if is_ghost_type(argtype_unwrapped)
+            # No kernel parameter, but register a ghost CGVal so codegen
+            # can resolve the value (e.g. get_constant on function singletons)
+            tv = ghost_value(argtype_unwrapped,
+                             Base.issingletontype(argtype_unwrapped) ?
+                                 argtype_unwrapped.instance : nothing)
+            ctx[SlotNumber(i)] = tv
+            ctx[Argument(i)] = tv
             continue
         elseif is_const_arg(i)
             continue  # const arg: no kernel parameter

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -1236,6 +1236,25 @@ end
             end
         end
     end
+
+    @testset "function singleton argument" begin
+        # Ghost function types (e.g. typeof(+)) passed as kernel arguments
+        # must be registered in the codegen context so that get_constant can
+        # resolve them.
+        @test @filecheck begin
+            @check_label "entry"
+            @check "addf"
+            function _ghost_op_kernel(a::ct.TileArray{Float32,1}, b::ct.TileArray{Float32,1}, op)
+                pid = ct.bid(1)
+                tile_a = ct.load(a, pid, (16,))
+                tile_b = ct.load(b, pid, (16,))
+                result = op.(tile_a, tile_b)
+                ct.store(a, pid, result)
+                return
+            end
+            code_tiled(_ghost_op_kernel, Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, typeof(+)})
+        end
+    end
 end
 
 #=============================================================================


### PR DESCRIPTION
Ghost-type kernel arguments (e.g. function singletons like typeof(+), Nothing, Val{N}) were skipped in emit_kernel! without registering a CGVal in the codegen context. This could cause codegen to fail if the IR references these arguments, since emit_value!/get_constant would return nothing for unregistered Argument/SlotNumber entries.

Register ghost values (with .instance for singletons, matching Julia's Base.issingletontype) so that codegen can always resolve ghost-type arguments, consistent with how emit_subprogram! already handles them.