### PR TITLE
Add KernelState plumbing for per-launch ambient state.

### DIFF
--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -174,6 +174,9 @@ function cuTile.launch(@nospecialize(f), grid, args...;
                        opt_level::Union{Int, Nothing}=nothing,
                        num_ctas::Union{Int, Nothing}=nothing,
                        occupancy::Union{Int, Nothing}=nothing)
+    # `KernelState` is the implicit per-launch ambient state; today it's a
+    # ghost so `flatten(state)` adds zero kernel args and zero overhead.
+    state = cuTile.KernelState()
     bytecode_version = check_tile_ir_support()
 
     # Resolve sm_arch: nothing → device capability
@@ -216,8 +219,11 @@ function cuTile.launch(@nospecialize(f), grid, args...;
     # Run cached compilation
     cufunc = emit_function!(cache, mi; const_argtypes)
 
-    # Flatten arguments for cudacall - Constant returns () so ghost types disappear
-    flat_args = Tuple(Iterators.flatten(map(flatten, tile_args)))
+    # Flatten arguments for cudacall - Constant returns () so ghost types
+    # disappear. The trailing `flatten(state)` matches the implicit
+    # KernelState destructured at the end of the bytecode kernel signature
+    # by `emit_kernel!`.
+    flat_args = (Iterators.flatten(map(flatten, tile_args))..., flatten(state)...)
     flat_types = Tuple{map(typeof, flat_args)...}
 
     # Get grid dimensions

--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -40,7 +40,11 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
         require_concrete_type(argtype, "kernel argument $i")
     end
 
-    # Build parameter list, handling ghost types, const args, and struct destructuring
+    # Build parameter list, handling ghost types, const args, and struct
+    # destructuring. The implicit `KernelState` slot lives at the trailing
+    # codegen arg_idx (`length(sci.argtypes) + 1`) — one past the last Julia
+    # arg — and is destructured *after* the user args so its flat params
+    # occupy the trailing slots in the bytecode kernel signature.
     param_types = TypeId[]
     param_mapping = Tuple{Int, Vector{Int}}[]
 
@@ -66,6 +70,11 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
         end
     end
 
+    state_arg_idx = length(sci.argtypes) + 1
+    ctx.arg_types[state_arg_idx] = KernelState
+    flatten_struct_params!(ctx, param_types, param_mapping,
+                           state_arg_idx, KernelState, Int[])
+
     # Return types
     result_types = TypeId[]
     if rettype !== Nothing && rettype !== Union{}
@@ -90,7 +99,9 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
     # Set up argument values
     arg_values = make_block_args!(cb, length(param_types))
 
-    # Build arg_flat_values map
+    # Build arg_flat_values map. User args and the trailing KernelState
+    # pieces land here — they go through the same `param_mapping`-keyed path.
+    # `kernel_state()` resolves to a lazy arg_ref into this map.
     field_values = Dict{Tuple{Int, Vector{Int}}, Vector{Value}}()
     for (param_idx, val) in enumerate(arg_values)
         key = param_mapping[param_idx]
@@ -105,7 +116,7 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
         arg_idx, path = key
         ctx.arg_flat_values[key] = values
 
-        if isempty(path) && !haskey(ctx.arg_types, arg_idx)
+        if isempty(path) && !is_destructured_arg(ctx, arg_idx)
             # Regular (non-destructured) argument - create concrete CGVal
             if length(values) != 1
                 throw(IRError("Expected exactly one value for argument $arg_idx, got $(length(values))"))
@@ -146,7 +157,8 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
     end
 
     # For destructured args, create lazy CGVals that track the argument index
-    for (arg_idx, argtype) in ctx.arg_types
+    for (arg_idx, argtype) in enumerate(ctx.arg_types)
+        argtype === nothing && continue
         tv = arg_ref_value(arg_idx, Int[], argtype)
         ctx[SlotNumber(arg_idx)] = tv
         ctx[Argument(arg_idx)] = tv
@@ -311,6 +323,20 @@ function emit_subprogram!(ctx::CGCtx, func, arg_types::Vector,
                       ctx.type_cache, ctx.sm_arch,
                       ctx.cache)
     append!(sub_ctx.fpmode_stack, ctx.fpmode_stack)
+
+    # Inherit kernel-state flat values from the parent. Subprograms compile
+    # inline as nested regions, so the parent's SSA `Value`s for the state
+    # fields remain in scope; copying them into `sub_ctx.arg_flat_values` makes
+    # `kernel_state()` resolve identically inside subprograms (e.g. reduce
+    # combiners, broadcast bodies) as in the entry kernel. Each ctx uses its
+    # own trailing arg_idx (`length(sci.argtypes) + 1`), so we re-key on the
+    # way in.
+    parent_state_idx = length(ctx.sci.argtypes) + 1
+    sub_state_idx    = length(sci.argtypes) + 1
+    sub_ctx.arg_types[sub_state_idx] = KernelState
+    for (k, v) in ctx.arg_flat_values
+        k[1] == parent_state_idx && (sub_ctx.arg_flat_values[(sub_state_idx, k[2])] = v)
+    end
 
     # 4. Map arguments dynamically: ghost args get ghost_value, non-ghost args
     #    consume block_args sequentially.

--- a/src/compiler/intrinsics.jl
+++ b/src/compiler/intrinsics.jl
@@ -91,5 +91,6 @@ include("intrinsics/atomics.jl")
 include("intrinsics/views.jl")
 include("intrinsics/misc.jl")
 include("intrinsics/fpmode.jl")
+include("intrinsics/kernel_state.jl")
 
 include("intrinsics/julia.jl")

--- a/src/compiler/intrinsics/kernel_state.jl
+++ b/src/compiler/intrinsics/kernel_state.jl
@@ -1,0 +1,23 @@
+# KernelState intrinsic
+#
+# `kernel_state()` returns the host-supplied `KernelState` struct that
+# `emit_kernel!` registers at the trailing codegen arg_idx
+# (`length(sci.argtypes) + 1`) — its primitive fields are destructured into
+# the trailing kernel parameters. The intrinsic resolves to a lazy arg-ref
+# pointing at that virtual destructured arg; `getfield(:field)` then flows
+# through the standard destructured-arg path, so no per-field emit plumbing
+# is needed.
+#
+# This works because every cuTile-emitted Tile IR function is an entry kernel
+# and subprograms compile inline as nested regions (outer SSA is in scope);
+# `emit_subprogram!` re-keys the parent's state flat values into the sub-ctx's
+# own trailing slot. If we ever add non-entry callable subroutines, they would
+# need GPUCompiler-style state threading via a leading parameter on every
+# reachable function instead.
+
+@intrinsic kernel_state()
+tfunc(𝕃, ::typeof(Intrinsics.kernel_state)) = KernelState
+efunc(::typeof(Intrinsics.kernel_state), effects::CC.Effects) =
+    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.kernel_state), args) =
+    arg_ref_value(length(ctx.sci.argtypes) + 1, Int[], KernelState)

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -263,7 +263,10 @@ mutable struct CGCtx
     # Destructured argument handling: path-keyed flat values
     # Key: (arg_idx, path) where path is e.g. [1] or [1, 2] (field indices)
     arg_flat_values::Dict{Tuple{Int, Vector{Int}}, Vector{Value}}
