### PR TITLE
Handle Vararg tuple types in scalar elimination

### DIFF
--- a/src/compiler/transform/canonicalize.jl
+++ b/src/compiler/transform/canonicalize.jl
@@ -194,6 +194,7 @@ function promote_scalar_type(@nospecialize(T))
     T <: Number && return Tile{T, Tuple{}}
     if T <: Tuple
         params = T.parameters
+        any(P -> P isa Core.TypeofVararg, params) && return nothing
         any_promoted = false
         new_params = map(params) do P
             P = CC.widenconst(P)

--- a/src/compiler/transform/canonicalize.jl
+++ b/src/compiler/transform/canonicalize.jl
@@ -194,7 +194,7 @@ function promote_scalar_type(@nospecialize(T))
     T <: Number && return Tile{T, Tuple{}}
     if T <: Tuple
         params = T.parameters
-        any(P -> P isa Core.TypeofVararg, params) && return nothing
+        any(Base.isvarargtype, params) && return nothing
         any_promoted = false
         new_params = map(params) do P
             P = CC.widenconst(P)


### PR DESCRIPTION
Fixes the exact error in #225, but the new one is also not a very useful diagnostic. Is it the type of `tile` that becomes `Any`? How come it isn't `Tile{Float32}` or something?

```julia
using CUDACore; import cuTile as ct

function fill_normal!(A::ct.TileArray{Float32, 1}, n::Int)
    bid = ct.bid(1)
    tile = randn(Float32, (n,))
    ct.store(A; index=bid, tile=tile)
    return
end

@cuda backend=ct blocks=64 fill_normal!(CuArray{Float32}(undef, 65536), 1024)
```

```
ERROR: IRError: Unsupported Julia type for Tile IR: Any
Stacktrace:
  [1] tile_type_for_julia!(ctx::cuTile.CGCtx, T::Any; throw_error::Bool)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/utils.jl:600
  [2] tile_type_for_julia!
    @ ~/.julia/dev/cuTile/src/compiler/utils.jl:590 [inlined]
  [3] emit_if_op!(ctx::cuTile.CGCtx, op::IRStructurizer.IfOp, parent_result_type::Any, ssa_idx::Int64)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/codegen/control_flow.jl:70
  [4] emit_control_flow_op!(ctx::cuTile.CGCtx, op::IRStructurizer.IfOp, rt::Any, idx::Int64)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/codegen/control_flow.jl:48
  [5] emit_block!(ctx::cuTile.CGCtx, block::IRStructurizer.Block; skip_terminator::Bool)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/codegen/control_flow.jl:27
  [6] emit_block!
    @ ~/.julia/dev/cuTile/src/compiler/codegen/control_flow.jl:10 [inlined]
  [7] emit_kernel!(writer::cuTile.BytecodeWriter, func_buf::Vector{…}, sci::IRStructurizer.StructuredIRCode, rettype::Type; name::String, sm_arch::VersionNumber, is_entry::Bool, num_ctas::Nothing, occupancy::Nothing, cache::CompilerCaching.CacheView{…}, const_argtypes::Nothing)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/codegen/kernel.jl:188
  [8] emit_kernel!
    @ ~/.julia/dev/cuTile/src/compiler/codegen/kernel.jl:13 [inlined]
  [9] #95
    @ ~/.julia/dev/cuTile/src/compiler/driver.jl:174 [inlined]
 [10] write_bytecode!(f::cuTile.var"#95#96"{String, @NamedTuple{…}, CompilerCaching.CacheView{…}, Nothing, IRStructurizer.StructuredIRCode, Type{…}, Nothing, Nothing}, num_functions::Int64; version::VersionNumber)
    @ cuTile ~/.julia/dev/cuTile/src/bytecode/writer.jl:561
 [11] emit_tile(sci::IRStructurizer.StructuredIRCode, rettype::Type, kernel_meta::Dict{…}; name::String, opts::@NamedTuple{…}, cache::CompilerCaching.CacheView{…}, const_argtypes::Nothing)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/driver.jl:173
 [12] emit_tile!(cache::CompilerCaching.CacheView{cuTile.TileCacheKey, cuTile.CuTileResults}, mi::Core.MethodInstance, ci::Core.CodeInstance, res::cuTile.CuTileResults; const_argtypes::Nothing)
    @ cuTile ~/.julia/dev/cuTile/src/compiler/driver.jl:311
 [13] emit_tile!
    @ ~/.julia/dev/cuTile/src/compiler/driver.jl:294 [inlined]
 [14] emit_binary!(cache::CompilerCaching.CacheView{cuTile.TileCacheKey, cuTile.CuTileResults}, mi::Core.MethodInstance, ci::Core.CodeInstance, res::cuTile.CuTileResults; const_argtypes::Nothing)
    @ cuTile ~/.julia/dev/cuTile/src/launch.jl:392
 [15] emit_binary!
    @ ~/.julia/dev/cuTile/src/launch.jl:386 [inlined]
 [16] compile(f::Any, argtypes::Any, const_argtypes::Nothing, key::cuTile.TileCacheKey)
    @ cuTile ~/.julia/dev/cuTile/src/launch.jl:573
 [17] cufunction_compile(f::Any, tt::Any, argtypes::Any, const_argtypes::Nothing, key::cuTile.TileCacheKey)
    @ cuTile ~/.julia/dev/cuTile/src/launch.jl:583
 [18] #invoke_frozen#385
    @ ~/.julia/dev/cuTile/src/cuTile.jl:114 [inlined]
 [19] invoke_frozen
    @ ~/.julia/dev/cuTile/src/cuTile.jl:110 [inlined]
 [20] #cufunction#381
    @ ~/.julia/dev/cuTile/src/launch.jl:539 [inlined]
 [21] cufunction
    @ ~/.julia/dev/cuTile/src/launch.jl:518 [inlined]
 [22] kernel_compile(::cuTile.TileBackend, f::typeof(fill_normal!), tt::Type{Tuple{cuTile.TileArray{Float32, 1, cuTile.ArraySpec{1, 128, true, (0,), (16,)}()}, Int64}})
    @ cuTile ~/.julia/dev/cuTile/src/launch.jl:76
 [23] top-level scope
    @ ~/.julia/packages/CUDACore/sIGRL/src/compiler/execution.jl:182
Some type information was truncated. Use `show(err)` to see complete types.
```