### PR TITLE
Suppress divby assume on tile-of-pointers from offset.

### DIFF
--- a/src/compiler/analysis/divisibility.jl
+++ b/src/compiler/analysis/divisibility.jl
@@ -90,12 +90,26 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
     # The base may be either `Tile{Ptr{T}, ()}` (post-canonicalize tile form)
     # or raw `Ptr{T}` (the SCI annotation on `getfield(arg, :ptr)`); both
     # lower to a 0-D pointer Value at codegen.
+    #
+    # Only propagate alignment when the result is a 0-D pointer (Array.slice
+    # style). For tiles of pointers (the gather/scatter `broadcast(base) +
+    # offsets` chain), return 1 — tileiras's vectorizer walks the offset SSA
+    # itself, and a redundant `assume div_by<elem_bytes>` (the natural
+    # alignment of the pointee) defeats coalescing into wide stores.
+    # Mirrors cuTile Python's `PointerOffset` rule in
+    # `_passes/dataflow_analysis.py`.
     if func === Intrinsics.offset
         length(ops) >= 2 || return 1
         base_T = value_type(block, ops[1])
         base_T = base_T === nothing ? Any : CC.widenconst(base_T)
         elem_T = ptr_pointee(base_T)
         elem_T === nothing && return 1
+        # Result shape mirrors the offsets shape (base is 0-D by ptr_pointee
+        # above). Bail out for tile-shaped offsets — the result is a tile of
+        # pointers and divby of those is tileiras's job, not ours.
+        off_T = value_type(block, ops[2])
+        off_T = off_T === nothing ? Any : CC.widenconst(off_T)
+        is_scalar_tile_shape(off_T) || return 1
         elem_bytes = sizeof(elem_T)
         ptr_div = operand_value(a, r, ops[1])
         off_div = operand_value(a, r, ops[2])
@@ -196,6 +210,16 @@ function ptr_pointee(@nospecialize(T))
         return eltype(T)
     end
     return nothing
+end
+
+# Whether `T` represents a scalar value — either a non-`Tile` type or a `Tile`
+# with all dims `== 1` (mirrors Python's `all(x == 1 for x in shape)`, which
+# treats `()` and `(1,1,...)` interchangeably).
+function is_scalar_tile_shape(@nospecialize(T))
+    T <: Tile || return true
+    shape_T = T.parameters[2]
+    shape_T isa DataType || return false
+    return all(s -> s isa Integer && s == 1, shape_T.parameters)
 end
 
 #=============================================================================

--- a/test/codegen/assume.jl
+++ b/test/codegen/assume.jl
@@ -159,11 +159,13 @@ end
 @testset "assume — kernel-arg ptr wrap survives offset for gather/scatter" begin
     # Pure-gather/scatter kernel: no MTV consumes the kernel-arg ptr, so
     # the only path that can attach `spec.alignment` to the base pointer
-    # is the kernel-arg-entry wrap (`apply_arg_assume_predicates!`). The
-    # post-offset ptr that reaches `load_ptr_tko` / `store_ptr_tko` then
-    # carries the base-alignment fact (via the assumed `Value` flowing
-    # through `reshape` → `broadcast` → `offset`) plus a tighter local
-    # divby chain wrapped at the consumer site.
+    # is the kernel-arg-entry wrap (`apply_arg_assume_predicates!`). That
+    # base-alignment fact still flows through `reshape` → `broadcast` →
+    # `offset` to the gather/scatter consumer, but we deliberately do NOT
+    # emit a per-element divby assume on the resulting tile-of-pointers:
+    # the natural pointee alignment is vacuous for tileiras and stamping
+    # it onto the IR defeats wide-store coalescing. Mirrors cuTile
+    # Python's `PointerOffset` rule.
     spec1d = ct.ArraySpec{1}(128, true)
     @test @filecheck begin
         @check_label "entry"
@@ -177,10 +179,11 @@ end
         # Base alignment on each kernel-arg ptr (entry wrap).
         @check "assume div_by<128>"
         @check "assume div_by<128>"
-        # Local divby chain on the post-offset ptr at each consumer.
-        @check "assume div_by<"
+        # No divby assume on the post-offset tile-of-pointers — tileiras
+        # walks the offset SSA itself.
+        @check_not "assume div_by"
         @check "load_ptr_tko"
-        @check "assume div_by<"
+        @check_not "assume div_by"
         @check "store_ptr_tko"
     end
 end
@@ -190,8 +193,8 @@ end
     # the same kernel-arg ptr. The entry wrap puts one `assume div_by<128>`
     # on it; the per-`Value` cache (`ctx.assume_wrapped`) ensures the
     # MTV consumer wraps don't re-emit the same predicate on the same
-    # source. The post-offset gather ptr is a different `Value` and
-    # gets its own (looser) divby chain.
+    # source. The post-offset gather ptr is a tile-of-pointers and the
+    # `PointerOffset` divby rule deliberately suppresses any assume there.
     spec1d = ct.ArraySpec{1}(128, true)
     @test @filecheck begin
         @check_label "entry"


### PR DESCRIPTION
For gather/scatter, `Intrinsics.offset(base_ptr, tile_offset)` produces a tile-of-pointers whose per-element divisor is `gcd(ptr_align, off_div * sizeof(elem))`. When that gcd collapses to the natural pointee alignment (e.g. 2 for f16), stamping it onto the IR as `assume div_by<2>` is vacuously true and actively harmful: tileiras's vectorizer trusts the explicit assume as the source of truth and skips its own offset-SSA walk, emitting `STG.E.U16` (2-byte stores) where the structurally-equivalent Python kernel gets `STG.E.128` (16-byte stores). 8x narrower stores, ~9x wall-time regression on the MoE scatter (121 GB/s vs Python's 1111 GB/s on the isolated MWE).

Fix the divby transfer for `Intrinsics.offset` to mirror cuTile Python's `PointerOffset` rule: only propagate alignment when the result is 0-D (`Array.slice` style); for tile-shaped offsets, return 1 and let tileiras handle vectorization. MoE bench: 1.27 ms -> 0.95 ms (now 25% faster than Python). Other benchmarks unchanged.