### PR TITLE
Fix soundness holes in the bounds/divisibility dataflow analyses

### DIFF
--- a/src/compiler/analysis/bounds.jl
+++ b/src/compiler/analysis/bounds.jl
@@ -150,9 +150,22 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
         length(ops) >= 3 || return TOP_RANGE
         v = operand_value(a, r, ops[1])
         s = constant_operand(block, ops[3])
-        s === Signedness.Signed && return v
-        (v isa IntRange && v.lo !== nothing && v.lo >= 0) && return v
-        return TOP_RANGE
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        (v isa IntRange && src_T !== nothing && dst_T !== nothing) || return TOP_RANGE
+        nonnegative = v.lo !== nothing && v.lo >= 0
+        if s === Signedness.Signed
+            src_max = src_T === Bool ? 0 : Int(typemax(signed(src_T)))
+            source_ok = src_T <: Signed || (v.hi !== nothing && v.hi <= src_max)
+            target_ok = dst_T <: Signed || nonnegative
+        elseif s === Signedness.Unsigned
+            dst_max = dst_T === Bool ? 0 : Int(typemax(signed(dst_T)))
+            source_ok = !(src_T <: Signed) || nonnegative
+            target_ok = !(dst_T <: Signed) || (v.hi !== nothing && v.hi <= dst_max)
+        else
+            return TOP_RANGE
+        end
+        return source_ok && target_ok ? v : TOP_RANGE
     end
     if func === Intrinsics.trunci
         return TOP_RANGE
@@ -292,11 +305,7 @@ function result_int_eltype(@nospecialize(inst))
     inst isa Instruction || return nothing
     T = inst[:type]
     T === nothing && return nothing
-    T = CC.widenconst(T)
-    T isa DataType || return nothing
-    T <: Tile && (T = eltype(T))
-    (T isa DataType && T <: Base.BitInteger) || return nothing
-    return T
+    return bitinteger_eltype(T)
 end
 
 function range_intersect(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange})

--- a/src/compiler/analysis/bounds.jl
+++ b/src/compiler/analysis/bounds.jl
@@ -223,27 +223,20 @@ end
 
 @inline function add_or_nothing(a::Union{Int,Nothing}, b::Union{Int,Nothing})
     (a === nothing || b === nothing) && return nothing
-    r = a + b
-    # Detect overflow (signed): result has different sign from inputs.
-    (a > 0 && b > 0 && r < 0) && return nothing
-    (a < 0 && b < 0 && r > 0) && return nothing
-    return r
+    r, overflow = Base.add_with_overflow(a, b)
+    return overflow ? nothing : r
 end
 
 @inline function sub_or_nothing(a::Union{Int,Nothing}, b::Union{Int,Nothing})
     (a === nothing || b === nothing) && return nothing
-    r = a - b
-    (a >= 0 && b < 0 && r < 0) && return nothing
-    (a < 0 && b > 0 && r > 0) && return nothing
-    return r
+    r, overflow = Base.sub_with_overflow(a, b)
+    return overflow ? nothing : r
 end
 
 @inline function mul_or_nothing(a::Union{Int,Nothing}, b::Union{Int,Nothing})
     (a === nothing || b === nothing) && return nothing
-    a == 0 && return 0
-    b == 0 && return 0
-    abs(a) > typemax(Int) ÷ abs(b) && return nothing
-    return a * b
+    r, overflow = Base.mul_with_overflow(a, b)
+    return overflow ? nothing : r
 end
 
 range_add(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange}) = begin
@@ -258,9 +251,7 @@ end
 
 range_neg(a::Union{Nothing,IntRange}) = begin
     a === nothing && return nothing
-    lo = a.hi === nothing ? nothing : -a.hi
-    hi = a.lo === nothing ? nothing : -a.lo
-    IntRange(lo, hi)
+    IntRange(sub_or_nothing(0, a.hi), sub_or_nothing(0, a.lo))
 end
 
 # General multiplication — pick min/max over all four corner products.
@@ -291,8 +282,8 @@ function clamp_to_width(rng::Union{Nothing, IntRange}, @nospecialize(inst))
     T === nothing && return rng
     sizeof(T) <= 8 || return TOP_RANGE
     (rng.lo === nothing || rng.hi === nothing) && return TOP_RANGE
-    tmin = T <: Unsigned ? Int128(0) : Int128(typemin(T))
-    return (tmin <= rng.lo && rng.hi <= Int128(typemax(T))) ? rng : TOP_RANGE
+    lo, hi = Int128(rng.lo), Int128(rng.hi)
+    return Int128(typemin(T)) <= lo <= hi <= Int128(typemax(T)) ? rng : TOP_RANGE
 end
 
 # Integer element type of an instruction's inferred result type (peeling

--- a/src/compiler/analysis/bounds.jl
+++ b/src/compiler/analysis/bounds.jl
@@ -35,6 +35,7 @@ end
 
 const TOP_RANGE = IntRange(nothing, nothing)
 nonneg_range() = IntRange(0, nothing)
