### PR TITLE
Align with cuTile Python

### DIFF
--- a/src/bytecode/writer.jl
+++ b/src/bytecode/writer.jl
@@ -708,7 +708,10 @@ function format_sm_arch(cap::VersionNumber)
     "sm_$(cap.major)$(cap.minor)$(suffix)"
 end
 
-function make_load_store_hints(sm_arch::Union{VersionNumber, Nothing}, hints::LoadStoreHints)
+function make_load_store_hints(sm_arch::Union{VersionNumber, Nothing}, version::VersionNumber,
+                               hints::LoadStoreHints)
+    # v13.3+ keys hints under "default", applying them to every architecture
+    version >= v"13.3" && return OptimizationHints([("default", hints)])
     isnothing(sm_arch) && throw(ArgumentError("sm_arch must be explicitly passed when load/store hints are present"))
     OptimizationHints([(format_sm_arch(sm_arch), hints)])
 end
@@ -778,10 +781,15 @@ function encode_entry_hints(writer::BytecodeWriter, sm_arch::Union{VersionNumber
 
     # Always emit optimization hints when sm_arch is specified, even with an empty
     # dict. Python cuTile emits `optimization_hints=<sm_NNN = {}>` unconditionally
-    # so the CUBIN compiler knows the target architecture.
+    # so the CUBIN compiler knows the target architecture. On v13.3+ the hints
+    # are keyed under "default" instead, applying them to every architecture.
     sm_arch === nothing && isempty(items) && return nothing
-    arch_ver = @something sm_arch throw(ArgumentError("sm_arch must be specified when entry hints are present"))
-    arch = format_sm_arch(arch_ver)
+    arch = if writer.version >= v"13.3"
+        "default"
+    else
+        arch_ver = @something sm_arch throw(ArgumentError("sm_arch must be specified when entry hints are present"))
+        format_sm_arch(arch_ver)
+    end
 
     buf = UInt8[]
 

--- a/src/compiler/codegen/values.jl
+++ b/src/compiler/codegen/values.jl
@@ -102,6 +102,10 @@ function get_constant(ctx::CGCtx, @nospecialize(ref))
          ref isa Expr || ref isa GlobalRef || ref isa QuoteNode)
         return Some(ref)
     end
+    # QuoteNodes are compile-time constants by definition; unwrap directly
+    # rather than via emit_value!, which would emit a dead ConstantOp (or
+    # fail outright for non-Tile types like AssumePredicate).
+    ref isa QuoteNode && return Some(ref.value)
     # IR references - extract constant through emit_value!
     tv = emit_value!(ctx, ref)
     tv === nothing && return nothing

--- a/src/compiler/intrinsics.jl
+++ b/src/compiler/intrinsics.jl
@@ -68,7 +68,7 @@ function create_optimization_hints(ctx::CGCtx, latency::Union{Int, Nothing}, all
     isnothing(latency) && allow_tma && return nothing
     isnothing(latency) || 1 <= latency <= 10 || throw(ArgumentError("latency must be between 1 and 10, got $latency"))
     hints = LoadStoreHints(; latency, allow_tma)
-    return make_load_store_hints(ctx.sm_arch, hints)
+    return make_load_store_hints(ctx.sm_arch, ctx.cb.version, hints)
 end
 
 # Check if an intrinsic argument is a mask (Tile{Bool}) or nothing.

--- a/src/compiler/intrinsics/core.jl
+++ b/src/compiler/intrinsics/core.jl
@@ -289,6 +289,22 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.extract), args)
     validate_tile_shape(collect(Int, shape_tuple), "extract")
     output_shape = RowMajorShape(ColMajorShape(shape_tuple))
 
+    # Validate index and shape against the input tile (Julia order, 0-based index)
+    input_shape = Tuple(ColMajorShape(source.shape).dims)
+    length(shape_tuple) == length(input_shape) ||
+        throw(IRError("extract() shape has $(length(shape_tuple)) dimensions, but input tile has $(length(input_shape))"))
+    length(index_tuple) == length(input_shape) ||
+        throw(IRError("extract() index has $(length(index_tuple)) dimensions, but input tile has $(length(input_shape))"))
+    for (i, (s1, s2, idx)) in enumerate(zip(input_shape, shape_tuple, index_tuple))
+        s1 % s2 == 0 ||
+            throw(IRError("extract: input shape $input_shape is not divisible by extract shape $shape_tuple in dimension $i"))
+        n_slices = s1 ÷ s2
+        0 <= idx < n_slices ||
+            throw(IRError("extract: slice index $(idx + 1) out of bounds in dimension $i: " *
+                          "input shape $input_shape divides into $n_slices slices of shape $shape_tuple, " *
+                          "so valid indices are 1:$n_slices"))
+    end
+
     # Get element type
     elem_type = eltype(CC.widenconst(source.jltype))
 

