### PR TITLE
Fix alias analysis not tracking pointer aliases through getfield/offset

### DIFF
--- a/src/compiler/passes/alias_analysis.jl
+++ b/src/compiler/passes/alias_analysis.jl
@@ -133,7 +133,7 @@ function analyze_statement!(tracker::AliasTracker, block::Block, inst::Instructi
         func = callee(s)
 
         # getfield: propagate from parent
-        if func === GlobalRef(Core, :getfield) && length(operands) >= 1
+        if resolved_func === getfield && length(operands) >= 1
             field = length(operands) >= 2 ? operands[2] : nothing
 
             # For TileArray.ptr field access, propagate pointer alias
@@ -145,7 +145,7 @@ function analyze_statement!(tracker::AliasTracker, block::Block, inst::Instructi
             end
 
         # Pointer arithmetic: propagate from pointer operand
-        elseif func === GlobalRef(Base, :+) || func === GlobalRef(Base, :-)
+        elseif resolved_func === Base.:+ || resolved_func === Base.:-
             for arg in operands
                 # Find the pointer argument and propagate
                 arg_aliases = tracker[arg]
@@ -191,12 +191,6 @@ function is_view_constructor(func)
 end
 
 function is_pointer_passthrough(func)
-    func === GlobalRef(Core.Intrinsics, :bitcast) && return true
-
-    # Check by name for cuTile intrinsics that pass pointers through
-    if func isa Function
-        n = nameof(func)
-        return n === :bitcast || n === :assume_div_by || n === :assume_bounded || n === :assume_aligned
-    end
-    return false
+    return func === Intrinsics.offset ||
+        func === Core.Intrinsics.bitcast
 end

--- a/src/compiler/passes/dce.jl
+++ b/src/compiler/passes/dce.jl
@@ -102,10 +102,10 @@ function must_keep(block::Block, @nospecialize(s))
             # No efunc override → pure intrinsic, safe to remove
             return false
         end
-        # getfield is pure (both Core.getfield GlobalRef and bare getfield)
+        # getfield is pure
         if s isa Expr
             func = s.args[1]
-            if func === getfield || (func isa GlobalRef && func.mod === Core && func.name === :getfield)
+            if func === getfield || (func isa GlobalRef && getfield(func.mod, func.name) === getfield)
                 return false
             end
         end
@@ -414,7 +414,6 @@ end
     is_getfield_of(s, ref::SSAValue) -> Bool
 
 Check if `s` is a `getfield(ref, idx::Int)` expression.
-Handles both `Core.getfield` (GlobalRef) and bare `getfield` (resolved function).
 """
 function is_getfield_of(@nospecialize(s), ref::SSAValue)
     s isa Expr || return false
@@ -422,7 +421,7 @@ function is_getfield_of(@nospecialize(s), ref::SSAValue)
     length(s.args) >= 3 || return false
     func = s.args[1]
     is_gf = if func isa GlobalRef
-        func.mod === Core && func.name === :getfield
+        getfield(func.mod, func.name) === getfield
     else
         func === getfield
     end


### PR DESCRIPTION
The alias analysis compared callees against `GlobalRef(Core, :getfield)`, but Julia's typed IR uses `GlobalRef(Base, :getfield)`. Since these are different GlobalRef objects (even though the underlying function is the same), getfield calls were never matched, causing all pointer field accesses to fall through to ALIAS_UNIVERSE.

This made gather and scatter operations share a single alias set, preventing DCE from removing dead token loop-carries. The result was unnecessary token dependencies that triggered a tileiras optimizer crash at -O1+.

Fix by comparing against resolved functions instead of fragile GlobalRef matching. Also add `Intrinsics.offset` as a pointer passthrough, and apply the same resolved-function pattern to DCE's getfield checks.