### PR TITLE
Extend reflection: support constants, add kwargs.

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -365,13 +365,70 @@ function resolve_hint(explicit, kernel_meta::Dict{Symbol, Any}, key::Symbol,
 end
 
 """
+    get_ci(cache, mi; const_argtypes=nothing) -> CodeInstance
+
+Ensure inference is done and return the CodeInstance. Runs `typeinf!` which is
+a no-op when already cached. When `const_argtypes` is provided, also ensures
+the const-specialized entry exists.
+"""
+function get_ci(cache::CacheView, mi::Core.MethodInstance;
+                const_argtypes::Union{Vector{Any}, Nothing}=nothing)
+    # Ensure CI exists
+    ci = get(cache, mi, nothing)
+    if ci === nothing
+        interp = cuTileInterpreter(cache)
+        typeinf!(cache, interp, mi)
+        ci = get(cache, mi)
+    end
+
+    # Run const-prop inference, if needed
+    if const_argtypes !== nothing
+        interp = cuTileInterpreter(cache)
+        typeinf!(cache, interp, mi, const_argtypes)
+    end
+
+    return ci
+end
+
+# Get the inferred source and return type from a CodeInstance.
+function get_inferred(cache::CacheView{K,V}, ci::Core.CodeInstance,
+                      mi::Core.MethodInstance; const_argtypes::Union{Vector{Any},
+                      Nothing}=nothing) where {K,V}
+    rettype = CC.widenconst(ci.rettype)
+    if const_argtypes === nothing
+        src = @something get_source(ci)
+    else
+        src = @something get_source(ci, const_argtypes)
+
+        # Extract the return type from a const-specialized entry.
+        cached = CC.traverse_analysis_results(ci) do @nospecialize(result)
+            result isa CompilerCaching.CachedResult{V} ? result : nothing
+        end
+        for entry in cached.const_entries
+            if entry.argtypes == const_argtypes
+                rettype = CC.widenconst(entry.rettype)
+            end
+        end
+    end
+    ir = CC.inflate_ir(src, mi)
+    return ir, rettype
+end
+
+"""
+    emit_julia(cache, mi; const_argtypes=nothing) -> (IRCode, rettype)
+
+Julia phase: run inference and return IRCode.
+"""
+function emit_julia(cache::CacheView, mi::Core.MethodInstance;
+                    const_argtypes::Union{Vector{Any}, Nothing}=nothing)
+    ci = get_ci(cache, mi; const_argtypes)
+    get_inferred(cache, ci, mi; const_argtypes)
+end
+
+"""
     emit_ir(cache, mi; const_argtypes=nothing) -> (StructuredIRCode, rettype, kernel_meta)
 
-IR phase: run inference if needed and return structured IR plus extracted kernel meta.
-
-When `const_argtypes` is provided (a `Vector{Any}` with `CC.Const` entries for
-compile-time constants), const-seeded inference is used, producing specialized
-IR where constant values are folded in.
+IR phase: structurize and optimize IRCode. Caches the result.
 """
 function emit_ir(cache::CacheView, mi::Core.MethodInstance;
                  const_argtypes::Union{Vector{Any}, Nothing}=nothing)
@@ -397,57 +454,19 @@ function emit_ir(cache::CacheView, mi::Core.MethodInstance;
         compile_hook[](f, tt)
     end
 
-    # Ensure generic CI exists
-    ci = get(cache, mi, nothing)
-    if ci === nothing
-        interp = cuTileInterpreter(cache)
-        typeinf!(cache, interp, mi)
-        ci = get(cache, mi)
-    end
+    ci = get_ci(cache, mi; const_argtypes)
 
-    if const_argtypes !== nothing
-        # Const-seeded path: run const-prop inference and use specialized source
-        interp = cuTileInterpreter(cache)
-        typeinf!(cache, interp, mi, const_argtypes)
-        res = results(cache, ci, const_argtypes)
-        res.julia_ir !== nothing && return res.julia_ir
-        src = @something get_source(ci, const_argtypes)
-        ir = CC.inflate_ir(src, mi)
-        process_meta!(ir)
-        kernel_meta = extract_meta(ir)
-        sci = StructuredIRCode(ir)
-        rettype = _specialized_rettype(cache, ci, const_argtypes)
-        res.julia_ir = (sci, rettype, kernel_meta)
-        return res.julia_ir
-    else
-        # Generic path
-        res = results(cache, ci)
-        res.julia_ir !== nothing && return res.julia_ir
-        src = @something get_source(ci)
-        ir = CC.inflate_ir(src, mi)
-        process_meta!(ir)
-        kernel_meta = extract_meta(ir)
-        sci = StructuredIRCode(ir)
-        res.julia_ir = (sci, ci.rettype, kernel_meta)
-        return res.julia_ir
-    end
-end
+    # Check result cache
+    res = const_argtypes !== nothing ? results(cache, ci, const_argtypes) : results(cache, ci)
+    res.julia_ir !== nothing && return res.julia_ir
 
-"""
-    _specialized_rettype(cache, ci, argtypes) -> Type
-
-Extract the return type from a const-specialized entry.
-"""
-function _specialized_rettype(cache::CacheView{K,V}, ci, argtypes) where {K,V}
-    cached = CC.traverse_analysis_results(ci) do @nospecialize(result)
-        result isa CompilerCaching.CachedResult{V} ? result : nothing
-    end
-    for entry in cached.const_entries
-        if entry.argtypes == argtypes
-            return CC.widenconst(entry.rettype)
-        end
-    end
-    return CC.widenconst(ci.rettype)
+    # Inflate and structurize
+    ir, rettype = get_inferred(cache, ci, mi; const_argtypes)
+    process_meta!(ir)
+    kernel_meta = extract_meta(ir)
+    sci = StructuredIRCode(ir)
+    res.julia_ir = (sci, rettype, kernel_meta)
+    return res.julia_ir
 end
 
 # Encode characters outside [a-zA-Z0-9_] as _XX hex escapes for PTX/MLIR compatibility.
@@ -521,15 +540,33 @@ function disassemble_tileir(bytecode::Vector{UInt8})::String
 end
 
 """
+    lookup_method_instance(f, argtypes; world) -> MethodInstance
+
+Look up a MethodInstance for a cuTile function, checking the overlay method table first.
+"""
+function lookup_method_instance(@nospecialize(f), @nospecialize(argtypes);
+                                world::UInt=Base.get_world_counter())
+    tt = Base.signature_type(f, argtypes)
+    if !Base.isdispatchtuple(tt)
+        throw(ArgumentError("requires a dispatch tuple, got non-concrete signature"))
+    end
+    @something(match_method_instance(f, argtypes; world, method_table=cuTileMethodTable),
+               match_method_instance(f, argtypes; world),
+               throw(MethodError(f, argtypes)))
+end
+
+"""
     code_typed(f, argtypes; world, kwargs...) -> Vector{Any}
 
 Return typed code for a cuTile function. Analogous to `Base.code_typed`.
 """
 function code_typed(@nospecialize(f), @nospecialize(argtypes);
                     world::UInt=Base.get_world_counter(), kwargs...)
+    stripped, const_argtypes = process_const_argtypes(f, argtypes)
+    mi = lookup_method_instance(f, stripped; world)
     cache = CacheView{CuTileResults}(:cuTile, world)
-    interp = cuTileInterpreter(cache)
-    Base.code_typed(f, argtypes; world, interp, kwargs...)
+    ir, rettype = emit_julia(cache, mi; const_argtypes)
+    [ir => rettype]
 end
 
 """
@@ -539,12 +576,16 @@ Return the structured IR for a cuTile function.
 """
 function code_structured(@nospecialize(f), @nospecialize(argtypes);
                          world::UInt=Base.get_world_counter(),
-                         validate::Bool=true)
+                         optimize::Bool=true)
+    stripped, const_argtypes = process_const_argtypes(f, argtypes)
+    mi = lookup_method_instance(f, stripped; world)
     cache = CacheView{CuTileResults}(:cuTile, world)
-    interp = cuTileInterpreter(cache)
-    map(Base.code_ircode(f, argtypes; world, interp)) do (ir, ret_type)
-        StructuredIRCode(ir; validate) => ret_type
+    sci, rettype, _ = emit_ir(cache, mi; const_argtypes)
+    if optimize
+        sci = deepcopy(sci)
+        run_passes!(sci)
     end
+    [sci => rettype]
 end
 
 """
@@ -594,13 +635,7 @@ function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
                     world::UInt=Base.get_world_counter())
     # Strip Constant types from argtypes for MI lookup, build const_argtypes
     stripped, const_argtypes = process_const_argtypes(f, argtypes)
-    tt = Base.signature_type(f, stripped)
-    if !Base.isdispatchtuple(tt)
-        throw(ArgumentError("code_tiled requires a dispatch tuple, got non-concrete signature"))
-    end
-    mi = @something(match_method_instance(f, stripped; world, method_table=cuTileMethodTable),
-                    match_method_instance(f, stripped; world),
-                    throw(MethodError(f, stripped)))
+    mi = lookup_method_instance(f, stripped; world)
 
     opts = (sm_arch=sm_arch, opt_level=opt_level, num_ctas=num_ctas, occupancy=occupancy,
             bytecode_version=bytecode_version)

--- a/test/codegen/reflection.jl
+++ b/test/codegen/reflection.jl
@@ -1,0 +1,79 @@
+spec = ct.ArraySpec{1}(16, true)
+TT3 = Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}
+
+function reflect_vadd(a, b, c)
+    pid = ct.bid(1)
+    tile_a = ct.load(a; index=pid, shape=(16,))
+    tile_b = ct.load(b; index=pid, shape=(16,))
+    ct.store(c; index=pid, tile=tile_a + tile_b)
+    return
+end
+
+@testset "code_typed" begin
+    @test @filecheck begin
+        @check "get_tile_block_id"
+        @check "load_partition_view"
+        @check "addf"
+        @check "store_partition_view"
+        ct.code_typed(reflect_vadd, TT3)
+    end
+end
+
+@testset "code_structured" begin
+    @testset "optimize=false" begin
+        @test @filecheck begin
+            @check "StructuredIRCode"
+            @check "get_tile_block_id"
+            # Core intrinsics survive without optimization
+            @check "Base.add_int"
+            @check "addf"
+            ct.code_structured(reflect_vadd, TT3; optimize=false)
+        end
+    end
+
+    @testset "optimize=true" begin
+        @test @filecheck begin
+            @check "StructuredIRCode"
+            # Token ordering inserts make_token
+            @check "MakeTokenNode"
+            @check "get_tile_block_id"
+            @check "addf"
+            # Core intrinsics lowered by normalize pass
+            @check_not "Base.add_int"
+            ct.code_structured(reflect_vadd, TT3)
+        end
+    end
+end
+
+@testset "Constant args" begin
+    const_spec = ct.ArraySpec{1}(128, true, (0,), (32,))
+    ConstTT = Tuple{ct.TileArray{Float32,1,const_spec}, ct.TileArray{Float32,1,const_spec},
+                    ct.TileArray{Float32,1,const_spec}, ct.Constant{Int64, 16}}
+
+    function reflect_const_vadd(a, b, c, tile_size::Int)
+        pid = ct.bid(1)
+        tile_a = ct.load(a; index=pid, shape=(tile_size,))
+        tile_b = ct.load(b; index=pid, shape=(tile_size,))
+        ct.store(c; index=pid, tile=tile_a + tile_b)
+        return
+    end
+
+    @testset "code_typed" begin
+        @test @filecheck begin
+            # Constant folded: shape=(16,) appears as literal tuple
+            @check "make_partition_view"
+            @check "(16,)"
+            @check "Tuple{16}"
+            ct.code_typed(reflect_const_vadd, ConstTT)
+        end
+    end
+
+    @testset "code_structured" begin
+        @test @filecheck begin
+            @check "make_partition_view"
+            @check "(16,)"
+            @check "Tuple{16}"
+            ct.code_structured(reflect_const_vadd, ConstTT; optimize=false)
+        end
+    end
+end


### PR DESCRIPTION
You can now very clearly see the optimization happening by calling `code_structured` with `optimize=false`:

```julia-repl
julia> function vadd(a, b, c, tile_size::Int)
           pid = ct.bid(1)
           tile_a = ct.load(a; index=pid, shape=(tile_size,))
           tile_b = ct.load(b; index=pid, shape=(tile_size,))
           ct.store(c; index=pid, tile=tile_a + tile_b)
           return
       end
vadd (generic function with 1 method)

julia> ct.code_typed(vadd, Tuple{ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.Constant{Int64, 16}})
1-element Vector{Pair{Compiler.IRCode, DataType}}:
2 1 ─ %1  =   dynamic (cuTile.Intrinsics.get_tile_block_id)(0)::Int32
  │   %2  = intrinsic Base.add_int(%1, 1)::Int32╻              +
3 │   %3  =   dynamic (cuTile.Intrinsics.make_tensor_view)(_2)::cuTile.TensorView{Float32, 1}
  │   %4  =   dynamic (cuTile.Intrinsics.make_partition_view)(%3, (16,), $(QuoteNode(cuTile.PaddingMode.Undetermined)), cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
  │   %5  = intrinsic Base.sub_int(%2, 1)::Int32│╻╷╷╷╷╷╷╷       load
  │   %6  =   builtin Core.tuple(%5)::Tuple{Int32}┃│││││         #load#141
  │   %7  =   dynamic (cuTile.Intrinsics.load_partition_view)(%4, cuTile.nothing, cuTile.nothing, %6)::cuTile.FloatTile{Tuple{16}, Float32}
4 │   %8  =   dynamic (cuTile.Intrinsics.make_tensor_view)(_3)::cuTile.TensorView{Float32, 1}
  │   %9  =   dynamic (cuTile.Intrinsics.make_partition_view)(%8, (16,), $(QuoteNode(cuTile.PaddingMode.Undetermined)), cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
  │   %10 = intrinsic Base.sub_int(%2, 1)::Int32│╻╷╷╷╷╷╷╷       load
  │   %11 =   builtin Core.tuple(%10)::Tuple{Int32}│││││         #load#141
  │   %12 =   dynamic (cuTile.Intrinsics.load_partition_view)(%9, cuTile.nothing, cuTile.nothing, %11)::cuTile.FloatTile{Tuple{16}, Float32}
5 │   %13 =   dynamic (cuTile.Intrinsics.addf)(%7, %12)::cuTile.FloatTile{Tuple{16}, Float32}
  │   %14 = intrinsic Base.sub_int(%2, 1)::Int32╻╷╷╷╷╷╷╷╷╷╷╷╷  #store#154
  │   %15 =   builtin Core.tuple(%14)::Tuple{Int32}│││││        store
  │   %16 =   dynamic (cuTile.Intrinsics.make_tensor_view)(_4)::cuTile.TensorView{Float32, 1}
  │   %17 =   dynamic (cuTile.Intrinsics.make_partition_view)(%16, (16,), $(QuoteNode(cuTile.PaddingMode.Undetermined)), nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
  │           dynamic (cuTile.Intrinsics.store_partition_view)(%17, %13, nothing, nothing, %15)::Nothing
6 └──       return nothing                    │
   => Nothing

julia> ct.code_structured(vadd, Tuple{ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.Constant{Int64, 16}}; optimize=false)
1-element Vector{Pair{IRStructurizer.StructuredIRCode, DataType}}:
 StructuredIRCode(
│ %1  = cuTile.Intrinsics.get_tile_block_id(0)::Int32
│ %2  = intrinsic Base.add_int(%1, 1)::Int32
│ %3  = cuTile.Intrinsics.make_tensor_view(_2)::cuTile.TensorView{Float32, 1}
│ %4  = cuTile.Intrinsics.make_partition_view(%3, (16,), cuTile.PaddingMode.Undetermined, cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %5  = intrinsic Base.sub_int(%2, 1)::Int32
│ %6  = Core.tuple(%5)::Tuple{Int32}
│ %7  = cuTile.Intrinsics.load_partition_view(%4, cuTile.nothing, cuTile.nothing, %6)::cuTile.FloatTile{Tuple{16}, Float32}
│ %8  = cuTile.Intrinsics.make_tensor_view(_3)::cuTile.TensorView{Float32, 1}
│ %9  = cuTile.Intrinsics.make_partition_view(%8, (16,), cuTile.PaddingMode.Undetermined, cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %10 = intrinsic Base.sub_int(%2, 1)::Int32
│ %11 = Core.tuple(%10)::Tuple{Int32}
│ %12 = cuTile.Intrinsics.load_partition_view(%9, cuTile.nothing, cuTile.nothing, %11)::cuTile.FloatTile{Tuple{16}, Float32}
│ %13 = cuTile.Intrinsics.addf(%7, %12)::cuTile.FloatTile{Tuple{16}, Float32}
│ %14 = intrinsic Base.sub_int(%2, 1)::Int32
│ %15 = Core.tuple(%14)::Tuple{Int32}
│ %16 = cuTile.Intrinsics.make_tensor_view(_4)::cuTile.TensorView{Float32, 1}
│ %17 = cuTile.Intrinsics.make_partition_view(%16, (16,), cuTile.PaddingMode.Undetermined, nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %18 = cuTile.Intrinsics.store_partition_view(%17, %13, nothing, nothing, %15)::Nothing
└ return nothing
) => Nothing

julia> ct.code_structured(vadd, Tuple{ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
                                 ct.Constant{Int64, 16}})
1-element Vector{Pair{IRStructurizer.StructuredIRCode, DataType}}:
 StructuredIRCode(
│ %20 = cuTile.MakeTokenNode()::cuTile.TokenType()
│ %1  = cuTile.Intrinsics.get_tile_block_id(0)::Int32
│ %3  = cuTile.Intrinsics.make_tensor_view(_2)::cuTile.TensorView{Float32, 1}
│ %4  = cuTile.Intrinsics.make_partition_view(%3, (16,), cuTile.PaddingMode.Undetermined, cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %6  = Core.tuple(%1)::Tuple{Int32}
│ %7  = cuTile.Intrinsics.load_partition_view(%4, cuTile.nothing, cuTile.nothing, %6, %20)::cuTile.FloatTile{Tuple{16}, Float32}
│ %8  = cuTile.Intrinsics.make_tensor_view(_3)::cuTile.TensorView{Float32, 1}
│ %9  = cuTile.Intrinsics.make_partition_view(%8, (16,), cuTile.PaddingMode.Undetermined, cuTile.nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %11 = Core.tuple(%1)::Tuple{Int32}
│ %12 = cuTile.Intrinsics.load_partition_view(%9, cuTile.nothing, cuTile.nothing, %11, %20)::cuTile.FloatTile{Tuple{16}, Float32}
│ %13 = cuTile.Intrinsics.addf(%7, %12)::cuTile.FloatTile{Tuple{16}, Float32}
│ %15 = Core.tuple(%1)::Tuple{Int32}
│ %16 = cuTile.Intrinsics.make_tensor_view(_4)::cuTile.TensorView{Float32, 1}
│ %17 = cuTile.Intrinsics.make_partition_view(%16, (16,), cuTile.PaddingMode.Undetermined, nothing)::cuTile.PartitionView{Float32, 1, Tuple{16}}
│ %18 = cuTile.Intrinsics.store_partition_view(%17, %13, nothing, nothing, %15, %20)::Nothing
└ return nothing
) => Nothing
```