### PR TITLE
Add atomic max, min, or, and, xor operations

### DIFF
--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -168,20 +168,19 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode)
     CGVal(old_val, result_tile_type, Tile{elem_type, Tuple{shape...}}, collect(shape))
 end
 
-# cuda_tile.atomic_rmw_tko with XCHG
-@intrinsic atomic_xchg(ptr_tile, val, mask, memory_order, memory_scope)
-tfunc(𝕃, ::typeof(Intrinsics.atomic_xchg), @nospecialize args...) = atomic_tfunc(𝕃, args...)
-efunc(::typeof(Intrinsics.atomic_xchg), effects::CC.Effects) =
-    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
-function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.atomic_xchg), args)
-    emit_atomic_rmw!(ctx, args, AtomicXCHG)
-end
-
-# cuda_tile.atomic_rmw_tko with ADD
-@intrinsic atomic_add(ptr_tile, val, mask, memory_order, memory_scope)
-tfunc(𝕃, ::typeof(Intrinsics.atomic_add), @nospecialize args...) = atomic_tfunc(𝕃, args...)
-efunc(::typeof(Intrinsics.atomic_add), effects::CC.Effects) =
-    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
-function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.atomic_add), args)
-    emit_atomic_rmw!(ctx, args, AtomicADD)
+# cuda_tile.atomic_rmw_tko variants
+for (op, mode) in ((:xchg, :AtomicXCHG), (:add, :AtomicADD),
+                    (:max, :AtomicMAX),  (:min, :AtomicMIN),
+                    (:or,  :AtomicOR),   (:and, :AtomicAND),
+                    (:xor, :AtomicXOR))
+    name = Symbol(:atomic_, op)
+    @eval begin
+        @intrinsic $name(ptr_tile, val, mask, memory_order, memory_scope)
+        tfunc(𝕃, ::typeof(Intrinsics.$name), @nospecialize args...) = atomic_tfunc(𝕃, args...)
+        efunc(::typeof(Intrinsics.$name), effects::CC.Effects) =
+            CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+        function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.$name), args)
+            emit_atomic_rmw!(ctx, args, $mode)
+        end
+    end
 end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -2,7 +2,7 @@
 #
 # Provides atomic compare-and-swap, exchange, and add operations for TileArrays.
 
-public atomic_cas, atomic_xchg, atomic_add
+public atomic_cas, atomic_xchg, atomic_add, atomic_max, atomic_min, atomic_or, atomic_and, atomic_xor
 
 """
 Memory ordering for atomic operations.
@@ -146,7 +146,47 @@ ct.atomic_xchg(locks, idx, Int32(0); memory_order=ct.MemoryOrder.Release)
 """
 function atomic_xchg end
 
-for op in (:add, :xchg)
+"""
+    atomic_max(array::TileArray, index, val; memory_order, memory_scope) -> T
+
+Atomic maximum. Atomically replaces the value at `index` with `max(old, val)`
+and returns the original value. Index is 1-indexed.
+"""
+function atomic_max end
+
+"""
+    atomic_min(array::TileArray, index, val; memory_order, memory_scope) -> T
+
+Atomic minimum. Atomically replaces the value at `index` with `min(old, val)`
+and returns the original value. Index is 1-indexed.
+"""
+function atomic_min end
+
+"""
+    atomic_or(array::TileArray, index, val; memory_order, memory_scope) -> T
+
+Atomic bitwise OR. Atomically replaces the value at `index` with `old | val`
+and returns the original value. Index is 1-indexed.
+"""
+function atomic_or end
+
+"""
+    atomic_and(array::TileArray, index, val; memory_order, memory_scope) -> T
+
+Atomic bitwise AND. Atomically replaces the value at `index` with `old & val`
+and returns the original value. Index is 1-indexed.
+"""
+function atomic_and end
+
+"""
+    atomic_xor(array::TileArray, index, val; memory_order, memory_scope) -> T
+
+Atomic bitwise XOR. Atomically replaces the value at `index` with `old ⊻ val`
+and returns the original value. Index is 1-indexed.
+"""
+function atomic_xor end
+
+for op in (:add, :xchg, :max, :min, :or, :and, :xor)
     fname = Symbol(:atomic_, op)
     intrinsic = Symbol(:atomic_, op)
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1477,6 +1477,66 @@ end
                 return
             end
         end
