### PR TITLE
Support GatherScatterView through Julia views

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,25 @@ The result can be passed to `ct.load`/`ct.store` (or sliced again). Runtime
 asserts verify that ranges start at ≥ 1 and have a positive step; negative
 steps cannot be represented by Tile IR TensorViews.
 
+For a 2D-or-higher array, one 1D integer `Tile` index plus integer unit ranges
+(or `:`) in every other dimension creates a sparse view consumed only by
+`ct.load` and `ct.store`. Public indices are one-based; the load shape is
+explicit and static while range starts may be runtime values. A `:` dense
+dimension starts at element 1 and takes its extent from the load shape.
+
+```julia
+rows = ct.arange(4; start=1, step=2)
+selected = @view a[rows, col_start:col_start+3]
+tile = ct.load(selected, (4, 4); padding_mode=ct.PaddingMode.Zero)
+ct.store(selected, tile)
+```
+
+Sparse loads apply the requested padding and stores clip partially
+out-of-bounds elements. Repeated sparse indices are valid for loads, but
+conflicting stores are undefined. This requires Tile IR v13.3. Direct bracket
+access, view atomics, and Python-style advanced-indexing function names are
+intentionally not provided.
+
 ```julia
 function rowsum(a, b, r1::Int32, r2::Int32)
     sub = @view a[r1:r2, :]                    # sub-range TileArray

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -100,6 +100,7 @@ module Opcode
     const UnpackOp = 112 # since 13.3
     # 113 (AllocaOp) not implemented
     const MmaFScaledOp = 114 # since 13.3
+    const MakeGatherScatterViewOp = 115 # since 13.3
     const MakeStridedViewOp = 116 # since 13.3
     const InsertOp = 118     # since 13.4
 end
@@ -458,6 +459,22 @@ Opcode: 66
 """
 function encode_MakePartitionViewOp!(cb::CodeBuilder, result_type::TypeId, tensor_view::Value)
     encode_varint!(cb.buf, Opcode.MakePartitionViewOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, tensor_view)
+    return new_op!(cb)
+end
+
+"""
+    encode_MakeGatherScatterViewOp!(cb, result_type, tensor_view) -> Value
+
+Create a gather/scatter view from a tensor view.
+Opcode: 115 (Tile IR v13.3+)
+"""
+function encode_MakeGatherScatterViewOp!(cb::CodeBuilder, result_type::TypeId,
+                                         tensor_view::Value)
+    cb.version >= v"13.3" ||
+        throw(IRError("MakeGatherScatterViewOp requires Tile IR v13.3+, got v$(cb.version)"))
+    encode_varint!(cb.buf, Opcode.MakeGatherScatterViewOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, tensor_view)
     return new_op!(cb)

--- a/src/bytecode/types.jl
+++ b/src/bytecode/types.jl
@@ -46,6 +46,7 @@ module CompositeType
     const TensorView    = UInt8(0x0e)
     const PartitionView = UInt8(0x0f)
     const Func          = UInt8(0x10)
+    const GatherScatterView = UInt8(0x14) # since 13.3
     const StridedView   = UInt8(0x15) # since 13.3
 end
 
@@ -221,6 +222,25 @@ function strided_view_type!(table::TypeTable,
     encode_int_list!(buf, collect(traversal_strides), 4)
     encode_varint!(buf, tensor_view.id)
     encode_int_list!(buf, dim_map, 4)
+    encode_optional_padding_byte!(buf, padding_value)
+    _get_or_create!(table, buf)
+end
+
+function gather_scatter_view_type!(table::TypeTable,
+                                   tile_shape::TileShape,
+                                   tensor_view::TypeId,
+                                   sparse_dim::Integer,
+                                   padding_value::PaddingValue.T)
+    table.version >= v"13.3" ||
+        throw(IRError("GatherScatterView requires Tile IR bytecode v13.3+, got v$(table.version)"))
+    sparse_dim >= 0 || throw(IRError("GatherScatterView sparse dimension must be non-negative, got $sparse_dim"))
+    sparse_dim < length(tile_shape) ||
+        throw(IRError("GatherScatterView sparse dimension $sparse_dim is outside rank $(length(tile_shape))"))
+    buf = UInt8[CompositeType.GatherScatterView]
+    encode_optional_flags!(buf, padding_value)
+    encode_int_list!(buf, collect(tile_shape), 4)
+    encode_varint!(buf, tensor_view.id)
+    encode_varint!(buf, sparse_dim)
     encode_optional_padding_byte!(buf, padding_value)
     _get_or_create!(table, buf)
 end

--- a/src/compiler/analysis/alias.jl
+++ b/src/compiler/analysis/alias.jl
@@ -103,7 +103,8 @@ These propagate alias identity from their first operand.
 function is_view_constructor(func)
     return func === Intrinsics.make_tensor_view ||
         func === Intrinsics.make_partition_view ||
-        func === Intrinsics.make_strided_view
+        func === Intrinsics.make_strided_view ||
+        func === Intrinsics.make_gather_scatter_view
 end
 
 function is_pointer_passthrough(func)

--- a/src/compiler/analysis/effects.jl
+++ b/src/compiler/analysis/effects.jl
@@ -22,10 +22,12 @@ externally observable side effect).
 function classify_memory_op(resolved_func)
     if resolved_func === Intrinsics.load_partition_view ||
        resolved_func === Intrinsics.load_strided_view ||
+       resolved_func === Intrinsics.load_gather_scatter_view ||
        resolved_func === Intrinsics.load_ptr_tko
         return MEM_LOAD
     elseif resolved_func === Intrinsics.store_partition_view ||
            resolved_func === Intrinsics.store_strided_view ||
+           resolved_func === Intrinsics.store_gather_scatter_view ||
            resolved_func === Intrinsics.store_ptr_tko
         return MEM_STORE
     elseif resolved_func === Intrinsics.print_tko

--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -280,6 +280,16 @@ function emit_getfield!(ctx::CGCtx, args, @nospecialize(result_type))
         return emit_value!(ctx, obj_tv.tuple[field])
     end
 
+    # Immutable compile-time aggregates such as literal UnitRanges are ghost
+    # values, but their scalar fields can still participate in kernel code.
+    # Materialize the selected field rather than attempting to lower the
+    # aggregate itself as a Tile IR value.
+    if obj_tv !== nothing && obj_tv.constant !== nothing
+        obj = something(obj_tv.constant)
+        index = field isa Symbol ? Base.fieldindex(typeof(obj), field) : field
+        index isa Integer && return emit_value!(ctx, getfield(obj, index))
+    end
+
     # If obj is a lazy arg_ref, extend the chain
     if obj_tv !== nothing && is_arg_ref(obj_tv)
         arg_idx, chain = obj_tv.arg_ref

--- a/src/compiler/codegen/values.jl
+++ b/src/compiler/codegen/values.jl
@@ -153,6 +153,11 @@ function emit_value!(ctx::CGCtx, val::Enum)
     ghost_value(typeof(val), val)
 end
 
+# Literal ranges are structural language values, not Tile IR values. Keep them
+# available for `getfield` extraction so view helpers can lower their scalar
+# endpoints without attempting to encode a range aggregate.
+emit_value!(ctx::CGCtx, val::AbstractUnitRange) = ghost_value(typeof(val), val)
+
 # Fallback for other types (constants embedded in IR)
 function emit_value!(ctx::CGCtx, @nospecialize(val))
     T = typeof(val)

--- a/src/compiler/intrinsics.jl
+++ b/src/compiler/intrinsics.jl
@@ -5,7 +5,7 @@
 module Intrinsics
 
 using Base: compilerbarrier, inferencebarrier
-using ..cuTile: Tile, TileArray, Constant, TensorView, PartitionView, StridedView
+using ..cuTile: Tile, TileArray, Constant, TensorView, PartitionView, StridedView, GatherScatterView
 using ..cuTile: Signedness, ComparisonPredicate, ComparisonOrdering
 using ..cuTile: IdentityVal, FloatIdentityVal, IntegerIdentityVal
 

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -63,20 +63,41 @@ end
 #-----------------------------------------------------------------------------
 
 # Return type for the view-load intrinsics: `Tile{eltype, Shape}` where `Shape`
-# is the view's tile-shape parameter (index 3 of both `PartitionView{T,N,Shape}`
-# and `StridedView{T,N,Shape,Steps}`). `min_params` guards a fully-parameterized
-# view type (3 for partition, 4 for strided).
+# is the view's tile-shape parameter (index 3 of `PartitionView{T,N,Shape}`,
+# `StridedView{T,N,Shape,Steps}`, and `GatherScatterView{T,N,Shape,SparseDim}`).
+# `min_params` guards a fully-parameterized view type (3 for partition, 4 for
+# strided and gather/scatter).
 function view_load_return_type(@nospecialize(view), min_params::Int)
     view_type = CC.widenconst(view)
     view_type isa DataType || return nothing
-    (view_type <: PartitionView || view_type <: StridedView) || return nothing
+    (view_type <: PartitionView || view_type <: StridedView ||
+     view_type <: GatherScatterView) || return nothing
     length(view_type.parameters) >= min_params || return nothing
     Shape = view_type.parameters[3]
     Shape isa Type || return nothing
     return Tile{eltype(view_type), Shape}
 end
 
-function emit_view_load!(ctx::CGCtx, args, name::String)
+# Index resolution for the view load/store helpers. Returns Julia-order values;
+# the helper reverses them for Tile IR's row-major layout. The homogeneous
+# default validates that every index tile shares a type and zero-pads a short
+# tuple to `ndim`; the gather/scatter variant accepts one 1D tile plus 0D
+# scalar tiles.
+function default_view_indices(ctx::CGCtx, indices_arg, view_arg, ndim::Int, name::String)
+    index_tvs = resolve_tuple(ctx, indices_arg, "$name indices")
+    index_vals = Value[tv.v for tv in index_tvs]
+    index_jl_types = Type[tv.jltype for tv in index_tvs]
+
+    unique_types = unique(index_jl_types)
+    length(unique_types) <= 1 || throw(IRError("All index types must match, got: $unique_types"))
+    isempty(unique_types) && ndim > 0 && throw(IRError("$name(): indices required for $(ndim)D view"))
+    index_jl_type = isempty(unique_types) ? Int32 : unique_types[1]  # Int32 only for 0D case
+    index_type = tile_type_for_julia!(ctx, index_jl_type)
+
+    return pad_indices(ctx, index_vals, ndim, index_type, index_jl_type)
+end
+
+function emit_view_load!(ctx::CGCtx, args, name::String; resolve_indices=default_view_indices)
     cb = ctx.cb
     tt = ctx.tt
 
@@ -106,18 +127,8 @@ function emit_view_load!(ctx::CGCtx, args, name::String)
     allow_tma_val = allow_tma isa Bool ? allow_tma : true
     check_bounds = @something get_constant(ctx, args[5]) throw(IRError("$name(): check_bounds must be a compile-time constant"))
 
-    index_tvs = resolve_tuple(ctx, args[4], "$name indices")
-    index_vals = Value[tv.v for tv in index_tvs]
-    index_jl_types = Type[tv.jltype for tv in index_tvs]
-
-    unique_types = unique(index_jl_types)
-    length(unique_types) <= 1 || throw(IRError("All index types must match, got: $unique_types"))
-    isempty(unique_types) && ndim > 0 && throw(IRError("$name(): indices required for $(ndim)D view"))
-    index_jl_type = isempty(unique_types) ? Int32 : unique_types[1]  # Int32 only for 0D case
-    index_type = tile_type_for_julia!(ctx, index_jl_type)
-
-    # Pad indices if needed, then reverse for Tile IR row-major order
-    index_vals = pad_indices(ctx, index_vals, ndim, index_type, index_jl_type)
+    # Resolve indices to Julia-order values, then reverse for Tile IR row-major.
+    index_vals = resolve_indices(ctx, args[4], view_arg, ndim, name)
     reverse!(index_vals)
 
     optimization_hints = create_optimization_hints(ctx, latency, allow_tma_val)
@@ -134,7 +145,8 @@ function emit_view_load!(ctx::CGCtx, args, name::String)
     return CGVal(tile_val, tile_type, Tile{elem_type, TupleType(julia_shape)}, tile_shape)
 end
 
-function emit_view_store!(ctx::CGCtx, args, name::String)
+function emit_view_store!(ctx::CGCtx, args, name::String;
+                          resolve_indices=default_view_indices, check_tile_shape::Bool=false)
     cb = ctx.cb
     tt = ctx.tt
 
@@ -154,6 +166,15 @@ function emit_view_store!(ctx::CGCtx, args, name::String)
     tile_shape = tile_tv.shape
     tile_shape === nothing && throw(IRError("Cannot determine tile shape for $name()"))
 
+    # Gather/scatter stores fix the tile shape to the view's static shape (no
+    # rank-normalizing reshape); partition/strided stores accept any tile.
+    if check_tile_shape
+        view_type = CC.widenconst(view_arg.jltype)
+        expected_shape = RowMajorShape(ColMajorShape(size(view_type)))
+        tile_shape == expected_shape ||
+            throw(IRError("$name(): tile shape $(Tuple(tile_shape)) does not match view shape $(Tuple(expected_shape))"))
+    end
+
     elem_type = eltype(CC.widenconst(tile_tv.jltype))
     dtype = lookup_dtype!(tt, elem_type)
 
@@ -171,17 +192,8 @@ function emit_view_store!(ctx::CGCtx, args, name::String)
     allow_tma_val = allow_tma isa Bool ? allow_tma : true
     check_bounds = @something get_constant(ctx, args[6]) throw(IRError("$name(): check_bounds must be a compile-time constant"))
 
-    index_tvs = resolve_tuple(ctx, args[5], "$name indices")
-    index_vals = Value[tv.v for tv in index_tvs]
-    index_jl_types = Type[tv.jltype for tv in index_tvs]
-
-    unique_types = unique(index_jl_types)
-    length(unique_types) <= 1 || throw(IRError("All index types must match, got: $unique_types"))
-    isempty(unique_types) && actual_ndim > 0 && throw(IRError("$name(): indices required for $(actual_ndim)D view"))
-    index_jl_type = isempty(unique_types) ? Int32 : unique_types[1]  # Int32 only for 0D case
-    index_type = tile_type_for_julia!(ctx, index_jl_type)
-
-    index_vals = pad_indices(ctx, index_vals, actual_ndim, index_type, index_jl_type)
+    # Resolve indices to Julia-order values, then reverse for Tile IR row-major.
+    index_vals = resolve_indices(ctx, args[5], view_arg, actual_ndim, name)
     reverse!(index_vals)
 
     optimization_hints = create_optimization_hints(ctx, latency, allow_tma_val)
@@ -229,6 +241,53 @@ tfunc(𝕃, ::typeof(Intrinsics.load_strided_view), @nospecialize(sv), @nospecia
     view_load_return_type(sv, 4)
 emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_strided_view), args) =
     emit_view_load!(ctx, args, "load_strided_view")
+
+"""
+    Intrinsics.load_gather_scatter_view(view::GatherScatterView, ...)
+
+Token-ordered load from a GatherScatterView. Its indices deliberately accept
+one one-dimensional tile plus scalar tiles, unlike PartitionView's homogeneous
+index tuple.
+"""
+@intrinsic load_gather_scatter_view(view, latency, allow_tma, indices, check_bounds)
+tfunc(𝕃, ::typeof(Intrinsics.load_gather_scatter_view), @nospecialize(view), @nospecialize args...) =
+    view_load_return_type(view, 4)
+emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_gather_scatter_view), args) =
+    emit_view_load!(ctx, args, "load_gather_scatter_view"; resolve_indices=gather_scatter_view_indices)
+
+# Gather/scatter index resolution: one 1D tile on the sparse dim plus 0D scalar
+# tiles elsewhere, validated against the view's static shape and sparse dim.
+function gather_scatter_view_indices(ctx::CGCtx, indices_arg, view_arg, ndim::Int, name::String)
+    view_type = CC.widenconst(view_arg.jltype)
+    sparse_dim = view_type.parameters[4]
+    return gather_scatter_index_values(ctx, indices_arg, size(view_type), ndim, sparse_dim,
+                                       "$name indices")
+end
+
+function gather_scatter_index_values(ctx::CGCtx, indices_arg, view_shape::Tuple, ndim::Int,
+                                     sparse_dim::Integer, name::AbstractString)
+    index_tvs = resolve_tuple(ctx, indices_arg, name)
+    length(index_tvs) == ndim ||
+        throw(IRError("$name must contain $ndim indices, got $(length(index_tvs))"))
+    1 <= sparse_dim <= ndim ||
+        throw(IRError("$name has invalid sparse dimension $sparse_dim for rank $ndim"))
+
+    for (dim, index_tv) in enumerate(index_tvs)
+        index_type = CC.widenconst(index_tv.jltype)
+        index_type <: Tile ||
+            throw(IRError("$name at dimension $dim must be a Tile{Int32}"))
+        eltype(index_type) === Int32 ||
+            throw(IRError("$name at dimension $dim must have Int32 elements, got $(eltype(index_type))"))
+        expected_rank = dim == sparse_dim ? 1 : 0
+        ndims(index_type) == expected_rank ||
+            throw(IRError("$name at dimension $dim must be a $(expected_rank)D Int32 tile"))
+        if dim == sparse_dim
+            size(index_type, 1) == view_shape[dim] ||
+                throw(IRError("$name sparse index length $(size(index_type, 1)) does not match view shape $(view_shape[dim]) at dimension $dim"))
+        end
+    end
+    return Value[index_tv.v for index_tv in index_tvs]
+end
 
 function pad_indices(ctx::CGCtx, index_vals::Vector{Value}, ndim::Int, idx_type::TypeId, idx_jl_type::Type)
     while length(index_vals) < ndim
@@ -364,6 +423,60 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_strided_view), arg
     elem_type = eltype(tensor_view.jltype)
     CGVal(strided, sv_type,
           StridedView{elem_type, ndim, Tuple{shape...}, Tuple{strides...}},
+          RowMajorShape(()), nothing, Some(ndim), nothing)
+end
+
+"""
+    Intrinsics.make_gather_scatter_view(tensor_view, shape, sparse_dim, padding_mode)
+
+Construct a Tile IR GatherScatterView. `shape` and the one-based Julia
+`sparse_dim` are compile-time constants; the emitted type uses Tile IR's
+reversed, zero-based dimension numbering.
+"""
+@intrinsic make_gather_scatter_view(tensor_view, shape, sparse_dim, padding_mode)
+function tfunc(𝕃, ::typeof(Intrinsics.make_gather_scatter_view), @nospecialize(tensor_view),
+               @nospecialize(shape_arg), @nospecialize(sparse_dim_arg), @nospecialize args...)
+    tv_type = CC.widenconst(tensor_view)
+    tv_type <: TensorView || return nothing
+    isa(shape_arg, CC.Const) || return nothing
+    isa(sparse_dim_arg, CC.Const) || return nothing
+    shape = shape_arg.val
+    sparse_dim = sparse_dim_arg.val
+    shape isa Tuple && sparse_dim isa Integer || return nothing
+    length(shape) == ndims(tv_type) || return nothing
+    1 <= sparse_dim <= length(shape) || return nothing
+    return GatherScatterView{eltype(tv_type), ndims(tv_type), Tuple{shape...}, sparse_dim}
+end
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_gather_scatter_view), args)
+    tensor_view = emit_value!(ctx, args[1])
+    tensor_view === nothing && throw(IRError("make_gather_scatter_view() requires a TensorView argument"))
+    ctx.tt.version >= v"13.3" ||
+        throw(IRError("make_gather_scatter_view requires Tile IR bytecode v13.3+, got v$(ctx.tt.version)"))
+
+    shape = @something get_constant(ctx, args[2]) throw(IRError("make_gather_scatter_view() shape must be a compile-time constant"))
+    shape isa Tuple || throw(IRError("make_gather_scatter_view() shape must be a tuple, got $(typeof(shape))"))
+    validate_tile_shape(collect(Int, shape), "gather/scatter view")
+
+    ndim = ndims(CC.widenconst(tensor_view.jltype))
+    length(shape) == ndim ||
+        throw(IRError("make_gather_scatter_view(): shape rank $(length(shape)) does not match TensorView rank $ndim"))
+    ndim >= 2 || throw(IRError("make_gather_scatter_view() requires a 2D or higher-rank TensorView"))
+
+    sparse_dim = @something get_constant(ctx, args[3]) throw(IRError("make_gather_scatter_view() sparse_dim must be a compile-time constant"))
+    sparse_dim isa Integer || throw(IRError("make_gather_scatter_view() sparse_dim must be an integer, got $(typeof(sparse_dim))"))
+    1 <= sparse_dim <= ndim ||
+        throw(IRError("make_gather_scatter_view(): sparse_dim $sparse_dim is outside rank $ndim"))
+
+    padding_value = convert_enum(PaddingValue,
+        @something get_constant(ctx, args[4]) throw(IRError("padding_mode must be a compile-time constant")))
+    tile_shape = RowMajorShape(ColMajorShape(shape))
+    tileir_sparse_dim = ndim - Int(sparse_dim)
+    view_type = gather_scatter_view_type!(ctx.tt, tile_shape, tensor_view.type_id,
+                                          tileir_sparse_dim, padding_value)
+    view = encode_MakeGatherScatterViewOp!(ctx.cb, view_type, tensor_view.v)
+    elem_type = eltype(tensor_view.jltype)
+    CGVal(view, view_type,
+          GatherScatterView{elem_type, ndim, Tuple{shape...}, Int(sparse_dim)},
           RowMajorShape(()), nothing, Some(ndim), nothing)
 end
 
@@ -606,3 +719,23 @@ efunc(::typeof(Intrinsics.store_strided_view), effects::CC.Effects) =
     CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
 emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.store_strided_view), args) =
     emit_view_store!(ctx, args, "store_strided_view")
+
+"""
+    Intrinsics.store_gather_scatter_view(view::GatherScatterView, tile, ...)
+
+Token-ordered store to a GatherScatterView. This stays distinct from
+`store_partition_view`, so loop-parallel-store analysis never treats sparse
+indices as injective.
+"""
+@intrinsic store_gather_scatter_view(view::GatherScatterView{T, N, Shape, SparseDim},
+                                     tile::Tile{T},
+                                     latency::Union{Int, Nothing},
+                                     allow_tma::Bool,
+                                     indices,
+                                     check_bounds::Bool) where {T, N, Shape, SparseDim}
+tfunc(𝕃, ::typeof(Intrinsics.store_gather_scatter_view), @nospecialize args...) = Nothing
+efunc(::typeof(Intrinsics.store_gather_scatter_view), effects::CC.Effects) =
+    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.store_gather_scatter_view), args) =
+    emit_view_store!(ctx, args, "store_gather_scatter_view";
+                     resolve_indices=gather_scatter_view_indices, check_tile_shape=true)

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -23,22 +23,61 @@
 # view / @view → unsafe_view
 #-----------------------------------------------------------------------------
 
-# Restricted to `Vararg{SliceIndex, N}`: rank mismatches and unsupported
-# index types (Int, CartesianIndex, non-integer ranges, …) fall through
-# to Base's regular `view` methods (which don't match TileArray) and surface
-# as a codegen-time `IRError`. The error message there is whatever
-# `_throw_method_error`'s formatting produces — cleaner reporting is tied
-# to a broader rework toward runtime asserts; defer.
-#
-# Throwing from inside `unsafe_view` doesn't work either: a
-# `throw(ArgumentError(...))` reached from inlined kernel code leaks the
-# exception object to codegen, which can't lower String / Exception values.
+# Two methods dispatch TileArray views. The affine method just below
+# (`Vararg{SliceIndex, N}`) wins by specificity for index tuples that are all
+# `:`/UnitRange/StepRange, deriving a sub-range TileArray. Every other
+# combination — a `Tile` index, scalar `Int`s, `CartesianIndex`, a rank
+# mismatch, … — routes to the less-specific `_gather_scatter_tile_view`, which
+# either builds a `GatherScatterTileView` (one 1D integer `Tile` plus unit
+# ranges/`:`) or throws an `ArgumentError`. Such throws reached from inlined
+# kernel code are rendered as clean `CodegenErrors` by the deferred-codegen
+# machinery, so they surface with their own message.
 const SliceIndex = Union{Colon, UnitRange{<:Integer}, StepRange{<:Integer, <:Integer}}
 Base.maybeview(arr::TileArray{T, N}, inds::Vararg{SliceIndex, N}) where {T, N} =
     Base.view(arr, inds...)
 function Base.view(arr::TileArray{T, N}, inds::Vararg{SliceIndex, N}) where {T, N}
     check_slice_bounds(inds)
     unsafe_view(arr, Val(1), inds)
+end
+
+# A Tile index selects GatherScatterView construction. This fallback is less
+# specific than the affine-only method above, so existing `:`/UnitRange views
+# keep returning TileArray values unchanged.
+Base.maybeview(arr::TileArray, inds...) = Base.view(arr, inds...)
+Base.view(arr::TileArray{T, N}, inds...) where {T, N} =
+    _gather_scatter_tile_view(arr, inds)
+
+@generated function _gather_scatter_tile_view(arr::TileArray{T, N}, inds::I) where {T, N, I <: Tuple}
+    types = I.parameters
+    length(types) == N || return :(throw(ArgumentError(
+        "GatherScatterView: index count $(length(inds)) does not match parent rank $N")))
+    N >= 2 || return :(throw(ArgumentError(
+        "GatherScatterView requires a 2D or higher-rank TileArray")))
+
+    sparse_dims = Int[i for (i, index_type) in enumerate(types) if index_type <: Tile]
+    isempty(sparse_dims) && return :(throw(ArgumentError(
+        "unsupported index types for a TileArray view; supported: Colon, " *
+        "UnitRange, or StepRange (affine views), or exactly one 1D integer " *
+        "Tile plus unit ranges/Colon (gather/scatter views). Scalar indices " *
+        "are not supported; use a length-1 range.")))
+    if length(sparse_dims) != 1
+        msg = "GatherScatterView requires exactly one Tile index; found $(length(sparse_dims))"
+        return :(throw(ArgumentError($msg)))
+    end
+    sparse_dim = only(sparse_dims)
+    sparse_type = types[sparse_dim]
+    eltype(sparse_type) <: Integer && ndims(sparse_type) == 1 ||
+        return :(throw(ArgumentError(
+            "GatherScatterView sparse index must be a one-dimensional integer Tile")))
+
+    for (dim, index_type) in enumerate(types)
+        dim == sparse_dim && continue
+        index_type <: Union{Colon, AbstractUnitRange{<:Integer}} ||
+            return :(throw(ArgumentError(
+                "GatherScatterView dense indices must be `:` or integer AbstractUnitRange values")))
+    end
+
+    return :(GatherScatterTileView{typeof(arr), typeof(inds), $sparse_dim}(arr, inds))
 end
 
 """
@@ -602,6 +641,79 @@ end
     load(arr, (index,), shape; kwargs...)
 end
 
+@inline function _gather_scatter_sparse_index(index::Tile{I}) where {I<:Integer}
+    convert(Tile{Int32}, index .- one(I))
+end
+
+Base.@constprop :aggressive function _gather_scatter_dense_index(index::AbstractUnitRange{I}) where {I<:Integer}
+    Intrinsics.assert(first(index) >= one(I), "GatherScatterView: dense range start must be ≥ 1")
+    Int32(first(index) - One())
+end
+# `:` starts at element 1 (0-based 0); its extent comes from the load/store shape.
+_gather_scatter_dense_index(::Colon) = Int32(0)
+
+Base.@constprop :aggressive function _check_gather_scatter_dense_shape(
+        index::AbstractUnitRange{I}, expected::Integer) where {I<:Integer}
+    Intrinsics.assert(length(index) == expected,
+                      "GatherScatterView: dense range length must match tile shape")
+    return
+end
+# `:` takes its extent from the tile shape, so there is no length to check.
+_check_gather_scatter_dense_shape(::Colon, ::Integer) = nothing
+
+@generated function _gather_scatter_indices(view::GatherScatterTileView{A, I, SparseDim}) where
+        {A, I <: Tuple, SparseDim}
+    expressions = Any[]
+    for dim in 1:length(I.parameters)
+        if dim == SparseDim
+            push!(expressions, :(_gather_scatter_sparse_index(view.indices[$dim])))
+        else
+            push!(expressions, :(_gather_scatter_dense_index(view.indices[$dim])))
+        end
+    end
+    Expr(:tuple, expressions...)
+end
+
+@generated function _check_gather_scatter_shape(view::GatherScatterTileView{A, I, SparseDim},
+                                                 shape::NTuple{N, Int}) where
+        {A, I <: Tuple, SparseDim, N}
+    rank = ndims(A)
+    # Both ranks are static here, so a mismatch is a compile-time error rather
+    # than a device-side trap.
+    if N != rank
+        msg = "GatherScatterView: load/store shape rank $N does not match view rank $rank"
+        return :(throw(ArgumentError($msg)))
+    end
+    checks = Any[]
+    for dim in 1:length(I.parameters)
+        dim == SparseDim && continue
+        push!(checks, :(_check_gather_scatter_dense_shape(view.indices[$dim], shape[$dim])))
+    end
+    Expr(:block, checks...)
+end
+
+"""
+    load(view::GatherScatterTileView, shape; padding_mode=PaddingMode.Undetermined,
+         check_bounds=true, latency=nothing, allow_tma=nothing) -> Tile
+
+Materialize a Julia gather/scatter view with an explicit static tile shape.
+The sparse tile index and dense range starts are one-based at this boundary.
+"""
+@inline function load(view::GatherScatterTileView, shape::NTuple{<:Any, Int};
+                      padding_mode::PaddingMode.T=PaddingMode.Undetermined,
+                      check_bounds::Bool=true,
+                      latency::Union{Int, Nothing}=nothing,
+                      allow_tma::Union{Bool, Nothing}=nothing)
+    _check_gather_scatter_shape(view, shape)
+    parent_array = parent(view)
+    tensor_view = Intrinsics.make_tensor_view(typeof(parent_array), parent_array.ptr,
+                                              parent_array.sizes, parent_array.strides)
+    gather_view = Intrinsics.make_gather_scatter_view(
+        tensor_view, shape, gather_scatter_sparse_dim(view), padding_mode)
+    Intrinsics.load_gather_scatter_view(
+        gather_view, latency, allow_tma, _gather_scatter_indices(view), check_bounds)
+end
+
 # Scalar indexing: arr[i, j, ...] → scalar T
 @overlay function Base.getindex(arr::TileArray{T, N}, indices::Vararg{Integer, N}) where {T, N}
     tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
@@ -679,6 +791,29 @@ end
 # Scalar index → wrap in tuple
 @inline function store(arr::TileArray{T}, index::Integer, tile::Tile{T}; kwargs...) where {T}
     store(arr, (index,), tile; kwargs...)
+end
+
+"""
+    store(view::GatherScatterTileView, tile; check_bounds=true,
+          latency=nothing, allow_tma=nothing) -> Tile
+
+Store through a Julia gather/scatter view. Repeated sparse indices retain Tile
+IR's undefined conflicting-store semantics and are conservatively token-ordered.
+"""
+@inline function store(view::GatherScatterTileView{A}, tile::Tile{T};
+                       check_bounds::Bool=true,
+                       latency::Union{Int, Nothing}=nothing,
+                       allow_tma::Union{Bool, Nothing}=nothing) where {T, A<:TileArray{T}}
+    shape = size(tile)
+    _check_gather_scatter_shape(view, shape)
+    parent_array = parent(view)
+    tensor_view = Intrinsics.make_tensor_view(typeof(parent_array), parent_array.ptr,
+                                              parent_array.sizes, parent_array.strides)
+    gather_view = Intrinsics.make_gather_scatter_view(
+        tensor_view, shape, gather_scatter_sparse_dim(view), PaddingMode.Undetermined)
+    Intrinsics.store_gather_scatter_view(
+        gather_view, tile, latency, allow_tma, _gather_scatter_indices(view), check_bounds)
+    return tile
 end
 
 # Scalar value → wrap in 1-element tile and store

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -470,6 +470,56 @@ function Base.size(tiles::TiledView, d::Integer)
 end
 
 """
+    GatherScatterView{T, N, Shape, SparseDim}
+
+Opaque Tile IR GatherScatterView value. `SparseDim` is a one-based Julia
+dimension; bytecode emission reverses it at the column-major boundary.
+"""
+mutable struct GatherScatterView{T, N, Shape, SparseDim} end
+
+Base.eltype(::Type{<:GatherScatterView{T}}) where {T} = T
+Base.eltype(::GatherScatterView{T}) where {T} = T
+Base.ndims(::Type{<:GatherScatterView{<:Any, N}}) where {N} = N
+Base.ndims(::GatherScatterView{<:Any, N}) where {N} = N
+Base.size(::Type{<:GatherScatterView{<:Any, <:Any, Shape}}) where {Shape} = Tuple(Shape.parameters)
+Base.size(::Type{<:GatherScatterView{<:Any, <:Any, Shape}}, d::Integer) where {Shape} = Shape.parameters[d]
+Base.size(view::GatherScatterView) = size(typeof(view))
+Base.size(view::GatherScatterView, d::Integer) = size(typeof(view), d)
+
+"""
+    GatherScatterTileView{A, I, SparseDim}
+
+Language-level descriptor for a Julia `view` with one sparse tile index and
+unit ranges in every other dimension. It is deliberately not an
+`AbstractArray`: direct indexing, iteration, broadcast, and mutation are not
+part of the GatherScatterView surface. `load` and `store` materialize it.
+"""
+struct GatherScatterTileView{A, I, SparseDim}
+    parent::A
+    indices::I
+end
+
+Base.parent(view::GatherScatterTileView) = view.parent
+Base.parentindices(view::GatherScatterTileView) = view.indices
+Base.eltype(::Type{<:GatherScatterTileView{A}}) where {A} = eltype(A)
+Base.eltype(view::GatherScatterTileView) = eltype(typeof(view))
+Base.ndims(::Type{<:GatherScatterTileView{A}}) where {A} = ndims(A)
+Base.ndims(view::GatherScatterTileView) = ndims(typeof(view))
+# A `Colon` dense dimension has no length of its own; report the parent extent.
+_gather_scatter_extent(view::GatherScatterTileView, ::Colon, d) = size(parent(view), d)
+_gather_scatter_extent(::GatherScatterTileView, index, ::Any) = length(index)
+Base.size(view::GatherScatterTileView) =
+    ntuple(i -> _gather_scatter_extent(view, view.indices[i], i), Val(ndims(view)))
+Base.size(view::GatherScatterTileView, d::Integer) =
+    _gather_scatter_extent(view, view.indices[d], d)
+
+# One-based Julia sparse dimension. Defined on the type (single source of
+# truth) with an instance forwarder, as for the `TiledView` accessors.
+gather_scatter_sparse_dim(::Type{<:GatherScatterTileView{A, I, SparseDim}}) where {A, I, SparseDim} =
+    SparseDim
+gather_scatter_sparse_dim(view::GatherScatterTileView) = gather_scatter_sparse_dim(typeof(view))
+
+"""
     Constant{T, V}
 
 Compile-time constant with element type `T` and value `V`.

--- a/test/bytecode.jl
+++ b/test/bytecode.jl
@@ -3,6 +3,28 @@ make_builder(version) = let strings = cuTile.StringTable(), constants = cuTile.C
     cuTile.CodeBuilder(strings, constants, types; version)
 end
 
+@testset "Tile IR v13.3 GatherScatterView encodings" begin
+    tt = cuTile.TypeTable(; version=v"13.3")
+    tensor_view = cuTile.TypeId(7)
+    view = cuTile.gather_scatter_view_type!(
+        tt, cuTile.RowMajorShape([4, 8]), tensor_view, 1, cuTile.PaddingValue.Zero)
+    @test view == cuTile.TypeId(2)
+    @test last(cuTile.items(tt)).first == UInt8[
+        0x14, 0x01,
+        0x02, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+        0x07, 0x01, 0x00,
+    ]
+    @test_throws "v13.3+" cuTile.gather_scatter_view_type!(
+        cuTile.TypeTable(; version=v"13.2"), cuTile.RowMajorShape([4]),
+        tensor_view, 0, cuTile.PaddingValue.Missing)
+
+    cb = make_builder(v"13.3")
+    @test cuTile.encode_MakeGatherScatterViewOp!(cb, cuTile.TypeId(5), cuTile.Value(2)) == cuTile.Value(0)
+    @test cb.buf == UInt8[115, 5, 2]
+    @test_throws "v13.3+" cuTile.encode_MakeGatherScatterViewOp!(
+        make_builder(v"13.2"), cuTile.TypeId(5), cuTile.Value(2))
+end
+
 @testset "Tile IR v13.4 encodings" begin
     @test v"13.4" in cuTile.SUPPORTED_BYTECODE_VERSIONS
 

--- a/test/codegen/gather_scatter_view.jl
+++ b/test/codegen/gather_scatter_view.jl
@@ -1,0 +1,140 @@
+# The low-level intrinsic tests live separately from the Julia `view` surface:
+# this commit proves the Tile IR carrier, dimension conversion, mixed-rank
+# index encoding, and conservative token behavior on their own.
+
+spec2d = ct.ArraySpec{2}(16, true)
+AT2d = ct.TileArray{Float32,2,spec2d}
+
+@testset "GatherScatterView — row-major dimension conversion" begin
+    @test @filecheck begin
+        @check_label "entry"
+        # Julia shape (4, 8) becomes Tile IR tile=(8x4). Julia dim 1 maps to
+        # Tile IR dim 1 after the column-major/row-major reversal.
+        @check "gather_scatter_view<tile=(8x4), padding_value = zero{{.*}}sparse_dim=1"
+        @check "tile<4xi32>"
+        code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+            tv = ct.Intrinsics.make_tensor_view(typeof(a), a.ptr, a.sizes, a.strides)
+            view = ct.Intrinsics.make_gather_scatter_view(tv, (4, 8), 1, ct.PaddingMode.Zero)
+            rows = ct.arange(4; start=0)
+            tile = ct.Intrinsics.load_gather_scatter_view(
+                view, nothing, nothing, (rows, Int32(0)), true)
+            Base.donotdelete(tile)
+            return
+        end
+    end
+end
+
+@testset "GatherScatterView — sparse stores retain loop tokens" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "gather_scatter_view<tile=(4x4){{.*}}sparse_dim=0"
+        @check "iter_values"
+        @check "store_view_tko"
+        code_tiled(Tuple{AT2d, Int32}; bytecode_version=v"13.3") do a, n
+            tv = ct.Intrinsics.make_tensor_view(typeof(a), a.ptr, a.sizes, a.strides)
+            view = ct.Intrinsics.make_gather_scatter_view(
+                tv, (4, 4), 2, ct.PaddingMode.Undetermined)
+            cols = ct.arange(4; start=0)
+            for _ in 1:n
+                tile = ct.load(a, (1, 1), (4, 4))
+                ct.Intrinsics.store_gather_scatter_view(
+                    view, tile, nothing, nothing, (Int32(0), cols), true)
+            end
+            return
+        end
+    end
+end
+
+@testset "GatherScatterView — Julia view surface" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "assert"
+        @check "gather_scatter_view<tile=(4x4), padding_value = zero{{.*}}sparse_dim=1"
+        @check "load_view_tko"
+        code_tiled(Tuple{AT2d, AT2d, Int32}; bytecode_version=v"13.3") do a, b, col_start
+            rows = ct.arange(4; start=1, step=2)
+            gather_view = @view a[rows, col_start:col_start + Int32(3)]
+            tile = ct.load(gather_view, (4, 4); padding_mode=ct.PaddingMode.Zero)
+            ct.store(b, (1, 1), tile)
+            return
+        end
+    end
+
+    # `@views` lowers to Base.maybeview, which must reach the same descriptor.
+    @test @filecheck begin
+        @check_label "entry"
+        @check "gather_scatter_view<tile=(4x4){{.*}}sparse_dim=1"
+        code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+            rows = ct.arange(4)
+            gather_view = @views a[rows, Int32(1):Int32(4)]
+            tile = ct.load(gather_view, (4, 4))
+            Base.donotdelete(tile)
+            return
+        end
+    end
+
+    # Julia dimension 2 becomes Tile IR sparse_dim 0 and reverses the mixed
+    # scalar/tile index tuple exactly once.
+    @test @filecheck begin
+        @check_label "entry"
+        @check "gather_scatter_view<tile=(8x4){{.*}}sparse_dim=0"
+        @check "tile<8xi32>"
+        code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+            cols = ct.arange(8)
+            gather_view = view(a, Int32(1):Int32(4), cols)
+            tile = ct.load(gather_view, (4, 8))
+            Base.donotdelete(tile)
+            return
+        end
+    end
+
+    # A `:` dense dimension starts at element 1 (constant 0); its extent comes
+    # from the load shape rather than the range length.
+    @test @filecheck begin
+        @check_label "entry"
+        @check "gather_scatter_view<tile=(8x4), padding_value = zero{{.*}}sparse_dim=1"
+        @check "constant <i32: 0>"
+        @check "load_view_tko"
+        code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+            rows = ct.arange(4)
+            gather_view = @view a[rows, :]
+            tile = ct.load(gather_view, (4, 8); padding_mode=ct.PaddingMode.Zero)
+            Base.donotdelete(tile)
+            return
+        end
+    end
+
+    # The pre-existing affine view route is still more specific than the
+    # GatherScatterView fallback.
+    @test @filecheck begin
+        @check_label "entry"
+        @check "make_partition_view"
+        @check_not "gather_scatter_view"
+        code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+            affine = view(a, Int32(1):Int32(4), Int32(1):Int32(4))
+            tile = ct.load(affine, (1, 1), (4, 4))
+            Base.donotdelete(tile)
+            return
+        end
+    end
+
+    @test_throws "tile dimension" code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+        rows = ct.arange(4)
+        gather_view = view(a, rows, Int32(1):Int32(3))
+        Base.donotdelete(ct.load(gather_view, (4, 3)))
+        return
+    end
+    @test_throws "sparse index length" code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+        rows = ct.arange(8)
+        gather_view = view(a, rows, Int32(1):Int32(4))
+        Base.donotdelete(ct.load(gather_view, (4, 4)))
+        return
+    end
+    # A load/store shape whose rank differs from the view is a compile-time error.
+    @test_throws "shape rank" code_tiled(Tuple{AT2d}; bytecode_version=v"13.3") do a
+        rows = ct.arange(4)
+        gather_view = view(a, rows, Int32(1):Int32(4))
+        Base.donotdelete(ct.load(gather_view, (4, 4, 4)))
+        return
+    end
+end

--- a/test/device/gather_scatter_view.jl
+++ b/test/device/gather_scatter_view.jl
@@ -1,0 +1,117 @@
+using CUDA
+
+@testset "GatherScatterView — sparse rows with dynamic dense start" begin
+    function gather_rows(a::ct.TileArray{Float32,2}, b::ct.TileArray{Float32,2}, col_start::Int32)
+        rows = ct.arange(4; start=1, step=2)
+        selected = @view a[rows, col_start:col_start + Int32(3)]
+        tile = ct.load(selected, (4, 4); padding_mode=ct.PaddingMode.Zero)
+        ct.store(b, (1, 1), tile)
+        return
+    end
+
+    a = CUDA.CuArray(reshape(Float32.(1:64), 8, 8))
+    b = CUDA.zeros(Float32, 4, 4)
+    @cuda backend=cuTile gather_rows(a, b, Int32(2))
+    @test Array(b) == Array(a)[[1, 3, 5, 7], 2:5]
+end
+
+@testset "GatherScatterView — Colon dense dimension" begin
+    function gather_full_cols(a::ct.TileArray{Float32,2}, b::ct.TileArray{Float32,2})
+        rows = ct.arange(4; start=1, step=2)
+        selected = @view a[rows, :]
+        tile = ct.load(selected, (4, 8); padding_mode=ct.PaddingMode.Zero)
+        ct.store(b, (1, 1), tile)
+        return
+    end
+
+    a = CUDA.CuArray(reshape(Float32.(1:64), 8, 8))
+    b = CUDA.zeros(Float32, 4, 8)
+    @cuda backend=cuTile gather_full_cols(a, b)
+    @test Array(b) == Array(a)[[1, 3, 5, 7], :]
+end
+
+@testset "GatherScatterView — sparse columns store" begin
+    function scatter_columns(src::ct.TileArray{Float32,2}, dst::ct.TileArray{Float32,2})
+        cols = ct.arange(4; start=1, step=2)
+        selected = view(dst, Int32(3):Int32(6), cols)
+        tile = ct.load(src, (1, 1), (4, 4))
+        ct.store(selected, tile)
+        return
+    end
+
+    src = CUDA.CuArray(reshape(Float32.(1:16), 4, 4))
+    dst = CUDA.zeros(Float32, 8, 8)
+    @cuda backend=cuTile scatter_columns(src, dst)
+    expected = zeros(Float32, 8, 8)
+    expected[3:6, [1, 3, 5, 7]] .= Array(src)
+    @test Array(dst) == expected
+end
+
+@testset "GatherScatterView — Colon dense dimension store" begin
+    function scatter_full_cols(src::ct.TileArray{Float32,2}, dst::ct.TileArray{Float32,2})
+        rows = ct.arange(4; start=1, step=2)
+        selected = @view dst[rows, :]
+        tile = ct.load(src, (1, 1), (4, 8))
+        ct.store(selected, tile)
+        return
+    end
+
+    src = CUDA.CuArray(reshape(Float32.(1:32), 4, 8))
+    dst = CUDA.zeros(Float32, 8, 8)
+    @cuda backend=cuTile scatter_full_cols(src, dst)
+    expected = zeros(Float32, 8, 8)
+    expected[[1, 3, 5, 7], :] .= Array(src)
+    @test Array(dst) == expected
+end
+
+@testset "GatherScatterView — partial out-of-bounds load" begin
+    function gather_oob(a::ct.TileArray{Float32,2}, b::ct.TileArray{Float32,2})
+        rows = ct.arange(4; start=7)
+        selected = @view a[rows, Int32(6):Int32(9)]
+        tile = ct.load(selected, (4, 4); padding_mode=ct.PaddingMode.Zero)
+        ct.store(b, (1, 1), tile)
+        return
+    end
+
+    a = CUDA.CuArray(reshape(Float32.(1:64), 8, 8))
+    b = CUDA.zeros(Float32, 4, 4)
+    @cuda backend=cuTile gather_oob(a, b)
+    expected = zeros(Float32, 4, 4)
+    for j in 1:4, i in 1:4
+        row, col = 6 + i, 5 + j
+        row <= 8 && col <= 8 && (expected[i, j] = Array(a)[row, col])
+    end
+    @test Array(b) == expected
+end
+
+@testset "GatherScatterView — partial out-of-bounds store" begin
+    function scatter_oob(src::ct.TileArray{Float32,2}, dst::ct.TileArray{Float32,2})
+        rows = ct.arange(4; start=7)
+        selected = view(dst, rows, Int32(6):Int32(9))
+        tile = ct.load(src, (1, 1), (4, 4))
+        ct.store(selected, tile)
+        return
+    end
+
+    src = CUDA.CuArray(reshape(Float32.(1:16), 4, 4))
+    dst = CUDA.zeros(Float32, 8, 8)
+    @cuda backend=cuTile scatter_oob(src, dst)
+    expected = zeros(Float32, 8, 8)
+    expected[7:8, 6:8] .= Array(src)[1:2, 1:3]
+    @test Array(dst) == expected
+end
+
+@testset "GatherScatterView — middle sparse 3D axis" begin
+    function gather_middle(a::ct.TileArray{Float32,3}, b::ct.TileArray{Float32,3})
+        depth = ct.arange(4; start=1, step=2)
+        selected = view(a, Int32(1):Int32(2), depth, Int32(3):Int32(4))
+        tile = ct.load(selected, (2, 4, 2))
+        ct.store(b, (1, 1, 1), tile)
+        return
+    end
+
+    a = CUDA.CuArray(reshape(Float32.(1:128), 4, 8, 4))
+    b = CUDA.zeros(Float32, 2, 4, 2)
+    @cuda backend=cuTile gather_middle(a, b)
+    @test Array(b) == Array(a)[1:2, [1, 3, 5, 7], 3:4]
+end

--- a/test/types.jl
+++ b/test/types.jl
@@ -112,6 +112,41 @@ end
     @test_throws "must be a permutation" eachtile(a, (8, 4); order=(1,))
 end
 
+@testset "GatherScatterTileView" begin
+    parent_array = ct.TileArray(Ptr{Float32}(0), (Int32(8), Int32(8)),
+                                (Int32(1), Int32(8)))
+    rows = ct.Tile{Int32, Tuple{4}}()
+    cols = Int32(3):Int32(6)
+
+    direct = view(parent_array, rows, cols)
+    macro_view = @view parent_array[rows, cols]
+    views_macro = @views parent_array[rows, cols]
+    @test typeof(direct) === typeof(macro_view) === typeof(views_macro)
+    @test parent(direct) === parent_array
+    @test parentindices(direct) == (rows, cols)
+    @test eltype(direct) === Float32
+    @test ndims(direct) == 2
+    @test size(direct) == (4, 4)
+    @test !hasmethod(getindex, Tuple{typeof(direct), Int, Int})
+    @test !hasmethod(setindex!, Tuple{typeof(direct), Float32, Int, Int})
+
+    # `:` is a valid dense index; its extent is the parent's (here, 8).
+    colon_view = @view parent_array[rows, :]
+    @test cuTile.gather_scatter_sparse_dim(colon_view) == 1
+    @test size(colon_view) == (4, 8)
+
+    # The more-specific affine view method remains available; its device
+    # result is checked in codegen/views rather than executed on the host.
+    @test hasmethod(view, Tuple{typeof(parent_array), UnitRange{Int32}, UnitRange{Int32}})
+
+    @test_throws "dense indices" view(parent_array, rows, 1:2:7)
+    @test_throws "exactly one Tile" view(parent_array, rows, rows)
+    @test_throws "sparse index" view(parent_array, ct.Tile{Float32, Tuple{4}}(), cols)
+    @test_throws "index count" view(parent_array, rows)
+    # No Tile index: describe the whole view surface, not gather/scatter alone.
+    @test_throws "Scalar indices" view(parent_array, 1, :)
+end
+
 @testset "TensorView" begin
     @test eltype(cuTile.TensorView{Float32, 2}) == Float32
     @test eltype(cuTile.TensorView{Float64, 3}) == Float64


### PR DESCRIPTION
Adds Tile IR v13.3 `GatherScatterView` support and exposes it through Julia’s existing `view` syntax.

```julia
rows = ct.arange(4; start=1, step=2)
selected = @view a[rows, col_start:col_start+3]

tile = ct.load(selected, (4, 4); padding_mode=ct.PaddingMode.Zero)
ct.store(selected, tile)
```

A gather/scatter view requires exactly one 1D integer `Tile` index and integer unit ranges for every other dimension. `view`, `@view`, and `@views` all construct the same internal descriptor; only `ct.load` and `ct.store` consume it.

Compared with cuTile Python:

- Python exposes `load_advanced_indexing` / `store_advanced_indexing` and a public `Slice` frontend.
- Julia uses its native `view` syntax, ranges, and `Base.view` / `Base.maybeview` extensions instead.
- No Python-style aliases or public slice type are added.
- Direct `getindex`, `setindex!`, and view atomics remain unsupported.