### PR TITLE
Support Ref-wrapped broadcast arguments (#254)

### DIFF
--- a/src/language/broadcast.jl
+++ b/src/language/broadcast.jl
@@ -34,6 +34,13 @@ struct TypeRef{T} end
 Base.Broadcast.BroadcastStyle(::Type{<:TypeRef}) = Base.Broadcast.DefaultArrayStyle{0}()
 Base.Broadcast.broadcastable(a::TypeRef) = a
 
+# Scalar-carrying broadcast arguments without a tile shape: TypeRef, plus
+# Base.RefValue from Julia's `broadcastable` fallback (e.g. `x .^ 2` lowers to
+# `broadcasted(literal_pow, ^, x, Val(2))`, wrapping `^` and `Val(2)` in Ref).
+# The Ref never reaches codegen: with all uses inlined and non-escaping, SROA
+# eliminates the mutable allocation.
+const ScalarRef = Union{TypeRef, Base.RefValue}
+
 
 #=============================================================================
  Broadcast materialization via copy
@@ -75,46 +82,43 @@ end
 # using its own type (e.g., 0.0f0 → Tile(Float32(0.0))), preserving the
 # type that Julia's broadcast promotion chose. This avoids the pitfall of
 # using the first Tile's eltype (which could be Bool for ifelse conditions).
-# TypeRef arguments pass through unchanged — they carry no tile shape.
+# ScalarRef arguments pass through unchanged — they carry no tile shape.
 @inline _promote_to_tiles() = ()
 @inline _promote_to_tiles(a::Tile, rest...) = (a, _promote_to_tiles(rest...)...)
 @inline _promote_to_tiles(a::T, rest...) where {T <: Number} =
     (Tile(a), _promote_to_tiles(rest...)...)
-@inline _promote_to_tiles(a::TypeRef, rest...) = (a, _promote_to_tiles(rest...)...)
+@inline _promote_to_tiles(a::ScalarRef, rest...) = (a, _promote_to_tiles(rest...)...)
 
 # Compute combined broadcast shape across all Tile arguments via tuple peeling.
 # Shape is always a tuple TYPE (e.g., Tuple{16, 32}). Convert to value for broadcast_shape.
-# TypeRef arguments are skipped — they have no shape.
+# ScalarRef arguments are skipped — they have no shape.
 @inline _tile_shape(t::Tile) = size(t)
 @inline _broadcast_shapes(t::Tile) = _tile_shape(t)
 @inline _broadcast_shapes(t::Tile, rest...) =
     broadcast_shape(_tile_shape(t), _broadcast_shapes(rest...))
-@inline _broadcast_shapes(::TypeRef, rest...) = _broadcast_shapes(rest...)
-@inline _broadcast_shapes(::TypeRef) = ()
+@inline _broadcast_shapes(::ScalarRef, rest...) = _broadcast_shapes(rest...)
+@inline _broadcast_shapes(::ScalarRef) = ()
 
 # Broadcast all tiles to shape S via tuple peeling.
-# TypeRef arguments pass through unchanged.
+# ScalarRef arguments pass through unchanged.
 @inline _broadcast_all(S::Tuple) = ()
 @inline _broadcast_all(S::Tuple, a::Tile, rest...) =
     (broadcast_to(a, S), _broadcast_all(S, rest...)...)
-@inline _broadcast_all(S::Tuple, a::TypeRef, rest...) =
+@inline _broadcast_all(S::Tuple, a::ScalarRef, rest...) =
     (a, _broadcast_all(S, rest...)...)
 
 # Convert args to scalars, apply f, wrap result back into a Tile.
 @inline function _apply_broadcast(f, args...)
-    scalar_args, S = _to_scalars(args...)
-    Intrinsics.from_scalar(f(scalar_args...), S)
+    Intrinsics.from_scalar(f(map(_to_scalar, args)...), _result_shape(args...))
 end
 
-# Reinterpret Tile arguments as scalars for broadcast application.
-# Skip and extract TypeRef arguments.
-# Returns (scalar_args_tuple, S) where S is the shape from the first Tile.
-@inline _to_scalars(t::Tile{<:Any,S}) where S = ((Intrinsics.to_scalar(t),), S)
-@inline function _to_scalars(t::Tile{<:Any,S}, rest...) where S
-    rest_scalars, _ = _to_scalars(rest...)
-    ((Intrinsics.to_scalar(t), rest_scalars...), S)
-end
-@inline function _to_scalars(::TypeRef{T}, rest...) where T
-    rest_scalars, S = _to_scalars(rest...)
-    ((T, rest_scalars...), S)
-end
+# Reinterpret arguments as scalars for broadcast application: Tiles via
+# to_scalar, TypeRefs via their type parameter, Refs via their contents.
+@inline _to_scalar(t::Tile) = Intrinsics.to_scalar(t)
+@inline _to_scalar(::TypeRef{T}) where T = T
+@inline _to_scalar(r::Base.RefValue) = r[]
+
+# Result shape comes from the first Tile argument; after _broadcast_all,
+# every Tile already has the common shape.
+@inline _result_shape(t::Tile{<:Any,S}, rest...) where S = S
+@inline _result_shape(::ScalarRef, rest...) = _result_shape(rest...)

--- a/src/language/broadcast.jl
+++ b/src/language/broadcast.jl
@@ -23,23 +23,11 @@ Base.Broadcast.BroadcastStyle(::TileStyle, ::Base.Broadcast.DefaultArrayStyle{0}
 Base.Broadcast.broadcastable(t::Tile) = t
 
 
-#=============================================================================
- Ghost wrapper for Type values in broadcasting
-=============================================================================#
-
-# Replaces Julia's RefValue{Type{T}} wrapping which the cuTile compiler can't construct.
-# The value is encoded in the type parameter — no runtime representation needed.
-struct TypeRef{T} end
-
-Base.Broadcast.BroadcastStyle(::Type{<:TypeRef}) = Base.Broadcast.DefaultArrayStyle{0}()
-Base.Broadcast.broadcastable(a::TypeRef) = a
-
-# Scalar-carrying broadcast arguments without a tile shape: TypeRef, plus
-# Base.RefValue from Julia's `broadcastable` fallback (e.g. `x .^ 2` lowers to
-# `broadcasted(literal_pow, ^, x, Val(2))`, wrapping `^` and `Val(2)` in Ref).
-# The Ref never reaches codegen: with all uses inlined and non-escaping, SROA
-# eliminates the mutable allocation.
-const ScalarRef = Union{TypeRef, Base.RefValue}
+# Base's `broadcastable` wraps scalar-like arguments in Ref: functions and
+# Vals via the fallback (e.g. `x .^ 2` lowers to `broadcasted(literal_pow,
+# ^, x, Val(2))`) and Types as `Ref{Type{T}}`. The Refs pass through the
+# machinery below and never reach codegen: with all uses inlined and
+# non-escaping, SROA eliminates the mutable allocation.
 
 
 #=============================================================================
@@ -82,29 +70,29 @@ end
 # using its own type (e.g., 0.0f0 → Tile(Float32(0.0))), preserving the
 # type that Julia's broadcast promotion chose. This avoids the pitfall of
 # using the first Tile's eltype (which could be Bool for ifelse conditions).
-# ScalarRef arguments pass through unchanged — they carry no tile shape.
+# Base.RefValue arguments pass through unchanged — they carry no tile shape.
 @inline _promote_to_tiles() = ()
 @inline _promote_to_tiles(a::Tile, rest...) = (a, _promote_to_tiles(rest...)...)
 @inline _promote_to_tiles(a::T, rest...) where {T <: Number} =
     (Tile(a), _promote_to_tiles(rest...)...)
-@inline _promote_to_tiles(a::ScalarRef, rest...) = (a, _promote_to_tiles(rest...)...)
+@inline _promote_to_tiles(a::Base.RefValue, rest...) = (a, _promote_to_tiles(rest...)...)
 
 # Compute combined broadcast shape across all Tile arguments via tuple peeling.
 # Shape is always a tuple TYPE (e.g., Tuple{16, 32}). Convert to value for broadcast_shape.
-# ScalarRef arguments are skipped — they have no shape.
+# Base.RefValue arguments are skipped — they have no shape.
 @inline _tile_shape(t::Tile) = size(t)
 @inline _broadcast_shapes(t::Tile) = _tile_shape(t)
 @inline _broadcast_shapes(t::Tile, rest...) =
     broadcast_shape(_tile_shape(t), _broadcast_shapes(rest...))
-@inline _broadcast_shapes(::ScalarRef, rest...) = _broadcast_shapes(rest...)
-@inline _broadcast_shapes(::ScalarRef) = ()
+@inline _broadcast_shapes(::Base.RefValue, rest...) = _broadcast_shapes(rest...)
+@inline _broadcast_shapes(::Base.RefValue) = ()
 
 # Broadcast all tiles to shape S via tuple peeling.
-# ScalarRef arguments pass through unchanged.
+# Base.RefValue arguments pass through unchanged.
 @inline _broadcast_all(S::Tuple) = ()
 @inline _broadcast_all(S::Tuple, a::Tile, rest...) =
     (broadcast_to(a, S), _broadcast_all(S, rest...)...)
-@inline _broadcast_all(S::Tuple, a::ScalarRef, rest...) =
+@inline _broadcast_all(S::Tuple, a::Base.RefValue, rest...) =
     (a, _broadcast_all(S, rest...)...)
 
 # Convert args to scalars, apply f, wrap result back into a Tile.
@@ -113,12 +101,13 @@ end
 end
 
 # Reinterpret arguments as scalars for broadcast application: Tiles via
-# to_scalar, TypeRefs via their type parameter, Refs via their contents.
+# to_scalar, Refs via their contents. The Ref{Type{T}} method recovers the
+# Type from the type parameter, mirroring Base's `_broadcast_getindex`.
 @inline _to_scalar(t::Tile) = Intrinsics.to_scalar(t)
-@inline _to_scalar(::TypeRef{T}) where T = T
 @inline _to_scalar(r::Base.RefValue) = r[]
+@inline _to_scalar(::Base.RefValue{Type{T}}) where T = T
 
 # Result shape comes from the first Tile argument; after _broadcast_all,
 # every Tile already has the common shape.
 @inline _result_shape(t::Tile{<:Any,S}, rest...) where S = S
-@inline _result_shape(::ScalarRef, rest...) = _result_shape(rest...)
+@inline _result_shape(::Base.RefValue, rest...) = _result_shape(rest...)

--- a/src/language/overlays.jl
+++ b/src/language/overlays.jl
@@ -32,14 +32,6 @@ end
 
 
 #=============================================================================
- Broadcasting
-=============================================================================#
-
-# Route Type values through TypeRef instead of RefValue (which can't be constructed in Tile IR).
-@overlay Base.Broadcast.broadcastable(::Type{T}) where T = TypeRef{T}()
-
-
-#=============================================================================
  Type Conversions
 =============================================================================#
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -412,6 +412,22 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
     end
 
+    @testset "literal pow" begin
+        # `x .^ 2` lowers through Base.literal_pow with `^` and `Val(2)` in
+        # Ref-wrapped argument position (broadcastable fallback); the Refs
+        # must vanish before codegen and the pow reduce to a multiply.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                @check "mulf"
+                ct.store(b, pid, tile .^ 2)
+                return
+            end
+        end
+    end
+
     @testset "cmpf" begin
         @test @filecheck begin
             @check_label "entry"

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1340,7 +1340,7 @@ end
     end
 
     @testset "Type broadcasting" begin
-        # convert.(Float16, tile) — Type arg via TypeRef
+        # convert.(Float16, tile) — Type arg via Ref{Type{Float16}}
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float16,1,spec1d}}) do a, b

