### PR TITLE
Lazily materialize ConstantOps for Constant-seeded arguments.

### DIFF
--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -134,7 +134,12 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
         end
     end
 
-    # Emit ConstantOps for const-seeded arguments (no kernel parameter)
+    # Register const-seeded arguments (no kernel parameter). Primitive constants
+    # are stored *lazily* — `v` stays `nothing` and only materializes into a
+    # ConstantOp on first access via `ctx[Argument(i)]`/`ctx[SlotNumber(i)]`.
+    # If Julia's inference folded the value into the body (the usual case),
+    # nothing references the argument and no ConstantOp is ever emitted.
+    # Mirrors `mark_julia_const` in Julia's codegen.cpp.
     if const_argtypes !== nothing
         for (i, cat) in enumerate(const_argtypes)
             cat isa CC.Const || continue
@@ -143,10 +148,9 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
             T = typeof(val)
             type_id = tile_type_for_julia!(ctx, T; throw_error=false)
             if type_id !== nothing
-                # Primitive: emit ConstantOp (jltype promoted to 0D tile)
-                bytes = constant_to_bytes(val, T)
-                v = encode_ConstantOp!(ctx.cb, type_id, bytes)
-                tv = CGVal(v, type_id, Tile{T, Tuple{}}, RowMajorShape(()), nothing, Some(val), nothing)
+                # Primitive: lazy const (jltype promoted to 0D tile)
+                tv = CGVal(nothing, type_id, Tile{T, Tuple{}}, RowMajorShape(()),
+                           nothing, Some(val), nothing)
             else
                 # Non-primitive (tuple etc.): ghost with constant
                 tv = ghost_value(T, val)

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -364,11 +364,44 @@ function Base.getindex(ctx::CGCtx, ssa::SSAValue)
 end
 
 function Base.getindex(ctx::CGCtx, arg::Argument)
-    get(ctx.args, arg.n, nothing)
+    tv = get(ctx.args, arg.n, nothing)
+    materialize_lazy_const!(ctx, tv, ctx.args, arg.n)
 end
 
 function Base.getindex(ctx::CGCtx, slot::SlotNumber)
-    get(ctx.slots, slot.id, nothing)
+    tv = get(ctx.slots, slot.id, nothing)
+    materialize_lazy_const!(ctx, tv, ctx.slots, slot.id)
+end
+
+# Lazy const materialization: a CGVal that records `constant=Some(val)` but no
+# `Value` defers the ConstantOp emission until first lookup. Mirrors Julia's
+# `mark_julia_const` (codegen.cpp:2390): the cgval carries the value but only
+# materializes an LLVM constant when a downstream consumer reads `.v`. If the
+# argument was fully constant-folded by inference and never looked up, no op
+# is emitted at all.
+@inline function materialize_lazy_const!(ctx::CGCtx, tv::Union{CGVal, Nothing},
+                                          slot::Dict{Int, CGVal}, key::Int)
+    tv === nothing && return nothing
+    is_lazy_const(tv) || return tv
+    val = something(tv.constant)
+    elem_type = tv.jltype <: Tile ? eltype(tv.jltype) : tv.jltype
+    bytes = constant_to_bytes(val, elem_type)
+    v = encode_ConstantOp!(ctx.cb, tv.type_id::TypeId, bytes)
+    new_tv = CGVal(v, tv.type_id, tv.jltype, tv.shape, tv.arg_ref, tv.constant, tv.tuple)
+    slot[key] = new_tv
+    return new_tv
+end
+
+# A CGVal is a "lazy const" when it carries a compile-time constant whose
+# ConstantOp hasn't been emitted yet: no `Value`, no destructured arg ref, no
+# multi-value extraction, but a real (non-ghost) Tile IR type and a stashed
+# `constant`. Ghosts (`type_id == TypeId(-1)`) and arg_refs stay lazy forever.
+@inline function is_lazy_const(tv::CGVal)
+    tv.v === nothing &&
+        tv.constant !== nothing &&
+        tv.arg_ref === nothing &&
+        tv.type_id !== nothing &&
+        tv.type_id != TypeId(-1)
 end
 
 function Base.setindex!(ctx::CGCtx, tv::CGVal, ssa::SSAValue)


### PR DESCRIPTION
Previously `emit_kernel!` eagerly emitted a ConstantOp for every `Constant{T,V}` argument and cached the SSA in the slot/argument maps. In practice Julia's inference folds those values into the body, so the body never references `Argument(i)` and the eagerly-emitted ConstantOps end up orphaned in the bytecode (10 unreferenced i64 constants at the top of the FFT kernel, etc.).

Switch to lazy materialization: store a CGVal with `v=nothing` and `constant=Some(val)`. When `ctx[Argument(i)]` / `ctx[SlotNumber(i)]` is first looked up, encode the ConstantOp on demand and replace the slot entry. If nothing ever looks up the argument, no op is emitted. Mirrors `mark_julia_const` in Julia.

Not convinced we want this. It does make the generated Tile IR a bit cleaner, but doesn't have a performance impact.