### PR TITLE
Use TF32 when comparing against CUBLAS.

### DIFF
--- a/examples/batchmatmul.jl
+++ b/examples/batchmatmul.jl
@@ -120,20 +120,27 @@ function run_others(data; nruns::Int=1, warmup::Int=0)
 
     C_cublas = similar(A, M, N, Batch)
 
-    # cuBLAS batched gemm via CUBLAS.gemm_strided_batched!
-    CUDA.@sync for _ in 1:warmup
-        cuBLAS.gemm_strided_batched!('N', 'N', one(eltype(A)), A, B, zero(eltype(A)), C_cublas)
-    end
-    times_cublas = Float64[]
-    NVTX.@range "cuBLAS batched" begin
-        for i in 1:nruns
-            NVTX.@range "run $i" begin
-                t = CUDA.@elapsed cuBLAS.gemm_strided_batched!('N', 'N', one(eltype(A)), A, B, zero(eltype(A)), C_cublas)
-                push!(times_cublas, t * 1000)
+    # cuBLAS batched gemm via CUBLAS.gemm_strided_batched!.
+    # The cuTile kernel downcasts Float32 inputs to TF32 for tensor cores,
+    # so let cuBLAS do the same to keep the comparison fair.
+    CUDA.math_mode!(CUDA.FAST_MATH; precision=:TensorFloat32)
+    try
+        CUDA.@sync for _ in 1:warmup
+            cuBLAS.gemm_strided_batched!('N', 'N', one(eltype(A)), A, B, zero(eltype(A)), C_cublas)
+        end
+        times_cublas = Float64[]
+        NVTX.@range "cuBLAS batched" begin
+            for i in 1:nruns
+                NVTX.@range "run $i" begin
+                    t = CUDA.@elapsed cuBLAS.gemm_strided_batched!('N', 'N', one(eltype(A)), A, B, zero(eltype(A)), C_cublas)
+                    push!(times_cublas, t * 1000)
+                end
             end
         end
+        results["cuBLAS batched"] = times_cublas
+    finally
+        CUDA.math_mode!(CUDA.DEFAULT_MATH)
     end
-    results["cuBLAS batched"] = times_cublas
 
     return results
 end

--- a/examples/matmul.jl
+++ b/examples/matmul.jl
@@ -115,20 +115,27 @@ function run_others(data; nruns::Int=1, warmup::Int=0)
 
     C_gpuarrays = similar(A, size(A, 1), size(B, 2))
 
-    # GPUArrays (uses cuBLAS under the hood via LinearAlgebra.mul!)
-    CUDA.@sync for _ in 1:warmup
-        mul!(C_gpuarrays, A, B)
-    end
-    times_gpuarrays = Float64[]
-    NVTX.@range "cuBLAS" begin
-        for i in 1:nruns
-            NVTX.@range "run $i" begin
-                t = CUDA.@elapsed mul!(C_gpuarrays, A, B)
-                push!(times_gpuarrays, t * 1000)
+    # GPUArrays (uses cuBLAS under the hood via LinearAlgebra.mul!).
+    # The cuTile kernel downcasts Float32 inputs to TF32 for tensor cores,
+    # so let cuBLAS do the same to keep the comparison fair.
+    CUDA.math_mode!(CUDA.FAST_MATH; precision=:TensorFloat32)
+    try
+        CUDA.@sync for _ in 1:warmup
+            mul!(C_gpuarrays, A, B)
+        end
+        times_gpuarrays = Float64[]
+        NVTX.@range "cuBLAS" begin
+            for i in 1:nruns
+                NVTX.@range "run $i" begin
+                    t = CUDA.@elapsed mul!(C_gpuarrays, A, B)
+                    push!(times_gpuarrays, t * 1000)
+                end
             end
         end
+        results["cuBLAS"] = times_gpuarrays
+    finally
+        CUDA.math_mode!(CUDA.DEFAULT_MATH)
     end
-    results["cuBLAS"] = times_gpuarrays
 
     return results
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/cuTile.jl/issues/251