-    arg_types::Dict{Int, Type}
+    # 1-indexed by arg_idx, sized `length(sci.argtypes) + 1`. Slots 1..N
+    # mirror Julia args (entry = type for destructured struct args, `nothing`
+    # otherwise). Slot N+1 is reserved for the implicit `KernelState`.
+    arg_types::Vector{Union{Type, Nothing}}
 
     # Bytecode infrastructure
     cb::CodeBuilder
@@ -313,7 +316,7 @@ function CGCtx(; cb::CodeBuilder, tt::TypeTable, sci::StructuredIRCode,
         Dict{Int, CGVal}(),
         Dict{Int, CGVal}(),
         Dict{Tuple{Int, Vector{Int}}, Vector{Value}}(),
-        Dict{Int, Type}(),
+        Vector{Union{Type, Nothing}}(nothing, length(sci.argtypes) + 1),
         cb,
         tt,
         sci,
@@ -465,14 +468,14 @@ end
 
 Check if an argument was destructured into multiple flat parameters.
 """
-is_destructured_arg(ctx::CGCtx, arg_idx::Int) = haskey(ctx.arg_types, arg_idx)
+is_destructured_arg(ctx::CGCtx, arg_idx::Int) = ctx.arg_types[arg_idx] !== nothing
 
 """
     get_arg_type(ctx, arg_idx) -> Union{Type, Nothing}
 
 Get the original Julia type for a destructured argument.
 """
-get_arg_type(ctx::CGCtx, arg_idx::Int) = get(ctx.arg_types, arg_idx, nothing)
+get_arg_type(ctx::CGCtx, arg_idx::Int) = ctx.arg_types[arg_idx]
 
 
 #=============================================================================

--- a/src/cuTile.jl
+++ b/src/cuTile.jl
@@ -33,6 +33,7 @@ include("bytecode/encodings.jl")
 
 # Language definitions
 include("language/types.jl")
+include("language/kernel_state.jl")
 
 # Compiler implementation
 include("compiler/interpreter.jl")

--- a/src/language/kernel_state.jl
+++ b/src/language/kernel_state.jl
@@ -1,0 +1,16 @@
+# KernelState — per-launch ambient state implicitly threaded into every kernel
+#
+# A small struct that the host appends to every `cuTile.launch`. Its primitive
+# fields are destructured into trailing kernel parameters; inside the kernel,
+# the IR retrieves the value via the `kernel_state()` intrinsic, which resolves
+# to a lazy arg-ref into the destructured arg — `state.field` accesses flow
+# through the standard `getfield` path with no extra emit plumbing.
+#
+# `KernelState` is currently empty (a ghost type), so it adds zero kernel
+# parameters and zero per-launch overhead. The plumbing is wired so that
+# adding fields later (e.g. for a host-supplied RNG seed) requires no
+# additional codegen, host, or subprogram changes — just a field declaration.
+
+# Internal — not in `public`.
+struct KernelState
+end

--- a/test/codegen/kernel_state.jl
+++ b/test/codegen/kernel_state.jl
@@ -1,0 +1,25 @@
+# `Intrinsics.kernel_state()` plumbing tests
+#
+# `KernelState` is currently empty (a ghost), so the intrinsic is a no-op at
+# the IR level — `flatten_struct_params!` adds zero kernel params and the
+# returned ghost value is DCE'd. These tests verify the wiring tolerates the
+# empty case so that adding a field later (e.g. an RNG seed) needs no codegen
+# changes — just a struct field declaration.
+
+@testset "kernel_state()" begin
+    spec1d = ct.ArraySpec{1}(16, true)
+
+    @testset "ghost state adds no kernel params" begin
+        @test @filecheck begin
+            # `TileArray{Int32,1}` flattens to (ptr, size, stride) → 3 params.
+            # KernelState is ghost so no trailing param is appended.
+            @check "(%arg0: tile<ptr<i32>>, %arg1: tile<i32>, %arg2: tile<i32>)"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+                pid = ct.bid(1)
+                Base.donotdelete(ct.Intrinsics.kernel_state())
+                a[pid] = pid
+                return
+            end
+        end
+    end
+end


### PR DESCRIPTION
Introduce a `KernelState` struct that the host appends to every `cuTile.launch`. Its primitive fields are destructured into trailing kernel parameters; inside the kernel, the IR retrieves the value via a new `kernel_state()` intrinsic that resolves to a lazy arg-ref into the implicit destructured arg, so `state.field` accesses flow through the standard `getfield` path with no extra emit plumbing.

`emit_kernel!` registers `KernelState` at `length(sci.argtypes) + 1` and runs `flatten_struct_params!` after the user args, so the bytecode ABI ends with the state's flat params. `emit_subprogram!` re-keys the parent's state flat values into the sub-ctx's own trailing slot, so `kernel_state()` resolves identically inside subprograms (reduce combiners, broadcast bodies, etc.) — outer SSA stays in scope because subprograms compile inline as nested regions.

`KernelState` is currently empty (a ghost), so `flatten(state)` adds zero kernel args and the entire mechanism is zero-cost. The plumbing is wired so adding fields later (e.g. for a host-supplied RNG seed) needs no codegen, host, or subprogram changes — just a struct field.

Switches `CGCtx.arg_types` from `Dict{Int, Type}` to `Vector{Union{Type, Nothing}}` sized at construction, since arg_idx is now a dense `1..length(sci.argtypes) + 1` (user args 1..N, implicit state at N+1).

Split off from https://github.com/JuliaGPU/cuTile.jl/pull/193
Based on CUDA.jl