### PR TITLE
Clean-up and optimize mapreduce

### DIFF
--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -577,6 +577,7 @@ Equivalent to single-arg `permutedims`.
     end
 end
 
+@inline Base.convert(::Type{Tile{T}}, tile::Tile{T}) where {T} = tile
 @inline Base.convert(::Type{Tile{T2}}, tile::Tile{T1, Shape}) where {T1, T2, Shape} =
     map(T2, tile)
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -49,11 +49,9 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray, reduce_dims::
     N = ndims(A)
     src_ta = TileArray(A)
 
-    # Reduced dims first (larger tiles enable better hardware reduction),
-    # then non-reduced dims (parallelized across blocks anyway)
-    red = [d for d in 1:N if d in reduce_dims]
-    non_red = [d for d in 1:N if !(d in reduce_dims)]
-    ts = _compute_tile_sizes(size(A), Iterators.flatten((red, non_red)))
+    # Reduced dims first (larger tiles => better hardware reduction)
+    dim_order = (filter(d -> d in reduce_dims, 1:N)..., filter(d -> !(d in reduce_dims), 1:N)...)
+    ts = _compute_tile_sizes(size(A), dim_order)
 
     pad_mode = _padding_for_neutral(init)
     if pad_mode === nothing
@@ -72,50 +70,31 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray, reduce_dims::
     target = max(1, 128 ÷ non_reduce_blocks)
     par_blocks = min(max_tiles, target)
 
+    _dim_size(d) = d == par_dim ? par_blocks : d in reduce_dims ? 1 : size(A, d)
+
     if par_blocks > 1
-        # Two-pass reduction: split work across par_blocks, then reduce partials
-        tmp_size = ntuple(N) do d
-            if d == par_dim
-                par_blocks
-            elseif d in reduce_dims
-                1
-            else
-                size(A, d)
-            end
-        end
-        tmp = similar(A, eltype(R), tmp_size)
-
-        # Pass 1: grid-stride reduction into tmp
+        # Two-pass: parallelize along par_dim, then reduce partials
+        tmp = similar(A, eltype(R), ntuple(_dim_size, N))
         grid = ntuple(N) do d
-            if d == par_dim
-                par_blocks
-            elseif d in reduce_dims
-                1
-            else
-                cld(size(A, d), ts[d])
-            end
+            d == par_dim ? par_blocks : d in reduce_dims ? 1 : cld(size(A, d), ts[d])
         end
-        reduce_stride = ntuple(N) do d
-            d == par_dim ? Int32(par_blocks) : Int32(1)
-        end
-        launch_grid, overflow = _flatten_grid(grid)
-        launch(mapreduce_kernel, launch_grid, TileArray(tmp), src_ta,
-               f, op, Constant(ts), Constant(reduce_dims), Constant(overflow),
-               Constant(init), Constant(pad_mode), Constant(reduce_stride))
-
-        # Pass 2: reduce partials (identity because f was already applied)
+        reduce_stride = ntuple(d -> d == par_dim ? Int32(par_blocks) : Int32(1), N)
+        _launch_mapreduce!(grid, TileArray(tmp), src_ta, f, op, ts, reduce_dims,
+                           init, pad_mode, reduce_stride)
         _mapreducedim!(identity, op, R, tmp, (par_dim,); init)
     else
-        # Single-pass: all reduce dims handled by one block each
-        grid = ntuple(N) do d
-            d in reduce_dims ? 1 : cld(size(A, d), ts[d])
-        end
+        grid = ntuple(d -> d in reduce_dims ? 1 : cld(size(A, d), ts[d]), N)
         reduce_stride = ntuple(d -> Int32(1), N)
-        launch_grid, overflow = _flatten_grid(grid)
-        launch(mapreduce_kernel, launch_grid, TileArray(R), src_ta,
-               f, op, Constant(ts), Constant(reduce_dims), Constant(overflow),
-               Constant(init), Constant(pad_mode), Constant(reduce_stride))
+        _launch_mapreduce!(grid, TileArray(R), src_ta, f, op, ts, reduce_dims,
+                           init, pad_mode, reduce_stride)
     end
+end
+
+function _launch_mapreduce!(grid, dest_ta, src_ta, f, op, ts, reduce_dims, init, pad_mode, reduce_stride)
+    launch_grid, overflow = _flatten_grid(grid)
+    launch(mapreduce_kernel, launch_grid, dest_ta, src_ta,
+           f, op, Constant(ts), Constant(reduce_dims), Constant(overflow),
+           Constant(init), Constant(pad_mode), Constant(reduce_stride))
 end
 
 function _mapreduce(f, op, A::AbstractArray; dims, init)


### PR DESCRIPTION
The `_compute_tile_sizes` budget was allocated to non-reduced dimensions first. For reductions like `sum(4096×4096; dims=1)`, this produced `(1, 4096)` tiles — 4096 elements along the parallel axis but only 1 along the reduction axis. Each block had to loop over 4096 single-element tiles instead of loading a full column in one shot. This also caused infinite recursion in the two-pass path for large arrays.

Swapping priority so reduced dimensions get the tile budget first gives `(4096, 1)` tiles — maximum coverage along the reduction axis, letting hardware `reduce` do the heavy lifting. The kernel itself is unchanged; only the host-side tile sizing decision changed.

A second commit cleans up the host dispatch: replaces heap-allocated `Vector` comprehensions with tuples, extracts a shared `_launch_mapreduce!` helper, and adds a no-op `convert(Tile{T}, Tile{T})` identity method.

### Kernel-only performance (RTX 5080, median of 20 samples)

| Operation | CuArray | cuTile | Speedup |
|---|---:|---:|---:|
| sum 1D (16M) | 35.2 µs | 23.4 µs | **1.50x** |
| sum 2D full (4096²) | 68.0 µs | 26.4 µs | **2.58x** |
| sum 2D dims=1 (4096²) | 101.2 µs | 23.6 µs | **4.29x** |
| sum 2D dims=2 (4096²) | 232.7 µs | 223.9 µs | 1.04x |
| maximum 1D (16M) | 29.1 µs | 18.2 µs | **1.60x** |
| mapreduce(abs, +) (16M) | 29.1 µs | 23.2 µs | **1.25x** |
| broadcast sin (10M) | 92.4 µs | 69.2 µs | **1.34x** |
| broadcast add (10M) | 121.7 µs | 124.3 µs | 0.98x |