+signed_max_value(T::DataType) = T === Bool ? 0 : Int(typemax(signed(T)))
 
 """
     BoundsAnalysis
@@ -155,13 +156,13 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
         (v isa IntRange && src_T !== nothing && dst_T !== nothing) || return TOP_RANGE
         nonnegative = v.lo !== nothing && v.lo >= 0
         if s === Signedness.Signed
-            src_max = src_T === Bool ? 0 : Int(typemax(signed(src_T)))
-            source_ok = src_T <: Signed || (v.hi !== nothing && v.hi <= src_max)
+            source_ok = src_T <: Signed ||
+                        (v.hi !== nothing && v.hi <= signed_max_value(src_T))
             target_ok = dst_T <: Signed || nonnegative
         elseif s === Signedness.Unsigned
-            dst_max = dst_T === Bool ? 0 : Int(typemax(signed(dst_T)))
             source_ok = !(src_T <: Signed) || nonnegative
-            target_ok = !(dst_T <: Signed) || (v.hi !== nothing && v.hi <= dst_max)
+            target_ok = !(dst_T <: Signed) ||
+                        (v.hi !== nothing && v.hi <= signed_max_value(dst_T))
         else
             return TOP_RANGE
         end
@@ -281,31 +282,16 @@ function range_mul(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange})
     return TOP_RANGE
 end
 
-# Clamp an arithmetic transfer's result to what the destination element
-# width can represent. The interval arithmetic above is exact over ℤ
-# (saturating to open endpoints at the lattice level), but the hardware
-# op wraps modulo the element width — once a computed range can escape
-# `[typemin(T), typemax(T)]` (any open endpoint counts), the wrapped
-# runtime value can land anywhere, so the result degrades to top rather
-# than feeding a false range to downstream consumers (`Bounded` assume
-# predicates, `nsw`/`nuw` flags).
+# Arithmetic above is over ℤ. An open, inverted, or out-of-width interval
+# may wrap at runtime, so it degrades to top.
 function clamp_to_width(rng::Union{Nothing, IntRange}, @nospecialize(inst))
     rng === nothing && return rng               # ⊥ stays ⊥
-    T = result_int_eltype(inst)
+    T = inst isa Instruction ? bitinteger_eltype(inst[:type]) : nothing
     T === nothing && return rng
     sizeof(T) <= 8 || return TOP_RANGE
     (rng.lo === nothing || rng.hi === nothing) && return TOP_RANGE
     lo, hi = Int128(rng.lo), Int128(rng.hi)
     return Int128(typemin(T)) <= lo <= hi <= Int128(typemax(T)) ? rng : TOP_RANGE
-end
-
-# Integer element type of an instruction's inferred result type (peeling
-# `Tile{T}` to `T`), or `nothing` when the result isn't a bit-integer.
-function result_int_eltype(@nospecialize(inst))
-    inst isa Instruction || return nothing
-    T = inst[:type]
-    T === nothing && return nothing
-    return bitinteger_eltype(T)
 end
 
 function range_intersect(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange})

--- a/src/compiler/analysis/bounds.jl
+++ b/src/compiler/analysis/bounds.jl
@@ -81,22 +81,29 @@ end
 =============================================================================#
 
 function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
-                  ops, block::Block, ::Any)
+                  ops, block::Block, @nospecialize(inst))
+    # Arithmetic transfers compute the exact mathematical interval, but
+    # the hardware op wraps modulo the result's element width — clamp
+    # each result through `clamp_to_width` so a range the runtime value
+    # can escape never reaches downstream consumers.
     if func === Intrinsics.addi
         length(ops) >= 2 || return TOP_RANGE
-        return range_add(operand_value(a, r, ops[1]), operand_value(a, r, ops[2]))
+        return clamp_to_width(
+            range_add(operand_value(a, r, ops[1]), operand_value(a, r, ops[2])), inst)
     end
     if func === Intrinsics.subi
         length(ops) >= 2 || return TOP_RANGE
-        return range_sub(operand_value(a, r, ops[1]), operand_value(a, r, ops[2]))
+        return clamp_to_width(
+            range_sub(operand_value(a, r, ops[1]), operand_value(a, r, ops[2])), inst)
     end
     if func === Intrinsics.muli
         length(ops) >= 2 || return TOP_RANGE
-        return range_mul(operand_value(a, r, ops[1]), operand_value(a, r, ops[2]))
+        return clamp_to_width(
+            range_mul(operand_value(a, r, ops[1]), operand_value(a, r, ops[2])), inst)
     end
     if func === Intrinsics.negi
         length(ops) >= 1 || return TOP_RANGE
-        return range_neg(operand_value(a, r, ops[1]))
+        return clamp_to_width(range_neg(operand_value(a, r, ops[1])), inst)
     end
 
     if func === Intrinsics.constant
@@ -114,11 +121,14 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
     end
 
     # `Intrinsics.assume(x, predicate)` — refines via `Bounded` (interval
-    # intersection), passes through for any other predicate kind.
+    # intersection), passes through for any other predicate kind. The
+    # predicate is resolved through `constant_operand`: pass-constructed
+    # assumes embed it raw, user-written ones arrive as a `QuoteNode` or
+    # const-inferred SSAValue.
     if func === Intrinsics.assume
         length(ops) >= 2 || return TOP_RANGE
         x_range = operand_value(a, r, ops[1])
-        pred = ops[2]
+        pred = constant_operand(block, ops[2])
         if pred isa Bounded
             return range_intersect(x_range,
                                    IntRange(pred.lb === nothing ? nothing : Int(pred.lb),
@@ -127,13 +137,22 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
         return x_range
     end
 
-    # Casts: `bitcast`/`exti` preserve the integer value (exti is sign-
-    # or zero-extend; both widen the type without changing the
-    # mathematical value). `trunci` clamps to the destination width's
+    # Casts: `bitcast` preserves the integer value. `exti` preserves it
+    # for sign-extension; zero-extension reinterprets the source bits as
+    # unsigned, so it is value-preserving only when the source provably
+    # can't be negative. `trunci` clamps to the destination width's
     # signed range — conservatively bail to top when truncating.
-    if func === Intrinsics.bitcast || func === Intrinsics.exti
+    if func === Intrinsics.bitcast
         length(ops) >= 1 || return TOP_RANGE
         return operand_value(a, r, ops[1])
+    end
+    if func === Intrinsics.exti
+        length(ops) >= 3 || return TOP_RANGE
+        v = operand_value(a, r, ops[1])
+        s = constant_operand(block, ops[3])
+        s === Signedness.Signed && return v
+        (v isa IntRange && v.lo !== nothing && v.lo >= 0) && return v
+        return TOP_RANGE
     end
     if func === Intrinsics.trunci
         return TOP_RANGE
@@ -152,13 +171,10 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
 end
 
 # Override the framework's default ForOp transfer to seed the IV with
-# its static bounds. ForOp iterates `iv ∈ [lower, upper)` with stride
-# `step`; when `lower`/`upper`/`step` are literal-resolvable, the IV
-# range is exactly `[lower, last_iv]` where `last_iv = upper - step`
-# (assuming `step > 0`). Without literal bounds, the IV defaults to
-# top (the framework's default).
+# its static bounds (see `compute_iv_range`). Back-edges are collected
+# via `reachable_terminators`, mirroring the framework's ForOp handler.
 function transfer_cf!(analysis::BoundsAnalysis, result::DataflowResult,
-                      op::ForOp, ::SSAValue, ::Block, tracker::ChangeTracker)
+                      op::ForOp, ssa::SSAValue, ::Block, tracker::ChangeTracker)
     iv = compute_iv_range(analysis, result, op)
     record!(analysis, result, op.iv_arg, iv, tracker)
 
@@ -166,25 +182,34 @@ function transfer_cf!(analysis::BoundsAnalysis, result::DataflowResult,
         record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
     end
     walk!(analysis, result, op.body, tracker)
-    term = op.body.terminator
-    if term isa ContinueOp
-        for (arg, v) in zip(op.body.args, term.values)
+    for t in reachable_terminators(op.body)
+        t isa ContinueOp || continue
+        for (arg, v) in zip(op.body.args, t.values)
             record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
         end
     end
+    record!(analysis, result, ssa, top(analysis), tracker)
 end
 
+# ForOp iterates `iv ∈ [lower, upper)` with stride `step > 0`, so
+# `upper.hi - 1` is always a sound upper bound on the IV. The sharper
+# `upper - step` (the last IV taken) requires the trip length to divide
+# the step — slt/sle-promoted while loops with `step > 1` overshoot it
+# otherwise (0:4:10 visits 8, not 10 - 4 = 6) — so it is used only when
+# `lower`, `upper`, and `step` are exact and the divisibility holds.
 function compute_iv_range(a::BoundsAnalysis, r::DataflowResult, op::ForOp)
     lower = operand_value(a, r, op.lower)
     upper = operand_value(a, r, op.upper)
     step  = operand_value(a, r, op.step)
     iv_lo = (lower === nothing) ? nothing : lower.lo
-    # Last IV is `upper - step` (loop iterates while iv < upper). Need
-    # both an upper bound on `upper` and a lower bound on `step` to
-    # compute it.
-    iv_hi = (upper === nothing || step === nothing ||
-             upper.hi === nothing || step.lo === nothing || step.lo < 1) ?
-            nothing : upper.hi - step.lo
+    iv_hi = (upper === nothing || upper.hi === nothing) ? nothing :
+            sub_or_nothing(upper.hi, 1)
+    if iv_hi !== nothing &&
+       step !== nothing && step.lo !== nothing && step.lo == step.hi && step.lo > 1 &&
+       lower !== nothing && lower.lo !== nothing && lower.lo == lower.hi &&
+       upper.lo == upper.hi && mod(upper.hi - lower.lo, step.lo) == 0
+        iv_hi = sub_or_nothing(upper.hi, step.lo)
+    end
     return IntRange(iv_lo, iv_hi)
 end
 
@@ -250,6 +275,37 @@ function range_mul(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange})
     # on all four corners, and the open-endpoint logic gets fiddly.
     # Worth elaborating only if a workload demands it.
     return TOP_RANGE
+end
+
+# Clamp an arithmetic transfer's result to what the destination element
+# width can represent. The interval arithmetic above is exact over ℤ
+# (saturating to open endpoints at the lattice level), but the hardware
+# op wraps modulo the element width — once a computed range can escape
+# `[typemin(T), typemax(T)]` (any open endpoint counts), the wrapped
+# runtime value can land anywhere, so the result degrades to top rather
+# than feeding a false range to downstream consumers (`Bounded` assume
+# predicates, `nsw`/`nuw` flags).
+function clamp_to_width(rng::Union{Nothing, IntRange}, @nospecialize(inst))
+    rng === nothing && return rng               # ⊥ stays ⊥
+    T = result_int_eltype(inst)
+    T === nothing && return rng
+    sizeof(T) <= 8 || return TOP_RANGE
+    (rng.lo === nothing || rng.hi === nothing) && return TOP_RANGE
+    tmin = T <: Unsigned ? Int128(0) : Int128(typemin(T))
+    return (tmin <= rng.lo && rng.hi <= Int128(typemax(T))) ? rng : TOP_RANGE
+end
+
+# Integer element type of an instruction's inferred result type (peeling
+# `Tile{T}` to `T`), or `nothing` when the result isn't a bit-integer.
+function result_int_eltype(@nospecialize(inst))
+    inst isa Instruction || return nothing
+    T = inst[:type]
+    T === nothing && return nothing
+    T = CC.widenconst(T)
+    T isa DataType || return nothing
+    T <: Tile && (T = eltype(T))
+    (T isa DataType && T <: Base.BitInteger) || return nothing
+    return T
 end
 
 function range_intersect(a::Union{Nothing,IntRange}, b::Union{Nothing,IntRange})

--- a/src/compiler/analysis/dataflow.jl
+++ b/src/compiler/analysis/dataflow.jl
@@ -143,13 +143,37 @@ Base.values(r::DataflowResult) = values(r.values)
 
 Lattice value for an operand as used *inside a transfer function*. The
 default handles `LatticeAnchor`s (via dict lookup) and treats everything
-else (integer/float literals, QuoteNodes, GlobalRefs, …) as `bottom`.
-Analyses override this to recognise raw literals when those are
-meaningful lattice inputs — e.g. a constant analysis returns
-the integer itself for a raw `Int` operand.
+else (integer/float literals, QuoteNodes, GlobalRefs, …) as `top` — an
+unrecognised literal is "no information", never ⊥. Bottom is the merge
+identity, so returning it for a live operand would let the other side of
+a join keep facts this operand doesn't share. Analyses override this to
+recognise raw literals when those are meaningful lattice inputs — e.g. a
+constant analysis returns the integer itself for a raw `Int` operand.
 """
 operand_value(a::ForwardAnalysis, r::DataflowResult, @nospecialize(op)) =