--- a/test/device/broadcast.jl
+++ b/test/device/broadcast.jl
@@ -12,6 +12,10 @@ for (name, kernel_expr, cpu_expr) in [
     ("scalar .- tile",  :(5.0f0 .- tile),    :(5.0f0 .- Array(a))),
     ("tile * scalar",   :(tile * 2.5f0),     :(Array(a) .* 2.5f0)),
     ("scalar * tile",   :(3.0f0 * tile),     :(3.0f0 .* Array(a))),
+    ("tile .^ 2",       :(tile .^ 2),        :(Array(a) .^ 2)),
+    ("tile .^ 3",       :(tile .^ 3),        :(Array(a) .^ 3)),
+    ("tile .^ scalar",  :(tile .^ 2.0f0),    :(Array(a) .^ 2.0f0)),
+    ("tile .+ Ref",     :(tile .+ Ref(1.5f0)), :(Array(a) .+ 1.5f0)),
 ]
     sym = Symbol("scalar_tile_", replace(name, r"[^a-zA-Z0-9]" => "_"))
     @eval @testset $name begin


### PR DESCRIPTION
`x .^ 2` lowers through `Base.literal_pow` with `^` and `Val(2)` wrapped in `Ref` by the `broadcastable` fallback. Handle `Base.RefValue` in the TileStyle broadcast machinery alongside TypeRef; the non-escaping Ref allocation is then SROA'd away and never reaches codegen.

Fixes https://github.com/JuliaGPU/cuTile.jl/issues/254