### PR TITLE
Fix divisibility computation exceeding max_divisor.

### DIFF
--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -79,7 +79,7 @@ Returns 0 if value is 0 or not divisible by any power of 2.
 function compute_divisibility(value::Integer, max_divisor::Int=16)
     value == 0 && return 0
     divisor = 1
-    while divisor <= max_divisor && value % (divisor * 2) == 0
+    while divisor < max_divisor && value % (divisor * 2) == 0
         divisor *= 2
     end
     return divisor >= 2 ? divisor : 0  # Only return if at least divisible by 2


### PR DESCRIPTION
`compute_divisibility` used `<=` instead of `<` in its loop bound, allowing the result to overshoot `max_divisor`. With the default max_divisor=16, any shape divisible by 32 (common in GPU workloads) would produce a `DivBy(32)` assume in the Tile IR bytecode instead of the intended `DivBy(16)`, mismatching cuTile Python's behavior and causing unnecessary kernel respecialization via ArraySpec type params.