-    op isa LatticeAnchor ? r[op] : bottom(a)
+    op isa LatticeAnchor ? r[op] : top(a)
+
+"""
+    constant_operand(block::Block, op) -> value or nothing
+
+Resolve an operand to its compile-time constant value, mirroring what
+codegen's `get_constant` sees: raw embedded values are returned as-is,
+`QuoteNode`s are unwrapped, and anchors (SSAValues etc.) are chased
+through their inferred type via `singleton_type`. Returns `nothing` for
+operands with no known constant. Used by transfer rules that key on a
+constant operand — e.g. the `Intrinsics.assume` predicate, which is
+embedded directly when a pass constructs the call but arrives as a
+`QuoteNode` (or const-inferred SSAValue) from user-written kernels.
+"""
+function constant_operand(block::Block, @nospecialize(op))
+    op isa QuoteNode && return op.value
+    if op isa LatticeAnchor
+        T = value_type(block, op)
+        T === nothing && return nothing
+        return CC.singleton_type(T)
+    end
+    return op
+end
 
 """
     lookup_def_call(block::Block, val::SSAValue) -> Union{Tuple, Nothing}
@@ -234,6 +258,18 @@ function walk!(analysis::ForwardAnalysis, result::DataflowResult, block::Block, 
             transfer_cf!(analysis, result, s, SSAValue(inst.ssa_idx), block, tracker)
         elseif s isa Expr
             transfer_call!(analysis, result, block, inst, tracker)
+        elseif s isa PiNode
+            # Type-narrowing assertion on the same runtime value —
+            # pass the operand's lattice element through.
+            record!(analysis, result, SSAValue(inst.ssa_idx),
+                    operand_value(analysis, result, s.val), tracker)
+        else
+            # Statement kinds no transfer rule models (GlobalRefs, raw
+            # literals, …). Record ⊤ so the SSA never lingers at ⊥:
+            # bottom is the merge identity, and a ⊥ operand at a join
+            # would let the other side's facts survive unrefuted.
+            record!(analysis, result, SSAValue(inst.ssa_idx),
+                    top(analysis), tracker)
         end
     end
 end
@@ -241,7 +277,12 @@ end
 function transfer_call!(analysis::ForwardAnalysis, result::DataflowResult,
                         block::Block, inst::Instruction, tracker::ChangeTracker)
     call = resolve_call(block, inst)
-    call === nothing && return
+    if call === nothing
+        # Unresolvable callee — same ⊥-lingering hazard as unmodeled
+        # statement kinds above.
+        record!(analysis, result, SSAValue(inst.ssa_idx), top(analysis), tracker)
+        return
+    end
     func, ops = call
     new_val = transfer(analysis, result, func, ops, block, inst)
     record!(analysis, result, SSAValue(inst.ssa_idx), new_val, tracker)
@@ -309,8 +350,12 @@ function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
 
     tt = op.then_region.terminator
     et = op.else_region.terminator
-    (tt isa YieldOp && et isa YieldOp) || return
-    (isempty(tt.values) || isempty(et.values)) && return
+    if !(tt isa YieldOp && et isa YieldOp) || isempty(tt.values) || isempty(et.values)
+        # Shape we don't model (loop-exiting branch, no yields) — the
+        # IfOp's SSA must still leave ⊥.
+        record!(analysis, result, ssa, top(analysis), tracker)
+        return
+    end
 
     merged = bottom(analysis)
     n = min(length(tt.values), length(et.values))
@@ -324,25 +369,29 @@ end
 # ForOp — body.args receives loop-carried values: join(init_values, ContinueOp
 # yields). The IV lives in `op.iv_arg` (not in `body.args`), so init/continue
 # values line up positionally with `body.args` without skipping slot 1.
-# The IV is seeded to `top` (unknown at compile time).
+# The IV is seeded to `top` (unknown at compile time). Back-edges are
+# collected via `reachable_terminators` — a ContinueOp may sit behind a
+# nested IfOp branch, not only as the direct body terminator (same
+# scoping rule as the LoopOp handler below).
 function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
-                      op::ForOp, ::SSAValue, ::Block, tracker::ChangeTracker)
+                      op::ForOp, ssa::SSAValue, ::Block, tracker::ChangeTracker)
     record!(analysis, result, op.iv_arg, top(analysis), tracker)
     for (arg, v) in zip(op.body.args, op.init_values)
         record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
     end
     walk!(analysis, result, op.body, tracker)
-    term = op.body.terminator
-    if term isa ContinueOp
-        for (arg, v) in zip(op.body.args, term.values)
+    for t in reachable_terminators(op.body)
+        t isa ContinueOp || continue
+        for (arg, v) in zip(op.body.args, t.values)
             record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
         end
     end
+    record!(analysis, result, ssa, top(analysis), tracker)
 end
 
 # WhileOp — before.args ← init ⊔ after yields; after.args ← before's ConditionOp args.
 function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
-                      op::WhileOp, ::SSAValue, ::Block, tracker::ChangeTracker)
+                      op::WhileOp, ssa::SSAValue, ::Block, tracker::ChangeTracker)
     for (arg, v) in zip(op.before.args, op.init_values)
         record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
     end
@@ -360,6 +409,7 @@ function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
             record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
         end
     end
+    record!(analysis, result, ssa, top(analysis), tracker)
 end
 
 # LoopOp — body.args ← init ⊔ ContinueOp values ⊔ BreakOp values. ContinueOp /
@@ -368,7 +418,7 @@ end
 # own scope and their terminators target *themselves*, not this outer LoopOp.
 # `reachable_terminators` encodes that scoping rule.
 function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
-                      op::LoopOp, ::SSAValue, ::Block, tracker::ChangeTracker)
+                      op::LoopOp, ssa::SSAValue, ::Block, tracker::ChangeTracker)
     for (arg, v) in zip(op.body.args, op.init_values)
         record!(analysis, result, arg, operand_value(analysis, result, v), tracker)
     end
@@ -380,4 +430,5 @@ function transfer_cf!(analysis::ForwardAnalysis, result::DataflowResult,
             end
         end
     end
+    record!(analysis, result, ssa, top(analysis), tracker)
 end

--- a/src/compiler/analysis/dataflow.jl
+++ b/src/compiler/analysis/dataflow.jl
@@ -56,7 +56,7 @@ Optional methods, with defaults:
 
 - `operand_value(a, result, op)::T` — lattice value for an operand in a
   transfer-function position. Default routes anchors to `result[anchor]`
-  and returns `bottom(a)` for anything else. Override to recognise raw
+  and returns `top(a)` for anything else. Override to recognise raw
   literal operands (e.g. an integer literal is its own constant for a
   constant analysis).
 - `init_arg(a, i, argtype)::T` — seed for kernel parameter `Argument(i)` with
@@ -141,14 +141,9 @@ Base.values(r::DataflowResult) = values(r.values)
 """
     operand_value(analysis, result, op) -> T
 
