### PR TITLE
Fix UndefVarError in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ in a future release of CUDA.
 A simple vector addition kernel using cuTile looks like this:
 
 ```julia
-using CUDA
-using cuTile
+using CUDA, cuTile
 import cuTile as ct
 
 # Define kernel

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple vector addition kernel using cuTile looks like this:
 
 ```julia
 using CUDA
-import cuTile as ct
+using cuTile: cuTile, cuTile as ct
 
 # Define kernel
 function vadd(a, b, c, tile_size::Int)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ A simple vector addition kernel using cuTile looks like this:
 
 ```julia
 using CUDA
-using cuTile: cuTile, cuTile as ct
+using cuTile
+import cuTile as ct
 
 # Define kernel
 function vadd(a, b, c, tile_size::Int)


### PR DESCRIPTION
Fixes "UndefVarError: `cuTile` not defined in `Main`". Could also do `backend=ct`, but `backend=cuTile` is clearer.