### PR TITLE
Record line coverage during kernel codegen

### DIFF
--- a/src/compiler/codegen/expressions.jl
+++ b/src/compiler/codegen/expressions.jl
@@ -29,7 +29,7 @@ function emit_expr!(ctx::CGCtx, expr::Expr, @nospecialize(result_type))
         val = sptyp isa CC.Const ? sptyp.val : CC.widenconst(sptyp)
         return emit_value!(ctx, val)
     elseif expr.head === :code_coverage_effect
-        return nothing
+        return record_coverage!(ctx)
     else
         @warn "Unhandled expression head" expr.head expr
         return nothing
@@ -210,4 +210,18 @@ Get the Julia type of an IR value.
 function argextype(ctx::CGCtx, @nospecialize(x))
     tv = emit_value!(ctx, x)
     tv === nothing ? Any : CC.widenconst(tv.jltype)
+end
+
+function record_coverage!(ctx::CGCtx)
+    Base.JLOptions().code_coverage == 0 && return nothing
+    stack = source_location(ctx.sci, ctx.current_ssa_idx)
+    isempty(stack) && return nothing
+    loc = stack[end]                      # innermost (post-inlining) source line
+    line = Int(loc.line)
+    line > 0 || return nothing
+    file = string(loc.file)
+    isempty(file) && return nothing
+    ccall(:jl_coverage_visit_line, Cvoid, (Cstring, Csize_t, Cint),
+          file, ncodeunits(file), line)
+    return nothing
 end

--- a/test/codegen/coverage.jl
+++ b/test/codegen/coverage.jl
@@ -1,0 +1,51 @@
+@testset "device-code coverage" begin
+    @inline function cov_only_scale(a, b)
+        doubled = b * 2.0f0
+        return a + doubled
+    end
+
+    function cov_kernel(a, b, c)
+        pid = ct.bid(1)
+        ta = ct.load(a, (pid,), (16,))
+        tb = ct.load(b, (pid,), (16,))
+        ct.store(c, (pid,), cov_only_scale(ta, tb))
+        return
+    end
+
+    cov_spec = ct.ArraySpec{1}(16, true)
+    cov_tt = Tuple{ct.TileArray{Float32,1,cov_spec}, ct.TileArray{Float32,1,cov_spec},
+                ct.TileArray{Float32,1,cov_spec}}
+
+    # Whether any line in `lo:hi` of `file` has a nonzero execution count in an lcov
+    # tracefile.
+    function lcov_any_covered(tracefile, file, lo, hi)
+        in_block = false
+        for l in eachline(tracefile)
+            if startswith(l, "SF:")
+                in_block = (l == "SF:" * file)
+            elseif l == "end_of_record"
+                in_block = false
+            elseif in_block && startswith(l, "DA:")
+                ln, cnt = parse.(Int, split(l[4:end], ","))
+                lo <= ln <= hi && cnt >= 1 && return true
+            end
+        end
+        return false
+    end
+
+    if Base.JLOptions().code_coverage == 0
+        @test_skip "requires --code-coverage"
+    else
+        mktempdir() do dir
+            # Emit Tile IR only — drives codegen (and the coverage marking) without
+            # launching the kernel, so this needs no GPU execution of the body.
+            ct.code_tiled(devnull, cov_kernel, cov_tt)
+
+            # Flush coverage in-process and assert the device-only helper was marked.
+            tracefile = joinpath(dir, "coverage.info")
+            ccall(:jl_write_coverage_data, Cvoid, (Cstring,), tracefile)
+
+            @test lcov_any_covered(tracefile, @__FILE__, m.line, m.line + 4)
+        end
+    end
+end

--- a/test/codegen/coverage.jl
+++ b/test/codegen/coverage.jl
@@ -41,11 +41,15 @@
             # launching the kernel, so this needs no GPU execution of the body.
             ct.code_tiled(devnull, cov_kernel, cov_tt)
 
-            # Flush coverage in-process and assert the device-only helper was marked.
+            # Flush coverage in-process. Both the inlined device-only helper and the
+            # kernel entry must show covered lines, even though neither ran on the host.
             tracefile = joinpath(dir, "coverage.info")
             ccall(:jl_write_coverage_data, Cvoid, (Cstring,), tracefile)
 
-            @test lcov_any_covered(tracefile, @__FILE__, m.line, m.line + 4)
+            for f in (cov_only_scale, cov_kernel)
+                m = only(methods(f))
+                @test lcov_any_covered(tracefile, string(m.file), m.line, m.line + 4)
+            end
         end
     end
 end


### PR DESCRIPTION
I mainly want this for downstream packages, but we could now start tracking the coverage of cuTile.jl as well.