-Lattice value for an operand as used *inside a transfer function*. The
-default handles `LatticeAnchor`s (via dict lookup) and treats everything
-else (integer/float literals, QuoteNodes, GlobalRefs, …) as `top` — an
-unrecognised literal is "no information", never ⊥. Bottom is the merge
-identity, so returning it for a live operand would let the other side of
-a join keep facts this operand doesn't share. Analyses override this to
-recognise raw literals when those are meaningful lattice inputs — e.g. a
-constant analysis returns the integer itself for a raw `Int` operand.
+Lattice value for an operand inside a transfer function. Anchors read from
+the result; other operands default to top. Analyses override this to handle
+meaningful literals.
 """
 operand_value(a::ForwardAnalysis, r::DataflowResult, @nospecialize(op)) =
     op isa LatticeAnchor ? r[op] : top(a)
@@ -156,14 +151,8 @@ operand_value(a::ForwardAnalysis, r::DataflowResult, @nospecialize(op)) =
 """
     constant_operand(block::Block, op) -> value or nothing
 
-Resolve an operand to its compile-time constant value, mirroring what
-codegen's `get_constant` sees: raw embedded values are returned as-is,
-`QuoteNode`s are unwrapped, and anchors (SSAValues etc.) are chased
-through their inferred type via `singleton_type`. Returns `nothing` for
-operands with no known constant. Used by transfer rules that key on a
-constant operand — e.g. the `Intrinsics.assume` predicate, which is
-embedded directly when a pass constructs the call but arrives as a
-`QuoteNode` (or const-inferred SSAValue) from user-written kernels.
+Resolve raw, quoted, or inferred singleton constants. Returns `nothing`
+when an anchor is not constant.
 """
 function constant_operand(block::Block, @nospecialize(op))
     op isa QuoteNode && return op.value

--- a/src/compiler/analysis/dataflow.jl
+++ b/src/compiler/analysis/dataflow.jl
@@ -175,6 +175,15 @@ function constant_operand(block::Block, @nospecialize(op))
     return op
 end
 
+function bitinteger_eltype(@nospecialize(T))
+    T = CC.widenconst(T)
+    T isa DataType || return nothing
+    T <: Tile && (T = eltype(T))
+    return T isa DataType && T <: Base.BitInteger ? T : nothing
+end
+
+bitinteger_width(T::DataType) = T === Bool ? 1 : sizeof(T) * 8
+
 """
     lookup_def_call(block::Block, val::SSAValue) -> Union{Tuple, Nothing}
 