--- a/src/compiler/intrinsics/misc.jl
+++ b/src/compiler/intrinsics/misc.jl
@@ -72,6 +72,8 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.assume), args)
     pred = pred_c.value
     pred isa AssumePredicate ||
         throw(IRError("assume: predicate must be an AssumePredicate, got $(typeof(pred))"))
+    pred isa DivBy && pred.divisor < 1 &&
+        throw(IRError("assume: DivBy requires a positive divisor, got $(pred.divisor)"))
     new_val = encode_AssumeOp!(ctx.cb, x.type_id, x.v, pred)
     return CGVal(new_val, x.type_id, x.jltype, x.shape)
 end

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -1608,6 +1608,33 @@ br = ct.extract(tile, (2, 2), (4, 4))  # Bottom-right (rows 5-8, cols 5-8)
     Intrinsics.extract(tile, map(i -> i - 1, Index), Shape)
 
 #=============================================================================
+ Assume
+=============================================================================#
+
+public assume_divisible_by
+
+"""
+    assume_divisible_by(x::Integer, divisor::Integer) -> typeof(x)
+
+Declare that `x` is divisible by `divisor`, a compiler hint that propagates
+through arithmetic and can e.g. prove alignment for derived indices and
+pointer offsets, enabling wider memory operations.
+
+The caller is responsible for the correctness of the claim; behavior is
+undefined if `x` is not actually divisible by `divisor` at runtime.
+
+`divisor` must be a positive integer constant.
+
+# Examples
+```julia
+n = ct.assume_divisible_by(n, 128)
+ptr_offset = base + n  # compiler knows this is 128-divisible
+```
+"""
+@inline assume_divisible_by(x::Integer, divisor::Integer) =
+    Intrinsics.assume(x, DivBy(Int(divisor)))
+
+#=============================================================================
  Assert
 =============================================================================#
 

--- a/test/codegen/assume.jl
+++ b/test/codegen/assume.jl
@@ -211,3 +211,27 @@ end
         @check_not "assume div_by<128>"
     end
 end
+
+@testset "assume — user assume_divisible_by" begin
+    spec1d = ct.ArraySpec{1}(16, true)
+    @test @filecheck begin
+        @check_label "entry"
+        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            n = ct.bid(1) * Int32(128)
+            n = ct.assume_divisible_by(n, 128)
+            @check "muli"
+            @check "assume div_by<128>"
+            ct.store(a, n, ct.load(a, n, (64,)))
+            return
+        end
+    end
+
+    # Non-positive divisor is rejected
+    @test_throws "assume: DivBy requires a positive divisor, got 0" begin
+        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            n = ct.assume_divisible_by(ct.bid(1), 0)
+            ct.store(a, n, ct.load(a, n, (64,)))
+            return
+        end
+    end
+end

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -963,7 +963,7 @@ end
 
     @testset "num_ctas only" begin
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {num_cta_in_cga = 4}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 4}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=4) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -975,7 +975,7 @@ end
 
     @testset "occupancy only" begin
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {occupancy = 8}>"
+            @check "optimization_hints=<default = {occupancy = 8}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=8) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -987,7 +987,7 @@ end
 
     @testset "both hints" begin
         @test @filecheck begin
-            @check "optimization_hints=<sm_120 = {num_cta_in_cga = 2, occupancy = 4}"
+            @check "optimization_hints=<default = {num_cta_in_cga = 2, occupancy = 4}"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0", num_ctas=2, occupancy=4) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1001,7 +1001,7 @@ end
         # sm_arch without hints still emits optimization_hints with an empty dict
         # (matching Python cuTile, which always emits the target architecture).
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {}>"
+            @check "optimization_hints=<default = {}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1011,12 +1011,27 @@ end
         end
     end
 
-    @testset "architecture parameter" begin
+    @testset "legacy arch keying on v13.2" begin
+        # Pre-13.3 bytecode keys hints by the resolved target architecture
+        # instead of "default".
         @test @filecheck begin
             @check "optimization_hints=<sm_120 = {num_cta_in_cga = 4}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0", num_ctas=4) do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0",
+                          num_ctas=4, bytecode_version=v"13.2") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
+                ct.store(a, pid, t)
+                return nothing
+            end
+        end
+
+        @test @filecheck begin
+            @check "load_view_tko"
+            @check "optimization_hints = <sm_120 = {latency = 5}>"
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0",
+                          bytecode_version=v"13.2") do a
+                pid = ct.bid(1)
+                t = ct.load(a, pid, (16,); latency=5)
                 ct.store(a, pid, t)
                 return nothing
             end
