### PR TITLE
Fix analysis of reinterpreted integer values

### DIFF
--- a/src/compiler/analysis/bounds.jl
+++ b/src/compiler/analysis/bounds.jl
@@ -138,14 +138,28 @@ function transfer(a::BoundsAnalysis, r::DataflowResult, @nospecialize(func),
         return x_range
     end
 
-    # Casts: `bitcast` preserves the integer value. `exti` preserves it
-    # for sign-extension; zero-extension reinterprets the source bits as
-    # unsigned, so it is value-preserving only when the source provably
-    # can't be negative. `trunci` clamps to the destination width's
-    # signed range — conservatively bail to top when truncating.
+    # Casts: `bitcast` preserves bits, but only preserves the mathematical
+    # integer value when a signedness change cannot reinterpret the sign bit.
+    # `exti` preserves the value for sign-extension; zero-extension
+    # reinterprets the source bits as unsigned, so it is value-preserving only
+    # when the source provably can't be negative. `trunci` clamps to the
+    # destination width's signed range — conservatively bail to top when
+    # truncating.
     if func === Intrinsics.bitcast
-        length(ops) >= 1 || return TOP_RANGE
-        return operand_value(a, r, ops[1])
+        length(ops) >= 2 || return TOP_RANGE
+        v = operand_value(a, r, ops[1])
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        (v isa IntRange && src_T !== nothing && dst_T !== nothing &&
+         bitinteger_width(src_T) == bitinteger_width(dst_T)) || return TOP_RANGE
+        src_signed = src_T <: Signed
+        dst_signed = dst_T <: Signed
+        src_signed == dst_signed && return v
+        if src_signed
+            return v.lo !== nothing && v.lo >= 0 ? v : TOP_RANGE
+        else
+            return v.hi !== nothing && v.hi <= signed_max_value(dst_T) ? v : TOP_RANGE
+        end
     end
     if func === Intrinsics.exti
         length(ops) >= 3 || return TOP_RANGE

--- a/src/compiler/analysis/constant.jl
+++ b/src/compiler/analysis/constant.jl
@@ -69,13 +69,12 @@ function transfer(a::ConstantAnalysis, r::DataflowResult, @nospecialize(func),
        length(ops) >= 1
         return operand_value(a, r, ops[1])
     end
-    # Type-narrowing intrinsics — preserve scalar values across width changes
+    # Integer conversions preserve scalar values across width changes
     # so a `1::Int64` field becomes a `1::Int32` after `Int32(stride)` lowers
     # to `trunci`. Otherwise downstream `muli(idx, stride_i32)` would lose
-    # the constant on the convert. Also covers `exti` (widening) and `bitcast`
-    # (no-op on signless integers).
-    if (func === Intrinsics.trunci || func === Intrinsics.exti ||
-        func === Intrinsics.bitcast) && length(ops) >= 1
+    # the constant on the convert. `bitcast` cannot pass through: it preserves
+    # bits, not the scalar value used by this analysis.
+    if (func === Intrinsics.trunci || func === Intrinsics.exti) && length(ops) >= 1
         v = operand_value(a, r, ops[1])
         return v isa Number ? v : CONSTANT_TOP
     end

--- a/src/compiler/analysis/constant.jl
+++ b/src/compiler/analysis/constant.jl
@@ -36,6 +36,7 @@ through straight-line code and structured control flow. Recognises:
 
 - `Intrinsics.constant(shape, scalar, T)` — seeds from the scalar operand
 - `Intrinsics.broadcast(x, _)`, `Intrinsics.reshape(x, _)` — pass-through
+- `Intrinsics.exti`, `Intrinsics.trunci` — evaluates the integer conversion
 
 Everything else → `CONSTANT_TOP`.
 """
@@ -69,14 +70,36 @@ function transfer(a::ConstantAnalysis, r::DataflowResult, @nospecialize(func),
        length(ops) >= 1
         return operand_value(a, r, ops[1])
     end
-    # Integer conversions preserve scalar values across width changes
-    # so a `1::Int64` field becomes a `1::Int32` after `Int32(stride)` lowers
-    # to `trunci`. Otherwise downstream `muli(idx, stride_i32)` would lose
-    # the constant on the convert. `bitcast` cannot pass through: it preserves
-    # bits, not the scalar value used by this analysis.
-    if (func === Intrinsics.trunci || func === Intrinsics.exti) && length(ops) >= 1
+    # Evaluate integer conversions instead of passing the source scalar
+    # through. Signedness and the destination type can both change its value.
+    if func === Intrinsics.exti
+        length(ops) >= 3 || return CONSTANT_TOP
         v = operand_value(a, r, ops[1])
-        return v isa Number ? v : CONSTANT_TOP
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        signedness = constant_operand(block, ops[3])
+        (v isa Integer && src_T !== nothing && dst_T !== nothing &&
+         bitinteger_width(src_T) <= bitinteger_width(dst_T)) || return CONSTANT_TOP
+        if signedness === Signedness.Signed
+            source_signed = true
+        elseif signedness === Signedness.Unsigned
+            source_signed = false
+        else
+            return CONSTANT_TOP
+        end
+        value = interpret_integer(v, bitinteger_width(src_T), source_signed)
+        return convert(dst_T,
+                       interpret_integer(value, bitinteger_width(dst_T), dst_T <: Signed))
+    end
+    if func === Intrinsics.trunci
+        length(ops) >= 2 || return CONSTANT_TOP
+        v = operand_value(a, r, ops[1])
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        (v isa Integer && src_T !== nothing && dst_T !== nothing &&
+         bitinteger_width(src_T) >= bitinteger_width(dst_T)) || return CONSTANT_TOP
+        value = interpret_integer(v, bitinteger_width(dst_T), dst_T <: Signed)
+        return convert(dst_T, value)
     end
     # `getfield(getfield(arg::TileArray, :strides), 1)` for an array with
     # `ArraySpec` `contiguous=true` is statically `1` (Julia column-major
@@ -91,6 +114,12 @@ function transfer(a::ConstantAnalysis, r::DataflowResult, @nospecialize(func),
         v !== nothing && return v
     end
     CONSTANT_TOP
+end
+
+function interpret_integer(value::Integer, width::Int, signed::Bool)
+    modulus = big(1) << width
+    bits = mod(BigInt(value), modulus)
+    signed && bits >= modulus >> 1 ? bits - modulus : bits
 end
 
 # Project a `TileArrayFieldRef` to a scalar constant when the spec pins

--- a/src/compiler/analysis/dataflow.jl
+++ b/src/compiler/analysis/dataflow.jl
@@ -165,6 +165,10 @@ function constant_operand(block::Block, @nospecialize(op))
 end
 
 function bitinteger_eltype(@nospecialize(T))
+    if T isa GlobalRef
+        isdefined(T.mod, T.name) || return nothing
+        T = getfield(T.mod, T.name)
+    end
     T = CC.widenconst(T)
     T isa DataType || return nothing
     T <: Tile && (T = eltype(T))

--- a/src/compiler/analysis/divisibility.jl
+++ b/src/compiler/analysis/divisibility.jl
@@ -152,12 +152,19 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
         return operand_value(a, r, ops[1])
     end
 
-    # Integer casts: `bitcast` preserves the value (and so the divisor);
-    # `trunci` reduces to mod 2^bitwidth (matches Python's `TileAsType`
-    # rule on integer→integer).
+    # Integer casts: a signedness-changing `bitcast` can change the value by
+    # 2^bitwidth, so only the power-of-two part of the divisor survives.
+    # `trunci` reduces to mod 2^bitwidth (matches Python's `TileAsType` rule on
+    # integer→integer).
     if func === Intrinsics.bitcast
-        length(ops) >= 1 || return 1
-        return operand_value(a, r, ops[1])
+        length(ops) >= 2 || return 1
+        x_div = operand_value(a, r, ops[1])
+        src_T = bitinteger_eltype(value_type(block, ops[1]))
+        dst_T = bitinteger_eltype(constant_operand(block, ops[2]))
+        (src_T === nothing || dst_T === nothing ||
+         bitinteger_width(src_T) != bitinteger_width(dst_T)) && return 1
+        (src_T <: Signed) == (dst_T <: Signed) && return x_div
+        return divisor_after_reinterpret(x_div, bitinteger_width(src_T))
     end
     # Reinterpreting the source sign changes the value by 2^src_bits, so
     # only the power-of-two part of the divisor survives.
@@ -171,9 +178,8 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
         src_s = src_T <: Signed ? Signedness.Signed : Signedness.Unsigned
         dst_s = dst_T <: Signed ? Signedness.Signed : Signedness.Unsigned
         s === src_s && s === dst_s && return x_div
-        x_div == 0 && return 0
         width = min(bitinteger_width(src_T), bitinteger_width(dst_T))
-        return 1 << min(trailing_zeros(x_div), width)
+        return divisor_after_reinterpret(x_div, width)
     end
     if func === Intrinsics.trunci
         length(ops) >= 2 || return 1
@@ -192,6 +198,11 @@ function transfer(a::DivByAnalysis, r::DataflowResult, @nospecialize(func),
     end
 
     return 1
+end
+
+function divisor_after_reinterpret(divisor::Int, width::Int)
+    divisor == 0 && return 0
+    return 1 << min(trailing_zeros(divisor), width)
 end
 
 # Project a `TileArrayFieldRef` to its divisor:

--- a/test/analysis/dataflow.jl
+++ b/test/analysis/dataflow.jl
@@ -308,6 +308,43 @@ end
 end
 
 
+@testset "constant analysis evaluates integer conversions" begin
+    function converted_constant(scalar, func, T, operands...)
+        S = typeof(scalar)
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), scalar, S), S)
+        push!(entry, 2, Expr(:call, func, SSAValue(1), T, operands...), T)
+        entry.terminator = ReturnNode(SSAValue(2))
+        sci = StructuredIRCode(Any[Any], Any[], entry, 2)
+        constants = cuTile.analyze_constants(sci)
+        cuTile.const_value(constants, SSAValue(2))
+    end
+
+    signed = QuoteNode(cuTile.Signedness.Signed)
+    unsigned = QuoteNode(cuTile.Signedness.Unsigned)
+
+    @test converted_constant(Int8(-6), cuTile.Intrinsics.exti, Int32, signed) ===
+          Int32(-6)
+    @test converted_constant(Int8(-6), cuTile.Intrinsics.exti, Int32, unsigned) ===
+          Int32(250)
+    @test converted_constant(UInt8(250), cuTile.Intrinsics.exti, Int32, signed) ===
+          Int32(-6)
+    @test converted_constant(Int8(-6), cuTile.Intrinsics.exti, UInt32, signed) ===
+          UInt32(0xffff_fffa)
+    @test converted_constant(Int64(-6), cuTile.Intrinsics.exti, UInt128, unsigned) ===
+          UInt128(typemax(UInt64) - 5)
+
+    @test converted_constant(Int64(1), cuTile.Intrinsics.trunci, Int32) === Int32(1)
+    @test converted_constant(Int64(0xffff_ffff), cuTile.Intrinsics.trunci, Int32) ===
+          Int32(-1)
+    @test converted_constant(Int64(-1), cuTile.Intrinsics.trunci, UInt32) ===
+          typemax(UInt32)
+    @test converted_constant(typemax(UInt64), cuTile.Intrinsics.trunci, Int32) ===
+          Int32(-1)
+end
+
+
 # ── convergence cap ──────────────────────────────────────────────────────
 
 # A deliberately non-monotone analysis: its `tmerge` never stabilises, so the

--- a/test/analysis/dataflow.jl
+++ b/test/analysis/dataflow.jl
@@ -269,6 +269,45 @@ end
 end
 
 
+@testset "bitcast preserves only sound analysis facts" begin
+    function bitcast_sci(scalar, T; target=T)
+        S = typeof(scalar)
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), scalar, S), S)
+        push!(entry, 2, Expr(:call, cuTile.Intrinsics.bitcast,
+                             SSAValue(1), target), T)
+        entry.terminator = ReturnNode(SSAValue(2))
+        StructuredIRCode(Any[Any], Any[], entry, 2)
+    end
+
+    # Reinterpretation preserves bits, not the scalar value tracked by
+    # ConstantAnalysis.
+    sci = bitcast_sci(Int32(-1), UInt32)
+    constants = cuTile.analyze_constants(sci)
+    @test cuTile.const_value(constants, SSAValue(2)) === nothing
+
+    # A signedness change can add 2^width to the mathematical value. Only
+    # power-of-two divisors survive that change.
+    divisibility = cuTile.analyze_divisibility(bitcast_sci(Int32(-3), UInt32))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 1
+    divisibility = cuTile.analyze_divisibility(bitcast_sci(Int32(-4), UInt32))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 4
+    divisibility = cuTile.analyze_divisibility(
+        bitcast_sci(Int32(-4), UInt32; target=GlobalRef(Core, :UInt32)))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 4
+    divisibility = cuTile.analyze_divisibility(bitcast_sci(Int64(-6), UInt64))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 2
+
+    # Same-signedness integer bitcasts retain the divisor; non-integer
+    # bitcasts do not carry integer divisibility facts.
+    divisibility = cuTile.analyze_divisibility(bitcast_sci(Int32(-6), Int32))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 6
+    divisibility = cuTile.analyze_divisibility(bitcast_sci(Int32(-4), Float32))
+    @test cuTile.div_by(divisibility, SSAValue(2)) == 1
+end
+
+
 # ── convergence cap ──────────────────────────────────────────────────────
 
 # A deliberately non-monotone analysis: its `tmerge` never stabilises, so the

--- a/test/codegen/bounds.jl
+++ b/test/codegen/bounds.jl
@@ -177,6 +177,48 @@ end
     @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
 end
 
+@testset "bounds — bitcast consults source and destination signedness" begin
+    function bitcast_sci(scalar, T)
+        S = typeof(scalar)
+        entry = Block()
+        push!(entry, 1, Expr(:call, cuTile.Intrinsics.constant,
+                             QuoteNode(()), scalar, S), S)
+        push!(entry, 2, Expr(:call, cuTile.Intrinsics.bitcast,
+                             SSAValue(1), T), T)
+        entry.terminator = ReturnNode(SSAValue(2))
+        StructuredIRCode(Any[Any], Any[], entry, 2)
+    end
+
+    r = cuTile.analyze_bounds(bitcast_sci(Int32(-1), UInt32))
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    r = cuTile.analyze_bounds(bitcast_sci(Int32(5), UInt32))
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
+
+    r = cuTile.analyze_bounds(bitcast_sci(UInt8(250), Int8))
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    r = cuTile.analyze_bounds(bitcast_sci(UInt8(5), Int8))
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.IntRange(5, 5)
+
+    r = cuTile.analyze_bounds(bitcast_sci(Int32(-1), Float32))
+    @test cuTile.bounds(r, SSAValue(2)) == cuTile.TOP_RANGE
+
+    # The unknown bitcast range must not justify a no-wrap flag on an add
+    # that wraps from typemax(UInt32) to zero.
+    sci = bitcast_sci(Int32(-1), UInt32)
+    entry = sci.entry
+    push!(entry, 3, Expr(:call, cuTile.Intrinsics.constant,
+                         QuoteNode(()), UInt32(1), UInt32), UInt32)
+    push!(entry, 4, Expr(:call, cuTile.Intrinsics.addi,
+                         SSAValue(2), SSAValue(3)), UInt32)
+    entry.terminator = ReturnNode(SSAValue(4))
+    r = cuTile.analyze_bounds(sci)
+    @test cuTile.bounds(r, SSAValue(4)) == cuTile.TOP_RANGE
+    cuTile.no_wrap_pass!(sci, r)
+    @test length(entry.body[4].stmt.args) == 3
+end
+
 @testset "bounds — arithmetic clamps to the result element width" begin
     mk_add(T) = begin
         entry = Block()

--- a/test/device/core.jl
+++ b/test/device/core.jl
@@ -2,6 +2,22 @@
 
 using CUDA
 
+@testset "bitcast constants retain their bit-pattern semantics" begin
+    function bitcast_constants(a::ct.TileArray{UInt32,1})
+        pid = ct.bid(1)
+        x = ct.load(a, pid, (16,))
+        int_bits = reinterpret(UInt32, fill(Int32(-1), (16,)))
+        float_bits = reinterpret(UInt32, fill(Float32(-1), (16,)))
+        ct.store(a, pid, (x .+ int_bits) .- float_bits)
+        return
+    end
+
+    a = CUDA.zeros(UInt32, 16)
+    @cuda backend=cuTile blocks=1 bitcast_constants(a)
+    expected = reinterpret(UInt32, Int32(-1)) - reinterpret(UInt32, Float32(-1))
+    @test Array(a) == fill(expected, 16)
+end
+
 @testset "compilation cache" begin
     function cached_kernel(a::ct.TileArray{Float32,1}, b::ct.TileArray{Float32,1})
         pid = ct.bid(1)


### PR DESCRIPTION
As suggested in https://github.com/JuliaGPU/cuTile.jl/pull/265:

- make constant, bounds, and divisibility analysis sound across bitcasts
- evaluate `exti` and `trunci` constants using their actual integer conversion semantics
- cover signedness changes, non-integer bitcasts, unresolved target type references, no-wrap inference, and the original GPU wrong-code case

## Why

A same-width bitcast preserves bits, not the mathematical value. Passing source analysis facts through signed-to-unsigned, unsigned-to-signed, or integer-to-float reinterpretations could equate different constants, infer false bounds and divisibility, and attach invalid no-wrap flags. Constant analysis had the related issue of passing values through integer extensions and truncations without applying the conversion.

## Impact

The analyses now fall back conservatively when a bitcast changes interpretation, while retaining safe bounds and power-of-two divisibility where possible. Integer extension and truncation constants are represented with the destination type and value.

## Validation

- `julia --project=test test/runtests.jl --jobs=4`
- 2522 passed, 1 marked broken, 0 failures