--- a/src/compiler/analysis/divisibility.jl
+++ b/src/compiler/analysis/divisibility.jl
@@ -131,13 +131,14 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
     end
 
     # `Intrinsics.assume(x, predicate)` — refines when the predicate is
-    # `DivBy`, otherwise passes through. The predicate is an embedded
-    # `AssumePredicate` value (constructed at pass time), so it lives in
-    # the operand list directly rather than being wrapped in a QuoteNode.
+    # `DivBy`, otherwise passes through. The predicate is resolved
+    # through `constant_operand`: pass-constructed assumes embed the
+    # `AssumePredicate` value directly in the operand list, user-written
+    # ones arrive as a `QuoteNode` or const-inferred SSAValue.
     if func === Intrinsics.assume
         length(ops) >= 2 || return 1
         x_div = operand_value(a, r, ops[1])
-        pred = ops[2]
+        pred = constant_operand(block, ops[2])
         if pred isa DivBy
             d = pred.divisor
             return d > 0 ? lcm(max(x_div, 1), d) : x_div
@@ -151,12 +152,27 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
         return operand_value(a, r, ops[1])
     end
 
-    # Integer casts: `bitcast`/`exti` preserve the value (and so the
-    # divisor); `trunci` reduces to mod 2^bitwidth (matches Python's
-    # `TileAsType` rule on integer→integer).
-    if func === Intrinsics.bitcast || func === Intrinsics.exti
+    # Integer casts: `bitcast` preserves the value (and so the divisor);
+    # `trunci` reduces to mod 2^bitwidth (matches Python's `TileAsType`
+    # rule on integer→integer).
+    if func === Intrinsics.bitcast
         length(ops) >= 1 || return 1
         return operand_value(a, r, ops[1])
+    end
+    # `exti` preserves the value for sign-extension. Zero-extension of a
+    # negative adds 2^src_bits (`zext(x) = x mod 2^w`), so only divisors
+    # of both `x` and `2^w` survive: reduce to `gcd(x_div, 2^w)`.
+    if func === Intrinsics.exti
+        length(ops) >= 3 || return 1
+        x_div = operand_value(a, r, ops[1])
+        s = constant_operand(block, ops[3])
+        s === Signedness.Signed && return x_div
+        src_T = value_type(block, ops[1])
+        src_T = src_T === nothing ? Any : CC.widenconst(src_T)
+        src_T <: Tile && (src_T = eltype(src_T))
+        src_T isa DataType && src_T <: Base.BitInteger && sizeof(src_T) < 8 ||
+            return 1
+        return gcd(x_div, 1 << (sizeof(src_T) * 8))
     end
     if func === Intrinsics.trunci
         length(ops) >= 2 || return 1

--- a/src/compiler/analysis/divisibility.jl
+++ b/src/compiler/analysis/divisibility.jl
@@ -159,20 +159,21 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
         length(ops) >= 1 || return 1
         return operand_value(a, r, ops[1])
     end
-    # `exti` preserves the value for sign-extension. Zero-extension of a
-    # negative adds 2^src_bits (`zext(x) = x mod 2^w`), so only divisors
-    # of both `x` and `2^w` survive: reduce to `gcd(x_div, 2^w)`.
+    # Reinterpreting the source sign changes the value by 2^src_bits, so
+    # only the power-of-two part of the divisor survives.
     if func === Intrinsics.exti
         length(ops) >= 3 || return 1
         x_div = operand_value(a, r, ops[1])
         s = constant_operand(block, ops[3])
-        s === Signedness.Signed && return x_div
-        src_T = value_type(block, ops[1])
-        src_T = src_T === nothing ? Any : CC.widenconst(src_T)
-        src_T <: Tile && (src_T = eltype(src_T))
-        src_T isa DataType && src_T <: Base.BitInteger && sizeof(src_T) < 8 ||
-            return 1
-        return gcd(x_div, 1 << (sizeof(src_T) * 8))
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        (src_T === nothing || dst_T === nothing) && return 1
+        src_s = src_T <: Signed ? Signedness.Signed : Signedness.Unsigned
+        dst_s = dst_T <: Signed ? Signedness.Signed : Signedness.Unsigned
+        s === src_s && s === dst_s && return x_div
+        x_div == 0 && return 0
+        width = min(bitinteger_width(src_T), bitinteger_width(dst_T))
+        return 1 << min(trailing_zeros(x_div), width)
     end
     if func === Intrinsics.trunci
         length(ops) >= 2 || return 1

--- a/test/analysis/dataflow.jl
+++ b/test/analysis/dataflow.jl
@@ -233,25 +233,38 @@ end
 
 # ── exti signedness (divisibility) ───────────────────────────────────────
 
-@testset "zero-extension reduces divisibility mod 2^srcbits" begin
-    mk_exti(s) = begin
+@testset "exti preserves sound divisibility" begin
+    mk_exti(scalar, T, s) = begin
+        S = typeof(scalar)
         entry = Block()
         push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
-                             QuoteNode(()), -6, Int8), Int8)
+                             QuoteNode(()), scalar, S), S)
         push!(entry, 2, Expr(:call, cuTile.Intrinsics.exti,
-                             SSAValue(1), Int32, QuoteNode(s)), Int32)
+                             SSAValue(1), T, QuoteNode(s)), T)
         entry.terminator = ReturnNode(SSAValue(2))
         sci = StructuredIRCode(Any[Any], Any[], entry, 2)
         cuTile.analyze_divisibility(sci)
     end
 
     # Sign-extension preserves the value, and so the divisor.
