### PR TITLE
Fix @device_code_tiled crash on kernels with reduce.

### DIFF
--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -299,7 +299,15 @@ function emit_subprogram!(ctx::CGCtx, func, arg_types::Vector,
     if !haskey(ctx.cache, mi)
         error("Expected $func($(join(arg_types, ", "))) to be cached already by inference.")
     end
-    sci, _, _ = emit_ir(ctx.cache, mi)
+    # Suppress compile_hook to avoid @device_code_tiled treating
+    # region bodies (e.g. reduce combiners) as standalone entries.
+    old_hook = compile_hook[]
+    compile_hook[] = nothing
+    sci, _, _ = try
+        emit_ir(ctx.cache, mi)
+    finally
+        compile_hook[] = old_hook
+    end
 
     # 3. Create sub-context
     sub_ctx = CGCtx(; ctx.cb, ctx.tt, sci,

--- a/test/device/core.jl
+++ b/test/device/core.jl
@@ -218,6 +218,29 @@ end # invalidations
                                         ct.Constant(16))
     end
     @test Array(c2) ≈ Array(a) + Array(b)
+
+    # @device_code_tiled with reduce subprogram
+    # Regression: compile hook tried to compile the reduce combiner (e.g. +) as a
+    # standalone entry, which cuda-tile-translate rejects.
+    function reflect_reduce(a::ct.TileArray{Float32,2}, b::ct.TileArray{Float32,1})
+        pid = ct.bid(1)
+        tile = ct.load(a, (pid, 1), (1, 128))
+        ct.store(b, pid, sum(tile; dims=2))
+        return
+    end
+
+    m, k = 64, 128
+    a2d = CUDA.rand(Float32, m, k)
+    b1d = CUDA.zeros(Float32, m)
+
+    @test @filecheck begin
+        @check "entry @reflect_reduce"
+        @check "reduce"
+        @check "addf"
+        buf = IOBuffer()
+        ct.@device_code_tiled io=buf ct.launch(reflect_reduce, m, a2d, b1d)
+        String(take!(buf))
+    end
 end
 
 @testset "assert" begin


### PR DESCRIPTION
The compile hook fired for subprogram compilations (e.g. the + combiner in a reduce body), causing cuda-tile-translate to reject the combiner as a standalone entry ("entry op must not return values"). Suppress the hook during emit_subprogram! since region bodies are not top-level entries.