+
+        # max
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+                bid = ct.bid(1)
+                @check "offset"
+                @check "atomic_rmw_tko"
+                ct.atomic_max(arr, bid, Int32(0))
+                return
+            end
+        end
+
+        # min
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+                bid = ct.bid(1)
+                @check "offset"
+                @check "atomic_rmw_tko"
+                ct.atomic_min(arr, bid, Int32(0))
+                return
+            end
+        end
+
+        # or
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+                bid = ct.bid(1)
+                @check "offset"
+                @check "atomic_rmw_tko"
+                ct.atomic_or(arr, bid, Int32(1))
+                return
+            end
+        end
+
+        # and
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+                bid = ct.bid(1)
+                @check "offset"
+                @check "atomic_rmw_tko"
+                ct.atomic_and(arr, bid, Int32(-1))
+                return
+            end
+        end
+
+        # xor
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+                bid = ct.bid(1)
+                @check "offset"
+                @check "atomic_rmw_tko"
+                ct.atomic_xor(arr, bid, Int32(1))
+                return
+            end
+        end
     end
 
     @testset "tile-indexed atomic_cas_tko" begin

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -334,6 +334,96 @@ end
     @test all(Array(arr) .== 1)
 end
 
+@testset "atomic_max Int" begin
+    function atomic_max_kernel(out::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        ct.atomic_max(out, 1, bid;
+                     memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    n_blocks = 100
+    out = CUDA.zeros(Int, 1)
+
+    ct.launch(atomic_max_kernel, n_blocks, out)
+
+    result = Array(out)[1]
+    @test result == n_blocks
+end
+
+@testset "atomic_min Int" begin
+    function atomic_min_kernel(out::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        ct.atomic_min(out, 1, bid;
+                     memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    n_blocks = 100
+    out = CUDA.fill(Int(999), 1)
+
+    ct.launch(atomic_min_kernel, n_blocks, out)
+
+    result = Array(out)[1]
+    @test result == 1
+end
+
+@testset "atomic_or Int" begin
+    function atomic_or_kernel(out::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        # Set bit (bid-1) — bid is 1-indexed
+        ct.atomic_or(out, 1, 1 << (bid - 1);
+                    memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    n_blocks = 16
+    out = CUDA.zeros(Int, 1)
+
+    ct.launch(atomic_or_kernel, n_blocks, out)
+
+    result = Array(out)[1]
+    @test result == (1 << n_blocks) - 1
+end
+
+@testset "atomic_and Int" begin
+    function atomic_and_kernel(out::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        # Clear bit (bid-1)
+        ct.atomic_and(out, 1, ~(1 << (bid - 1));
+                     memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    n_blocks = 16
+    out = CUDA.fill(Int((1 << n_blocks) - 1), 1)
+
+    ct.launch(atomic_and_kernel, n_blocks, out)
+
+    result = Array(out)[1]
+    @test result == 0
+end
+
+@testset "atomic_xor Int" begin
+    function atomic_xor_kernel(out::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        # XOR with bid — each bid XORs once
+        ct.atomic_xor(out, 1, bid;
+                     memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    n_blocks = 100
+    out = CUDA.zeros(Int, 1)
+
+    ct.launch(atomic_xor_kernel, n_blocks, out)
+
+    # Expected: XOR of 1..n_blocks
+    expected = reduce(xor, 1:n_blocks)
+    result = Array(out)[1]
+    @test result == expected
+end
+
 @testset "1D gather - simple" begin
     # Simple 1D gather: copy first 16 elements using gather
     function gather_simple_kernel(src::ct.TileArray{Float32,1}, dst::ct.TileArray{Float32,1})


### PR DESCRIPTION
Complete the set of atomic RMW operations to match cuTile Python: add atomic_max, atomic_min, atomic_or, atomic_and, and atomic_xor with intrinsics, language wrappers, codegen tests, and execution tests.