-    r = mk_exti(cuTile.Signedness.Signed)
+    r = mk_exti(Int8(-6), Int32, cuTile.Signedness.Signed)
     @test cuTile.div_by(r, SSAValue(2)) == 6
 
     # Zero-extension of Int8(-6) yields 250 = -6 + 2^8, which is not a
     # multiple of 6; only divisors of gcd(6, 2^8) = 2 survive.
-    r = mk_exti(cuTile.Signedness.Unsigned)
+    r = mk_exti(Int8(-6), Int32, cuTile.Signedness.Unsigned)
+    @test cuTile.div_by(r, SSAValue(2)) == 2
+
+    # Sign-extension of UInt8(250) produces -6, so the same reduction applies.
+    r = mk_exti(UInt8(250), Int32, cuTile.Signedness.Signed)
+    @test cuTile.div_by(r, SSAValue(2)) == 2
+
+    # A differently signed destination also reinterprets the result.
+    r = mk_exti(Int8(-6), UInt32, cuTile.Signedness.Signed)
+    @test cuTile.div_by(r, SSAValue(2)) == 2
+
+    # The reduction also works when 2^srcbits does not fit in Int.
+    r = mk_exti(Int64(-6), Int128, cuTile.Signedness.Unsigned)
     @test cuTile.div_by(r, SSAValue(2)) == 2
 end
 

--- a/test/analysis/dataflow.jl
+++ b/test/analysis/dataflow.jl
@@ -6,11 +6,11 @@
 # intrinsic IR exercises `IfOp` / `ForOp` / `WhileOp` paths with shape
 # that we can assert against.
 
-using Core: SSAValue, Argument, ReturnNode
+using Core: SSAValue, Argument, ReturnNode, PiNode, GlobalRef
 using IRStructurizer
 using IRStructurizer: code_structured, Block, BlockArgument, ForOp, LoopOp,
-                      ContinueOp, ControlFlowOp, StructuredIRCode, blocks,
-                      instructions
+                      IfOp, YieldOp, ContinueOp, ControlFlowOp,
+                      StructuredIRCode, blocks, instructions
 
 using cuTile: ForwardAnalysis, DataflowResult, analyze, record!, has_value, LatticeAnchor
 import cuTile: bottom, top, tmerge, transfer, max_iters, operand_value
@@ -150,6 +150,109 @@ end
 
     @test r[a_out] === 100      # outer carry preserved; inner didn't leak in
     @test r[a_in]  === CTOP     # inner carry: 200 ⊔ 999 → ⊤
+end
+
+
+# ── soundness: ⊥ must never act as best-info at a join ──────────────────
+
+@testset "PiNode passes through; unmodeled statements record ⊤" begin
+    entry = Block()
+    push!(entry, 1, Expr(:call, Core.Intrinsics.add_int, 2, 3), Int)
+    push!(entry, 2, PiNode(SSAValue(1), Int), Int)
+    push!(entry, 3, GlobalRef(Base, :pi), Any)
+    entry.terminator = ReturnNode(SSAValue(2))
+    sci = StructuredIRCode(Any[Any], Any[], entry, 3)
+    r = analyze(ConstInt(), sci)
+
+    @test r[SSAValue(2)] === 5      # PiNode forwards its operand's fact
+    @test r[SSAValue(3)] === CTOP   # no transfer rule — never lingers at ⊥
+end
+
+@testset "PiNode-fed loop carry does not keep the init value's fact" begin
+    # Loop carry: init 16, ContinueOp yields a PiNode of an unanalysed
+    # argument. The PiNode's SSA used to linger at ⊥ (walk! skipped
+    # non-Expr statements), and ⊥ is the merge identity — so the carry
+    # incorrectly kept "divisible by 16" across iterations that replace
+    # it with an arbitrary value.
+    carry = BlockArgument(1, Int)
+    body = Block()
+    push!(body.args, carry)
+    push!(body, 1, PiNode(Argument(2), Int), Int)
+    body.terminator = ContinueOp(Any[SSAValue(1)])
+    loop = LoopOp(body, Any[16])
+    entry = Block()
+    push!(entry, 2, loop, Nothing)
+    entry.terminator = ReturnNode(nothing)
+    sci = StructuredIRCode(Any[Any, Int], Any[], entry, 2)
+
+    r = cuTile.analyze_divisibility(sci)
+    @test cuTile.div_by(r, carry) == 1
+end
+
+@testset "ForOp merges continues nested behind IfOp branches" begin
+    # A ContinueOp may sit inside a nested IfOp branch rather than as
+    # the direct body terminator. Its values must be merged into the
+    # loop carries like the direct back-edge's.
+    iv = BlockArgument(1, Int)
+    carry = BlockArgument(2, Int)
+    then_r = Block()
+    then_r.terminator = ContinueOp(Any[999])
+    else_r = Block()
+    else_r.terminator = YieldOp(Any[])
+    body = Block()
+    push!(body.args, carry)
+    push!(body, 1, IfOp(true, then_r, else_r), Nothing)
+    body.terminator = ContinueOp(Any[carry])
+    fop = ForOp(0, 10, 1, iv, body, Any[100])
+    entry = Block()
+    push!(entry, 2, fop, Nothing)
+    entry.terminator = ReturnNode(nothing)
+    sci = StructuredIRCode(Any[Any], Any[], entry, 2)
+
+    r = analyze(ConstInt(), sci)
+    @test r[carry] === CTOP     # 100 ⊔ 999 → ⊤, not 100
+end
+
+
+# ── user-written Intrinsics.assume ───────────────────────────────────────
+
+@testset "assume(DivBy) refines through a QuoteNode predicate" begin
+    # Pass-constructed assumes embed the predicate value directly; user-
+    # written kernels arrive with it const-folded into a QuoteNode. Both
+    # must refine.
+    entry = Block()
+    push!(entry, 1, Expr(:call, cuTile.Intrinsics.assume, Argument(2),
+                         QuoteNode(cuTile.DivBy(16))), Int)
+    entry.terminator = ReturnNode(SSAValue(1))
+    sci = StructuredIRCode(Any[Any, Int], Any[], entry, 1)
+
+    r = cuTile.analyze_divisibility(sci)
+    @test cuTile.div_by(r, SSAValue(1)) == 16
+end
+
+
+# ── exti signedness (divisibility) ───────────────────────────────────────
+
+@testset "zero-extension reduces divisibility mod 2^srcbits" begin
+    mk_exti(s) = begin
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), -6, Int8), Int8)
+        push!(entry, 2, Expr(:call, cuTile.Intrinsics.exti,
+                             SSAValue(1), Int32, QuoteNode(s)), Int32)
+        entry.terminator = ReturnNode(SSAValue(2))
+        sci = StructuredIRCode(Any[Any], Any[], entry, 2)
+        cuTile.analyze_divisibility(sci)
+    end
+
+    # Sign-extension preserves the value, and so the divisor.
+    r = mk_exti(cuTile.Signedness.Signed)
+    @test cuTile.div_by(r, SSAValue(2)) == 6
+
+    # Zero-extension of Int8(-6) yields 250 = -6 + 2^8, which is not a
+    # multiple of 6; only divisors of gcd(6, 2^8) = 2 survive.
+    r = mk_exti(cuTile.Signedness.Unsigned)
+    @test cuTile.div_by(r, SSAValue(2)) == 2
 end
 
 

