### PR TITLE
Make `Type` be seen as a ghost type

### DIFF
--- a/src/compiler/codegen/values.jl
+++ b/src/compiler/codegen/values.jl
@@ -86,6 +86,8 @@ end
 
 emit_value!(ctx::CGCtx, ::Nothing) = ghost_value(Nothing, nothing)
 
+type_singleton_value(@nospecialize(T)) = T.parameters[1]
+
 """
     get_constant(ctx, ref) -> Union{Some, Nothing}
 
@@ -114,6 +116,9 @@ function get_constant(ctx::CGCtx, @nospecialize(ref))
     end
     # Any ghost singleton can be reconstructed from its type
     T = CC.widenconst(tv.jltype)
+    # A concrete `Type{X}` kind (e.g. a `::Type{Float32}` field accessed via a
+    # lazy arg_ref) has no `.instance`; its sole inhabitant is `X` itself.
+    is_type_singleton(T) && return Some(type_singleton_value(T))
     is_ghost_type(T) && isdefined(T, :instance) && return Some(T.instance)
     return nothing
 end

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -665,12 +665,19 @@ end
  Struct destructuring helpers
 =============================================================================#
 
+is_type_singleton(@nospecialize(T)) =
+    isa(T, DataType) && T <: Type && length(T.parameters) == 1 &&
+    !(T.parameters[1] isa TypeVar)
+
 """
     is_ghost_type(T) -> Bool
 
-Check if a type is a ghost type (zero-size singleton).
+Check if a type is a ghost type (zero-size singleton). Includes concrete
+`Type{X}` kinds (see [`is_type_singleton`](@ref)), which carry compile-time
+type information but no runtime data.
 """
 function is_ghost_type(@nospecialize(T))
+    is_type_singleton(T) && return true
     try
         isbitstype(T) && sizeof(T) == 0
     catch

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -1382,6 +1382,26 @@ end
             code_tiled(_ghost_op_kernel, Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, typeof(+)})
         end
     end
+
+    @testset "Type{T} struct fields" begin
+        # `Type{T}` fields inside a struct argument are ghost types (no kernel
+        # parameter), just like `Val{N}` fields, and their value (the type `T`)
+        # must be resolvable in the kernel body.
+        struct TypeWrapper{T}
+            type::Type{T}
+        end
+        @test @filecheck begin
+            @check_label "entry"
+            @check "store_view_tko"
+            function _type_field_kernel(a, typewrapper)
+                pid = ct.bid(1)
+                ct.store(a, pid, zeros(typewrapper.type, (16,)))
+                return
+            end
+            code_tiled(_type_field_kernel,
+                       Tuple{ct.TileArray{Float32,1,spec}, TypeWrapper{Float32}})
+        end
+    end
 end
 
 #=============================================================================


### PR DESCRIPTION
See also #93, which was initially scoped to include this, but due to how `Constant` worked at the time, I needed a separation of concerns. I now think that `Type` fields would be nice for structs that encode types but don't necessarily need accessor functions that access type parameters.