@@ -1089,27 +1104,27 @@ end
 
         # Matching arch: both ByTarget hints resolve
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {num_cta_in_cga = 4, occupancy = 16}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 4, occupancy = 16}>"
             ct.code_tiled(_kernel_hints, argtypes; sm_arch=v"10.0")
         end
 
         # Non-matching arch: num_ctas falls back to default=2, occupancy absent (no default)
         @test @filecheck begin
-            @check "optimization_hints=<sm_120 = {num_cta_in_cga = 2}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 2}>"
             @check_not "occupancy"
             ct.code_tiled(_kernel_hints, argtypes; sm_arch=v"12.0")
         end
 
         # Explicit kwarg overrides @compiler_options meta
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {num_cta_in_cga = 8, occupancy = 16}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 8, occupancy = 16}>"
             ct.code_tiled(_kernel_hints, argtypes; sm_arch=v"10.0", num_ctas=8)
         end
 
         # Repeating an earlier call exercises cache reuse — if the cache returned
         # stale results from a different shard, FileCheck would catch the mismatch.
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {num_cta_in_cga = 4, occupancy = 16}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 4, occupancy = 16}>"
             ct.code_tiled(_kernel_hints, argtypes; sm_arch=v"10.0")
         end
 
@@ -1123,13 +1138,13 @@ end
         end
 
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {num_cta_in_cga = 4}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 4}>"
             ct.code_tiled(_kernel_plain_hint, argtypes; sm_arch=v"10.0")
         end
 
         # Plain scalar resolves the same on any arch
         @test @filecheck begin
-            @check "optimization_hints=<sm_120 = {num_cta_in_cga = 4}>"
+            @check "optimization_hints=<default = {num_cta_in_cga = 4}>"
             ct.code_tiled(_kernel_plain_hint, argtypes; sm_arch=v"12.0")
         end
 
@@ -1143,12 +1158,12 @@ end
         end
 
         @test @filecheck begin
-            @check "optimization_hints=<sm_100 = {occupancy = 12}>"
+            @check "optimization_hints=<default = {occupancy = 12}>"
             ct.code_tiled(_kernel_default_only, argtypes; sm_arch=v"10.0")
         end
 
         @test @filecheck begin
-            @check "optimization_hints=<sm_120 = {occupancy = 12}>"
+            @check "optimization_hints=<default = {occupancy = 12}>"
             ct.code_tiled(_kernel_default_only, argtypes; sm_arch=v"12.0")
         end
     end
@@ -1165,7 +1180,7 @@ end
     @testset "latency only on load" begin
         @test @filecheck begin
             @check "load_view_tko"
-            @check "optimization_hints = <sm_120 = {latency = 5}>"
+            @check "optimization_hints = <default = {latency = 5}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=5)
@@ -1178,7 +1193,7 @@ end
     @testset "allow_tma=false only on load" begin
         @test @filecheck begin
             @check "load_view_tko"
-            @check "optimization_hints = <sm_120 = {allow_tma = false}>"
+            @check "optimization_hints = <default = {allow_tma = false}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); allow_tma=false)
@@ -1191,7 +1206,7 @@ end
     @testset "both hints on load" begin
         @test @filecheck begin
             @check "load_view_tko"
-            @check "optimization_hints = <sm_120 = {allow_tma = false, latency = 7}>"
+            @check "optimization_hints = <default = {allow_tma = false, latency = 7}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=7, allow_tma=false)
@@ -1204,7 +1219,7 @@ end
     @testset "latency only on store" begin
         @test @filecheck begin
             @check "store_view_tko"
-            @check "optimization_hints = <sm_120 = {latency = 3}>"
+            @check "optimization_hints = <default = {latency = 3}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1217,7 +1232,7 @@ end
     @testset "allow_tma=false only on store" begin
         @test @filecheck begin
             @check "store_view_tko"
-            @check "optimization_hints = <sm_120 = {allow_tma = false}>"
+            @check "optimization_hints = <default = {allow_tma = false}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1230,7 +1245,7 @@ end
     @testset "both hints on store" begin
         @test @filecheck begin
             @check "store_view_tko"
-            @check "optimization_hints = <sm_120 = {allow_tma = false, latency = 2}>"
+            @check "optimization_hints = <default = {allow_tma = false, latency = 2}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1249,7 +1264,7 @@ end
         end
 
         @test @filecheck begin
-            @check "optimization_hints = <sm_120 = {latency = 8}>"
+            @check "optimization_hints = <default = {latency = 8}>"
             ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=8)
@@ -1263,10 +1278,10 @@ end
         @test @filecheck begin
             # First load with latency
             @check "load_view_tko"
-            @check "optimization_hints = <sm_120 = {latency = 5}>"
+            @check "optimization_hints = <default = {latency = 5}>"
             # Second load with allow_tma=false
             @check "load_view_tko"
