### PR TITLE
Cache ConstantOp emissions in CGCtx.

### DIFF
--- a/src/compiler/codegen/control_flow.jl
+++ b/src/compiler/codegen/control_flow.jl
@@ -40,6 +40,20 @@ emit_control_flow_op!(ctx::CGCtx, op::ForOp, @nospecialize(rt), idx::Int) = emit
 emit_control_flow_op!(ctx::CGCtx, op::WhileOp, @nospecialize(rt), idx::Int) = emit_while_op!(ctx, op, rt, idx)
 emit_control_flow_op!(ctx::CGCtx, op::LoopOp, @nospecialize(rt), idx::Int) = emit_loop_op!(ctx, op, rt, idx)
 
+# Run `f` with the constant_cache scoped to a nested region: entries added
+# inside `f` are dropped on exit. `with_region` rewinds `next_value_id` when
+# a region closes, so any Value created inside is ephemeral and must not be
+# reachable from the parent's cache.
+function with_region_constant_scope!(f, ctx::CGCtx)
+    saved = copy(ctx.constant_cache)
+    try
+        f()
+    finally
+        empty!(ctx.constant_cache)
+        merge!(ctx.constant_cache, saved)
+    end
+end
+
 #=============================================================================
  IfOp
 =============================================================================#
@@ -65,16 +79,20 @@ function emit_if_op!(ctx::CGCtx, op::IfOp, @nospecialize(parent_result_type), ss
     end
 
     then_body = function(_)
-        saved = copy(ctx.block_args)
-        emit_block!(ctx, op.then_region)
-        terminator(op.then_region) === nothing && encode_YieldOp!(ctx.cb, Value[])
-        empty!(ctx.block_args); merge!(ctx.block_args, saved)
+        with_region_constant_scope!(ctx) do
+            saved = copy(ctx.block_args)
+            emit_block!(ctx, op.then_region)
+            terminator(op.then_region) === nothing && encode_YieldOp!(ctx.cb, Value[])
+            empty!(ctx.block_args); merge!(ctx.block_args, saved)
+        end
     end
     else_body = function(_)
-        saved = copy(ctx.block_args)
-        emit_block!(ctx, op.else_region)
-        terminator(op.else_region) === nothing && encode_YieldOp!(ctx.cb, Value[])
-        empty!(ctx.block_args); merge!(ctx.block_args, saved)
+        with_region_constant_scope!(ctx) do
+            saved = copy(ctx.block_args)
+            emit_block!(ctx, op.else_region)
+            terminator(op.else_region) === nothing && encode_YieldOp!(ctx.cb, Value[])
+            empty!(ctx.block_args); merge!(ctx.block_args, saved)
+        end
     end
     results = encode_IfOp!(then_body, else_body, cb, result_types, cond_tv.v)
 
@@ -115,22 +133,24 @@ function emit_for_op!(ctx::CGCtx, op::ForOp, @nospecialize(parent_result_type), 
     result_types = TypeId[tile_type_for_julia!(ctx, arg.type) for arg in body_blk.args]
 
     body_builder = function(block_args)
-        saved = copy(ctx.block_args)
+        with_region_constant_scope!(ctx) do
+            saved = copy(ctx.block_args)
 
-        # Tile IR block args layout: [iv, carries...]
-        # (carries include both user values and token carries added by token_order_pass!)
-        ctx[iv_arg] = CGVal(block_args[1], iv_type, iv_jl_type)
-        for i in 1:n_carries
-            arg = body_blk.args[i]
-            shape = RowMajorShape(extract_tile_shape(arg.type))
-            ctx[arg] = CGVal(block_args[i + 1], result_types[i], arg.type, shape)
+            # Tile IR block args layout: [iv, carries...]
+            # (carries include both user values and token carries added by token_order_pass!)
+            ctx[iv_arg] = CGVal(block_args[1], iv_type, iv_jl_type)
+            for i in 1:n_carries
+                arg = body_blk.args[i]
+                shape = RowMajorShape(extract_tile_shape(arg.type))
+                ctx[arg] = CGVal(block_args[i + 1], result_types[i], arg.type, shape)
+            end
+            emit_block!(ctx, body_blk)
+            # If body has no terminator, emit a ContinueOp with all carried values
+            if terminator(body_blk) === nothing
+                encode_ContinueOp!(ctx.cb, block_args[2:end])
+            end
+            empty!(ctx.block_args); merge!(ctx.block_args, saved)
         end
-        emit_block!(ctx, body_blk)
-        # If body has no terminator, emit a ContinueOp with all carried values
-        if terminator(body_blk) === nothing
-            encode_ContinueOp!(ctx.cb, block_args[2:end])
-        end
-        empty!(ctx.block_args); merge!(ctx.block_args, saved)
     end
     results = encode_ForOp!(body_builder, cb, result_types, iv_type,
                              lower_tv.v, upper_tv.v, step_tv.v, init_values)
@@ -157,23 +177,25 @@ function emit_loop_op!(ctx::CGCtx, op::LoopOp, @nospecialize(parent_result_type)
     result_types = TypeId[tile_type_for_julia!(ctx, arg.type) for arg in body_blk.args]
 
     body_builder = function(block_args)
-        saved = copy(ctx.block_args)
+        with_region_constant_scope!(ctx) do
+            saved = copy(ctx.block_args)
 
-        # Tile IR block args layout: [carries...]
-        # (includes both user values and token carries added by token_order_pass!)
-        for i in 1:n_carries
-            arg = body_blk.args[i]
-            shape = RowMajorShape(extract_tile_shape(arg.type))
-            ctx[arg] = CGVal(block_args[i], result_types[i], arg.type, shape)
+            # Tile IR block args layout: [carries...]
+            # (includes both user values and token carries added by token_order_pass!)
+            for i in 1:n_carries
+                arg = body_blk.args[i]
+                shape = RowMajorShape(extract_tile_shape(arg.type))
+                ctx[arg] = CGVal(block_args[i], result_types[i], arg.type, shape)
+            end
+            emit_block!(ctx, body_blk)
+            # In Tile IR, if the loop body ends with an IfOp (even one with continue/break
+            # in all branches), the if is NOT a terminator. We need an explicit terminator
+            # after the if. Add an unreachable ContinueOp as fallback terminator.
+            if terminator(body_blk) === nothing
+                encode_ContinueOp!(ctx.cb, copy(block_args))
+            end
+            empty!(ctx.block_args); merge!(ctx.block_args, saved)
         end
-        emit_block!(ctx, body_blk)
-        # In Tile IR, if the loop body ends with an IfOp (even one with continue/break
-        # in all branches), the if is NOT a terminator. We need an explicit terminator
-        # after the if. Add an unreachable ContinueOp as fallback terminator.
-        if terminator(body_blk) === nothing
-            encode_ContinueOp!(ctx.cb, copy(block_args))
-        end
-        empty!(ctx.block_args); merge!(ctx.block_args, saved)
     end
     results = encode_LoopOp!(body_builder, cb, result_types, init_values)
 
@@ -205,6 +227,7 @@ function emit_while_op!(ctx::CGCtx, op::WhileOp, @nospecialize(parent_result_typ
     result_types = TypeId[tile_type_for_julia!(ctx, arg.type) for arg in before_blk.args]
 
     body_builder = function(block_args)
+        with_region_constant_scope!(ctx) do
         saved = copy(ctx.block_args)
 
         # Tile IR block args layout: [carries...]
@@ -229,22 +252,24 @@ function emit_while_op!(ctx::CGCtx, op::WhileOp, @nospecialize(parent_result_typ
         # This keeps nested loops in "after" at LoopOp body level
         then_body = (_) -> encode_YieldOp!(ctx.cb, Value[])
         else_body = function(_)
-            # Break with ConditionOp args (become loop results)
-            break_operands = Value[]
-            for arg in operands(cond_op)
-                tv = emit_value!(ctx, arg)
-                tv !== nothing && tv.v !== nothing && push!(break_operands, tv.v)
-            end
-            if isempty(break_operands)
-                append!(break_operands, block_args[1:n_carries])
-            else
-                # Append token carries (block_args beyond user carries from ConditionOp)
-                n_user = length(break_operands)
-                for i in (n_user + 1):n_carries
-                    push!(break_operands, block_args[i])
+            with_region_constant_scope!(ctx) do
+                # Break with ConditionOp args (become loop results)
+                break_operands = Value[]
+                for arg in operands(cond_op)
+                    tv = emit_value!(ctx, arg)
+                    tv !== nothing && tv.v !== nothing && push!(break_operands, tv.v)
                 end
+                if isempty(break_operands)
+                    append!(break_operands, block_args[1:n_carries])
+                else
+                    # Append token carries (block_args beyond user carries from ConditionOp)
+                    n_user = length(break_operands)
+                    for i in (n_user + 1):n_carries
+                        push!(break_operands, block_args[i])
+                    end
+                end
+                encode_BreakOp!(ctx.cb, break_operands)
             end
-            encode_BreakOp!(ctx.cb, break_operands)
         end
         encode_IfOp!(then_body, else_body, cb, TypeId[], cond_tv.v)
 
@@ -287,6 +312,7 @@ function emit_while_op!(ctx::CGCtx, op::WhileOp, @nospecialize(parent_result_typ
         encode_ContinueOp!(ctx.cb, continue_operands)
 
         empty!(ctx.block_args); merge!(ctx.block_args, saved)
+        end  # with_region_constant_scope!
     end
     results = encode_LoopOp!(body_builder, cb, result_types, init_values)
 

--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -145,7 +145,7 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
             if type_id !== nothing
                 # Primitive: emit ConstantOp (jltype promoted to 0D tile)
                 bytes = constant_to_bytes(val, T)
-                v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+                v = get_or_emit_constant!(ctx, type_id, bytes)
                 tv = CGVal(v, type_id, Tile{T, Tuple{}}, RowMajorShape(()), nothing, Some(val), nothing)
             else
                 # Non-primitive (tuple etc.): ghost with constant

--- a/src/compiler/codegen/values.jl
+++ b/src/compiler/codegen/values.jl
@@ -18,7 +18,7 @@ function emit_value!(ctx::CGCtx, val::Integer)
     jltype = typeof(val)
     type_id = tile_type_for_julia!(ctx, jltype)
     bytes = constant_to_bytes(val, jltype)
-    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+    v = get_or_emit_constant!(ctx, type_id, bytes)
     CGVal(v, type_id, Tile{jltype, Tuple{}}, RowMajorShape(()), nothing, Some(val), nothing)
 end
 
@@ -26,7 +26,7 @@ function emit_value!(ctx::CGCtx, val::AbstractFloat)
     jltype = typeof(val)
     type_id = tile_type_for_julia!(ctx, jltype)
     bytes = constant_to_bytes(val, jltype)
-    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+    v = get_or_emit_constant!(ctx, type_id, bytes)
     CGVal(v, type_id, Tile{jltype, Tuple{}}, RowMajorShape(()), nothing, Some(val), nothing)
 end
 
@@ -66,7 +66,7 @@ function emit_value!(ctx::CGCtx, ref::GlobalRef)
         type_id = tile_type_for_julia!(ctx, T; throw_error=false)
         if type_id !== nothing
             bytes = constant_to_bytes(val, T)
-            v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+            v = get_or_emit_constant!(ctx, type_id, bytes)
             return CGVal(v, type_id, boundary_jltype(T), RowMajorShape(()), nothing, Some(val), nothing)
         end
     end
@@ -135,7 +135,7 @@ function emit_value!(ctx::CGCtx, undef::Undef)
     type_id = tile_type_for_julia!(ctx, T)
     elem_type = T <: Tile ? eltype(T) : T
     bytes = constant_to_bytes(zero(elem_type), elem_type)
-    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+    v = get_or_emit_constant!(ctx, type_id, bytes)
     CGVal(v, type_id, T)
 end
 
@@ -171,7 +171,7 @@ function emit_constant!(ctx::CGCtx, @nospecialize(value), @nospecialize(result_t
 
     type_id = tile_type_for_julia!(ctx, result_type_unwrapped)
     bytes = constant_to_bytes(value, elem_type)
-    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+    v = get_or_emit_constant!(ctx, type_id, bytes)
 
     CGVal(v, type_id, result_type_unwrapped)
 end

--- a/src/compiler/intrinsics/core.jl
+++ b/src/compiler/intrinsics/core.jl
@@ -243,7 +243,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.constant), args)
     if tv.constant !== nothing
         # Compile-time constant: use ConstantOp directly
         value_bytes = constant_to_bytes(something(tv.constant), elem_type)
-        result = encode_ConstantOp!(cb, tile_type, value_bytes)
+        result = get_or_emit_constant!(ctx, tile_type, value_bytes)
     else
         # Runtime value: broadcast 0D tile to the target shape
         result = broadcast_tile_to_shape!(cb, tt, tv, tile_shape, dtype)
@@ -301,7 +301,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.extract), args)
     index_vals = Value[]
     for idx in reverse(index_tuple)
         idx_bytes = collect(reinterpret(UInt8, [Int32(idx)]))
-        idx_val = encode_ConstantOp!(cb, scalar_i32, idx_bytes)
+        idx_val = get_or_emit_constant!(ctx, scalar_i32, idx_bytes)
         push!(index_vals, idx_val)
     end
 

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -137,7 +137,7 @@ end
 function pad_indices(ctx::CGCtx, index_vals::Vector{Value}, ndim::Int, idx_type::TypeId, idx_jl_type::Type)
     while length(index_vals) < ndim
         idx_bytes = reinterpret(UInt8, [eltype(idx_jl_type)(0)])
-        push!(index_vals, encode_ConstantOp!(ctx.cb, idx_type, collect(idx_bytes)))
+        push!(index_vals, get_or_emit_constant!(ctx, idx_type, collect(idx_bytes)))
     end
     return index_vals
 end

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -287,6 +287,14 @@ mutable struct CGCtx
     # Type cache: Julia type -> TypeId
     type_cache::Dict{Type, TypeId}
 
+    # ConstantOp cache: (TypeId, value bytes) -> Value. The bytecode encoder
+    # otherwise emits a fresh ConstantOp for every literal use, even when the
+    # same (type, value) was already materialised. The translator's bytecode
+    # optimiser CSEs them anyway, but the duplication still bloats the
+    # bytecode payload and the type table. Bytecode-level analogue of LLVM
+    # IRBuilder's constant cache.
+    constant_cache::Dict{Tuple{TypeId, Vector{UInt8}}, Value}
+
     # Target architecture (e.g., v"10.0" for sm_100)
     sm_arch::Union{VersionNumber, Nothing}
 
@@ -324,6 +332,7 @@ function CGCtx(; cb::CodeBuilder, tt::TypeTable, sci::StructuredIRCode,
         Dict{Int, Value}(),              # result_tokens
         0,                               # current_ssa_idx
         type_cache,
+        Dict{Tuple{TypeId, Vector{UInt8}}, Value}(),  # constant_cache
         sm_arch,
         cache,
         FPMode[],                        # fpmode_stack
@@ -554,6 +563,23 @@ function require_concrete_type(@nospecialize(T), context::String)
         throw(IRError("Type must be fully concrete in $context, got partial type: $T"))
     end
     return T_unwrapped
+end
+
+"""
+    get_or_emit_constant!(ctx, type_id, bytes) -> Value
+
+Return the cached `Value` for `(type_id, bytes)` if one was already emitted in
+this kernel; otherwise emit a `ConstantOp` and cache it. The cache key uses
+`bytes` by content, so distinct `Vector{UInt8}` instances with identical
+contents share a slot.
+"""
+function get_or_emit_constant!(ctx::CGCtx, type_id::TypeId, bytes::Vector{UInt8})
+    key = (type_id, bytes)
+    cached = get(ctx.constant_cache, key, nothing)
+    cached !== nothing && return cached
+    v = encode_ConstantOp!(ctx.cb, type_id, bytes)
+    ctx.constant_cache[key] = v
+    return v
 end
 
 """


### PR DESCRIPTION
The bytecode encoder previously emitted a fresh ConstantOp for every literal, even when the same (type, bytes) was already materialised in the kernel. The translator CSEs them in its bytecode optimiser, but the duplication still bloats the bytecode payload and type table.

Add a per-CGCtx (TypeId, Vector{UInt8}) -> Value cache, populated by the new get_or_emit_constant! helper that wraps encode_ConstantOp!. The cache is region-scoped via with_region_constant_scope! around If/For/Loop/While body callbacks: with_region rewinds next_value_id on exit, so any Value created inside is ephemeral and must not be reachable from the parent's cache.

Not convinced we want this. It does make the generated bitcode a bit cleaner, but doesn't have a performance impact.