### PR TITLE
Support Constant(nothing) as kernel argument

### DIFF
--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -114,19 +114,15 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
             i > length(sci.argtypes) && continue
             val = cat.val
             T = typeof(val)
-            if is_ghost_type(T)
-                tv = ghost_value(T, val)
+            type_id = tile_type_for_julia!(ctx, T; throw_error=false)
+            if type_id !== nothing
+                # Scalar: emit ConstantOp
+                bytes = constant_to_bytes(val, T)
+                v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+                tv = CGVal(v, type_id, T, Int[], nothing, Some(val), nothing)
             else
-                type_id = tile_type_for_julia!(ctx, T; throw_error=false)
-                if type_id !== nothing
-                    # Scalar: emit ConstantOp
-                    bytes = constant_to_bytes(val, T)
-                    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
-                    tv = CGVal(v, type_id, T, Int[], nothing, Some(val), nothing)
-                else
-                    # Non-primitive (tuple etc.): ghost with constant
-                    tv = ghost_value(T, val)
-                end
+                # Non-primitive (tuple etc.): ghost with constant
+                tv = ghost_value(T, val)
             end
             ctx[SlotNumber(i)] = tv
             ctx[Argument(i)] = tv

--- a/src/compiler/codegen/utils.jl
+++ b/src/compiler/codegen/utils.jl
@@ -362,8 +362,6 @@ function _tile_type_for_julia!(tt::TypeTable, @nospecialize(T::Type))
         return tile_type!(tt, F32(tt), Int[])
     elseif T === Float64
         return tile_type!(tt, F64(tt), Int[])
-    elseif T === Nothing
-        return Token(tt)
     end
 
     # Pointers -> 0-D tile of pointer type


### PR DESCRIPTION
Skip ghost types in const-seeded argument emission to avoid attempting byte serialization of unsupported types like Nothing.