### PR TITLE
Include `(c - a*b)` pattern in FMA rewrite pipeline.

### DIFF
--- a/src/compiler/passes/pipeline.jl
+++ b/src/compiler/passes/pipeline.jl
@@ -33,6 +33,8 @@ const FMA_RULES = RewriteRule[
             Intrinsics.fma(~x, ~y, ~z)
     @rewrite Intrinsics.subf(one_use(Intrinsics.mulf(~x, ~y)), ~z) =>
             Intrinsics.fma(~x, ~y, Intrinsics.negf(~z))
+    @rewrite Intrinsics.subf(~z, one_use(Intrinsics.mulf(~x, ~y))) =>
+            Intrinsics.fma(Intrinsics.negf(~x), ~y, ~z)
 ]
 
 fma_fusion_pass!(sci::StructuredIRCode) = rewrite_patterns!(sci, FMA_RULES)

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1389,6 +1389,22 @@ end
                 return
             end
         end
+
+        # a .- b .* c → fma(negf(b), c, a)
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                pid = ct.bid(1)
+                ta = ct.load(a, pid, (16,))
+                tb = ct.load(a, pid, (16,))
+                tc = ct.load(a, pid, (16,))
+                @check "negf"
+                @check "fma"
+                result = ta .- tb .* tc
+                ct.store(a, pid, result)
+                return
+            end
+        end
     end
 
     @testset "remf" begin


### PR DESCRIPTION
Port https://github.com/NVIDIA/cutile-python/commit/4ab4f6e84e9e2f8627bd87e94c7396b8378db5cb