--- a/test/codegen/bounds.jl
+++ b/test/codegen/bounds.jl
@@ -100,6 +100,100 @@ end
           cuTile.TOP_RANGE
 end
 
+using Core: SSAValue, Argument, ReturnNode
+using IRStructurizer: StructuredIRCode, Block, BlockArgument, ForOp, ContinueOp
+
+@testset "bounds — ForOp IV upper bound is sound for step > 1" begin
+    mk_for(lower, upper, step) = begin
+        iv = BlockArgument(1, Int)
+        body = Block()
+        body.terminator = ContinueOp(Any[])
+        fop = ForOp(lower, upper, step, iv, body, Any[])
+        entry = Block()
+        push!(entry, 1, fop, Nothing)
+        entry.terminator = ReturnNode(nothing)
+        sci = StructuredIRCode(Any[Any, Int], Any[], entry, 1)
+        (cuTile.analyze_bounds(sci), iv)
+    end
+
+    # 0:4:<10 visits 0, 4, 8 — the last IV overshoots `upper - step`
+    # (= 6), so only the exclusive bound `upper - 1` is sound.
+    r, iv = mk_for(0, 10, 4)
+    @test r[iv] == cuTile.IntRange(0, 9)
+
+    # Trip length divides the step: the sharp `upper - step` applies.
+    r, iv = mk_for(0, 12, 4)
+    @test r[iv] == cuTile.IntRange(0, 8)
+
+    # Step 1: exclusive upper bound minus one, as before.
+    r, iv = mk_for(0, 10, 1)
+    @test r[iv] == cuTile.IntRange(0, 9)
+
+    # Unknown step: `iv < upper` alone still bounds the IV.
+    r, iv = mk_for(0, 10, Argument(2))
+    @test r[iv] == cuTile.IntRange(0, 9)
+end
+
+@testset "bounds — exti consults signedness" begin
+    mk_exti(scalar, s) = begin
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), scalar, Int32), Int32)
+        push!(entry, 2, Expr(:call, cuTile.Intrinsics.exti,
+                             SSAValue(1), Int64, QuoteNode(s)), Int64)
+        entry.terminator = ReturnNode(SSAValue(2))
+        sci = StructuredIRCode(Any[Any], Any[], entry, 2)
+        cuTile.analyze_bounds(sci)
+    end
+
+    # Sign-extension preserves the mathematical value.
+    r = mk_exti(-5, cuTile.Signedness.Signed)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(-5, -5)
+
+    # Zero-extension of a possibly-negative value reinterprets the bits
+    # (Int32(-5) zexts to 2^32 - 5) — the range must not pass through.
+    r = mk_exti(-5, cuTile.Signedness.Unsigned)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    # Zero-extension of a provably non-negative value stays exact.
+    r = mk_exti(5, cuTile.Signedness.Unsigned)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
+end
+
+@testset "bounds — arithmetic clamps to the result element width" begin
+    mk_add(T) = begin
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), typemax(Int32), Int32), Int32)
+        push!(entry, 2, Expr(:call, cuTile.Intrinsics.addi,
+                             SSAValue(1), SSAValue(1)), T)
+        entry.terminator = ReturnNode(SSAValue(2))
+        sci = StructuredIRCode(Any[Any], Any[], entry, 2)
+        cuTile.analyze_bounds(sci)
+    end
+
+    # i32 + i32 wraps at runtime: the exact sum 2^32 - 2 escapes Int32,
+    # so the wrapped value can land anywhere.
+    r = mk_add(Int32)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    # The same sum fits an Int64 destination and is kept exact.
+    r = mk_add(Int64)
+    @test cuTile.bounds(r, SSAValue(2)) ==
+          cuTile.IntRange(2 * Int(typemax(Int32)), 2 * Int(typemax(Int32)))
+end
+
+@testset "bounds — assume(Bounded) refines through a QuoteNode predicate" begin
+    entry = Block()
+    push!(entry, 1, Expr(:call, cuTile.Intrinsics.assume, Argument(2),
+                         QuoteNode(cuTile.Bounded(0, 63))), Int)
+    entry.terminator = ReturnNode(SSAValue(1))
+    sci = StructuredIRCode(Any[Any, Int], Any[], entry, 1)
+
+    r = cuTile.analyze_bounds(sci)
+    @test cuTile.bounds(r, SSAValue(1)) == cuTile.IntRange(0, 63)
+end
+
 @testset "bounds — combine narrows structural with dataflow" begin
     a = cuTile.BoundsAnalysis()
     nonneg = cuTile.IntRange(0, nothing)

--- a/test/codegen/bounds.jl
+++ b/test/codegen/bounds.jl
@@ -87,6 +87,8 @@ end
     @test cuTile.range_neg(cuTile.IntRange(2, 8)) == cuTile.IntRange(-8, -2)
     @test cuTile.range_neg(cuTile.IntRange(2, nothing)) ==
           cuTile.IntRange(nothing, -2)
+    @test cuTile.range_neg(cuTile.IntRange(typemin(Int), -1)) ==
+          cuTile.IntRange(1, nothing)
 
     # Non-negative multiplication: [a, b] * [c, d] = [a*c, b*d].
     @test cuTile.range_mul(cuTile.IntRange(2, 4), cuTile.IntRange(3, 5)) ==
@@ -181,6 +183,25 @@ end
     r = mk_add(Int64)
     @test cuTile.bounds(r, SSAValue(2)) ==
           cuTile.IntRange(2 * Int(typemax(Int32)), 2 * Int(typemax(Int32)))