-            @check "optimization_hints = <sm_120 = {allow_tma = false}>"
+            @check "optimization_hints = <default = {allow_tma = false}>"
             # Third load with no hints
             @check "load_view_tko"
             @check_not "optimization_hints"
@@ -1288,7 +1303,7 @@ end
     @testset "gather with latency hint" begin
         @test @filecheck begin
             @check "load_ptr_tko"
-            @check "optimization_hints = <sm_120 = {latency = 3}>"
+            @check "optimization_hints = <default = {latency = 3}>"
             code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}, ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a, b
                 pid = ct.bid(1)
                 indices = ct.arange(16)
@@ -1302,7 +1317,7 @@ end
     @testset "scatter with latency hint" begin
         @test @filecheck begin
             @check "store_ptr_tko"
-            @check "optimization_hints = <sm_120 = {latency = 5}>"
+            @check "optimization_hints = <default = {latency = 5}>"
             code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}, ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -750,6 +750,24 @@ end
                        Tuple{ct.TileArray{Float32,1,spec}})
         end
 
+        @testset "extract index out of bounds rejected" begin
+            @test_throws "extract: slice index 3 out of bounds in dimension 2" begin
+                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                    tile = ct.load(a, (ct.bid(1), 1), (4, 8))
+                    ct.extract(tile, (2, 3), (2, 4))
+                end
+            end
+        end
+
+        @testset "extract shape not dividing input rejected" begin
+            @test_throws "extract: input shape (4, 8) is not divisible by extract shape (4, 16)" begin
+                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                    tile = ct.load(a, (ct.bid(1), 1), (4, 8))
+                    ct.extract(tile, (1, 1), (4, 16))
+                end
+            end
+        end
+
         @testset "multi-dim: all dimensions must be pow2" begin
             @test_throws "load: tile dimension 2 must be a power of 2, got 3" begin
                 code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -481,6 +481,28 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
     end
 
+    @testset "tuple comparison" begin
+        # Tuple equality and lexicographic comparison work via the Base
+        # recursive definitions, lowering to scalar cmpi chains (the
+        # equivalent of cuTile Python ebaa570's tuple compare support).
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32}) do a, n
+                x = (ct.bid(1), Int32(2))
+                y = (n, Int32(2))
+                @check "cmpi"
+                if x == y
+                    ct.store(a, 1, ct.load(a, 1, (16,)) .+ 1f0)
+                end
+                @check "cmpi"
+                if x < y
+                    ct.store(a, 1, ct.load(a, 1, (16,)) .* 2f0)
+                end
+                return
+            end
+        end
+    end
+
     @testset "u16 + u64 promotes to u64" begin
         # Pin promote_type(UInt16, UInt64) == UInt64 so the narrower operand
         # is widened with `exti` (zero-extend) before `addi` rather than

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -288,8 +288,8 @@ spec4d = ct.ArraySpec{4}(16, true)
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "extract"
-                # Extract 2x4 slice starting at (2, 3) (1-indexed)
-                extracted = ct.extract(tile, (2, 3), (2, 4))
+                # Extract slice (2, 2) of the 2x2 slice grid (1-indexed)
+                extracted = ct.extract(tile, (2, 2), (2, 4))
                 ct.store(b, pid, extracted)
                 return
             end

--- a/test/device/tile.jl
+++ b/test/device/tile.jl
@@ -664,13 +664,13 @@ end
 end
 
 @testset "extract" begin
-    @testset "extract identity (0,0) full shape" begin
+    @testset "extract identity full shape" begin
         function extract_identity_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
             bid = ct.bid(1)
             # Load 4x8 tile
             tile = ct.load(x, (bid, 1), (4, 8))
-            # Extract the full tile starting at (0, 0)
-            extracted = ct.extract(tile, (2, 2), (4, 8))
+            # Extract the full tile: a single slice, index (1, 1)
+            extracted = ct.extract(tile, (1, 1), (4, 8))
             ct.store(y, (bid, 1), extracted)
             return
         end


### PR DESCRIPTION
Ports some changes from cuTile Python (upstream `88b8eed..d37b24d`):

- **Extract validation**: `ct.extract` now rejects out-of-bounds slice indices and shapes that don't divide the input tile, instead of passing silently invalid IR to tileiras. This caught two existing tests that misread the slice index as an element offset.
- **`assume_divisible_by`**: new user-facing compiler hint declaring an integer scalar divisible by a constant, feeding the existing divisibility analysis (e.g. to prove alignment for derived pointer offsets).
- **Hint encoding on bytecode v13.3+**: kernel-level and load/store optimization hints are now keyed under `"default"` instead of the resolved target architecture, matching cuTile Python's v13.3 output byte-for-byte. Pre-13.3 bytecode keeps the per-arch keying.
- **Tuple comparisons**: covered by a codegen test; Julia gets these natively through Base.