+end
+
+@testset "bounds — host Int overflow widens to top" begin
+    entry = Block()
+    push!(entry, 1, Expr(:call, cuTile.Intrinsics.assume, Argument(2),
+                         QuoteNode(cuTile.Bounded(typemin(Int), -1))), Int)
+    push!(entry, 2, Expr(:call, cuTile.Intrinsics.addi,
+                         SSAValue(1), SSAValue(1)), Int)
+    push!(entry, 3, Expr(:call, cuTile.Intrinsics.addi,
+                         SSAValue(2), 2), Int)
+    entry.terminator = ReturnNode(SSAValue(3))
+    sci = StructuredIRCode(Any[Any, Int], Any[], entry, 3)
+
+    r = cuTile.analyze_bounds(sci)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+    @test cuTile.bounds(r, SSAValue(3)) == cuTile.TOP_RANGE
+
+    cuTile.no_wrap_pass!(sci, r)
+    @test length(entry.body[3].stmt.args) == 3
 end
 
 @testset "bounds — assume(Bounded) refines through a QuoteNode predicate" begin

--- a/test/codegen/bounds.jl
+++ b/test/codegen/bounds.jl
@@ -137,28 +137,43 @@ using IRStructurizer: StructuredIRCode, Block, BlockArgument, ForOp, ContinueOp
 end
 
 @testset "bounds — exti consults signedness" begin
-    mk_exti(scalar, s) = begin
+    mk_exti(scalar, T, s) = begin
+        S = typeof(scalar)
         entry = Block()
         push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
-                             QuoteNode(()), scalar, Int32), Int32)
+                             QuoteNode(()), scalar, S), S)
         push!(entry, 2, Expr(:call, cuTile.Intrinsics.exti,
-                             SSAValue(1), Int64, QuoteNode(s)), Int64)
+                             SSAValue(1), T, QuoteNode(s)), T)
         entry.terminator = ReturnNode(SSAValue(2))
         sci = StructuredIRCode(Any[Any], Any[], entry, 2)
         cuTile.analyze_bounds(sci)
     end
 
     # Sign-extension preserves the mathematical value.
-    r = mk_exti(-5, cuTile.Signedness.Signed)
+    r = mk_exti(Int32(-5), Int64, cuTile.Signedness.Signed)
     @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(-5, -5)
 
     # Zero-extension of a possibly-negative value reinterprets the bits
     # (Int32(-5) zexts to 2^32 - 5) — the range must not pass through.
-    r = mk_exti(-5, cuTile.Signedness.Unsigned)
+    r = mk_exti(Int32(-5), Int64, cuTile.Signedness.Unsigned)
     @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
 
     # Zero-extension of a provably non-negative value stays exact.
-    r = mk_exti(5, cuTile.Signedness.Unsigned)
+    r = mk_exti(Int32(5), Int64, cuTile.Signedness.Unsigned)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
+
+    # Sign-extension reinterprets the high bit of an unsigned source.
+    r = mk_exti(UInt8(250), Int32, cuTile.Signedness.Signed)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    # Values below the signed maximum have the same interpretation.
+    r = mk_exti(UInt8(5), Int32, cuTile.Signedness.Signed)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
+
+    # The destination interpretation can also change the value.
+    r = mk_exti(Int8(-5), UInt32, cuTile.Signedness.Signed)
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+    r = mk_exti(Int8(5), UInt32, cuTile.Signedness.Signed)
     @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
 end
 


### PR DESCRIPTION
Batch of independent soundness fixes to the forward dataflow framework (`analysis/dataflow.jl`) and its two integer analyses (`analysis/bounds.jl`, `analysis/divisibility.jl`).

## Fixes

1. **ForOp IV upper bound wrong for `step > 1`** (P0). `compute_iv_range` used `upper.hi - step.lo` as the last IV, but slt/sle-promoted while loops don't guarantee the trip length divides the step: `i = 0; while i < 10; i += 4` visits 0, 4, **8** — the analysis claimed `i ≤ 6`. Now uses the always-sound exclusive bound `upper.hi - 1`, keeping the sharp `upper - step` only when lower/upper/step are exact and the divisibility holds. Loops with an unknown step but known upper bound now get a bound at all (previously none).

2. **Never-visited statements lingered at ⊥ and acted as best-info at joins** (P0). ⊥ is the merge identity, so a PiNode-fed loop carry (walk! skipped non-`Expr` statements) kept its init value's fact — e.g. claiming div-by-16 across iterations that replace the value. PiNodes now pass their operand's lattice element through; other unmodeled statements, unresolvable calls, unmodeled IfOp shapes, and the loop ops' own SSA results record ⊤. The framework-default `operand_value` likewise now returns ⊤ (not ⊥) for unrecognised literals.

3. **User-written `Intrinsics.assume` predicates were silently ignored.** Pass-constructed assumes embed the `AssumePredicate` value raw in the operand list, but user-written kernels arrive with it as a `QuoteNode` (or const-inferred SSAValue), failing the `pred isa DivBy` / `Bounded` tests. New `constant_operand` helper (QuoteNode unwrap + `singleton_type` chase, mirroring codegen's `get_constant`) is used by both analyses.

4. **`exti` ignored its signedness operand; arithmetic ignored wraparound.** Zero-extension is only value-preserving for provably non-negative ranges (bounds) and reduces divisors to `gcd(d, 2^srcbits)` (divisibility) — the comment's claim that zext "doesn't change the mathematical value" is false for negative inputs. Arithmetic interval transfers now clamp to the result element width: the lattice computes over ℤ but the hardware op wraps, so ranges that can escape `[typemin(T), typemax(T)]` degrade to ⊤ instead of feeding false `Bounded` predicates or `nsw`/`nuw` flags.

5. **ForOp back-edge merges only looked at the direct body terminator.** A `ContinueOp` behind a nested IfOp branch is a back-edge like any other; both ForOp handlers now use `reachable_terminators`, matching the LoopOp handler, DCE, and IR validation.

## Tests

Direct-API tests for each fix in `test/analysis/dataflow.jl` (PiNode carry, nested-continue merge, QuoteNode `DivBy`, divisibility zext) and `test/codegen/bounds.jl` (step-4 IV bound, exti signedness, width clamp, QuoteNode `Bounded`).

Verified: 68/68 in the directly affected files (`analysis/dataflow`, `codegen/{bounds,assume,no_wrap}`), 297/297 regression sweep over `codegen/{views,slice,cse,integration,operations}` — no output changes from the clamping or the `operand_value` default flip.

## Follow-up (not in this PR)

`bitcast` pass-through has the same signed↔unsigned reinterpretation issue as `exti` for same-width casts (e.g. `Int32(-1)` → `UInt32` changes the mathematical value); left untouched to keep this batch scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)