### PR TITLE
Add view-based atomic reductions and `ct.@atomic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,16 +378,46 @@ origins.
 | Operation | Description |
 |-----------|-------------|
 | `ct.atomic_cas(arr, idx, expected, desired; ...)` | Compare-and-swap |
-| `ct.atomic_xchg(arr, idx, val; ...)` | Exchange |
-| `ct.atomic_add(arr, idx, val; ...)` | Atomic add |
-| `ct.atomic_max(arr, idx, val; ...)` | Atomic max |
-| `ct.atomic_min(arr, idx, val; ...)` | Atomic min |
-| `ct.atomic_or(arr, idx, val; ...)` | Atomic bitwise OR |
-| `ct.atomic_and(arr, idx, val; ...)` | Atomic bitwise AND |
-| `ct.atomic_xor(arr, idx, val; ...)` | Atomic bitwise XOR |
+| `ct.atomic_xchg(arr, idx, val; ...)` | Exchange, returning the old value |
+| `ct.atomic_add(arr, idx, val; ...)` | Add, returning the old value |
+| `ct.atomic_max(arr, idx, val; ...)` | Maximum, returning the old value |
+| `ct.atomic_min(arr, idx, val; ...)` | Minimum, returning the old value |
+| `ct.atomic_or(arr, idx, val; ...)` | Bitwise OR, returning the old value |
+| `ct.atomic_and(arr, idx, val; ...)` | Bitwise AND, returning the old value |
+| `ct.atomic_xor(arr, idx, val; ...)` | Bitwise XOR, returning the old value |
+| `ct.atomic_store_add(dst, idx, update)` | Add a tile without returning old values |
+| `ct.atomic_store_{max,min,or,and,xor}(dst, idx, update)` | Other tile reductions without returning old values |
+| `ct.@atomic [order] expr` | Julia-style atomic reduction |
 
-All atomics accept `memory_order` (default: `ct.MemoryOrder.AcqRel`) and
-`memory_scope` (default: `ct.MemScope.Device`) keyword arguments.
+The `atomic_*` functions accept `memory_order` (default:
+`ct.MemoryOrder.AcqRel`) and `memory_scope` (default: `ct.MemScope.Device`)
+keyword arguments. Their indices may be scalars or tiles. Unsigned
+`atomic_max` and `atomic_min` use unsigned comparisons. Updates to bitwise
+atomics must have exactly the array element type.
+
+The `atomic_store_*` functions use Tile IR's view-based atomic reductions and
+require Tile IR bytecode v13.3 or newer. The destination may be a `TileArray`
+or a `TiledView` returned by `eachtile`; tile updates are broadcast to the
+selected window. These operations always use relaxed, device-wide ordering
+and return `nothing`. Addition supports `Int32`, `Int64`, `UInt32`, `UInt64`,
+`Float16`, `BFloat16`, `Float32`, and `Float64`; the other reductions support
+the four integer types. `BFloat16` addition also requires Hopper (sm_90) or
+newer.
+
+`ct.@atomic` provides statement and value forms:
+
+```julia
+ct.@atomic windows[i, j] += update
+ct.@atomic counters[i] = max(counters[i], value)
+old_new = ct.@atomic counters[i] + value
+```
+
+Statement forms return `nothing` and default to relaxed (`:monotonic`)
+ordering. Value forms return `old => new` and default to
+`:acquire_release`. The supported operators are `+`, `-`, `max`, `min`, `&`,
+`|`, and `⊻`. An explicit leading order may be `:monotonic`, `:acquire`,
+`:release`, or `:acquire_release`; ordered statements and value forms require
+a `TileArray`, while `TiledView` reductions support only `:monotonic`.
 
 ### Performance Tuning
 

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -2114,8 +2114,7 @@ end
                                token, memory_ordering, memory_scope, mode) -> Value
 
 Atomic read-modify-write of `value` into the tile selected by `index` within
-`view`. Unlike `AtomicRMWPtrOp`, it does not return the old value — only the
-ordering token.
+`view`. Returns an ordering token.
 Opcode: 117 (Tile IR v13.3+)
 """
 function encode_AtomicRedViewTkoOp!(cb::CodeBuilder,
@@ -2130,19 +2129,12 @@ function encode_AtomicRedViewTkoOp!(cb::CodeBuilder,
     cb.version >= v"13.3" ||
         throw(IRError("AtomicRedViewTkoOp requires Tile IR v13.3+, got v$(cb.version)"))
     encode_varint!(cb.buf, Opcode.AtomicRedViewTkoOp)
-    # Variadic result types (just token)
     encode_typeid_seq!(cb.buf, [token_type])
-
-    # Flags
     flags = token !== nothing ? 1 : 0
     encode_varint!(cb.buf, flags)
-
-    # Attributes
     encode_enum!(cb.buf, memory_ordering)
     encode_enum!(cb.buf, memory_scope)
     encode_enum!(cb.buf, mode)
-
-    # Operands
     encode_operand!(cb.buf, view)
     encode_sized_operands!(cb.buf, index)
     encode_operand!(cb.buf, value)

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -101,6 +101,7 @@ module Opcode
     # 113 (AllocaOp) not implemented
     const MmaFScaledOp = 114 # since 13.3
     const MakeStridedViewOp = 116 # since 13.3
+    const AtomicRedViewTkoOp = 117 # since 13.3
     const InsertOp = 118     # since 13.4
 end
 
@@ -2106,6 +2107,48 @@ function encode_AtomicRMWPtrOp!(cb::CodeBuilder,
     encode_optional_operand!(cb.buf, token)
 
     return new_op!(cb, 2)
+end
+
+"""
+    encode_AtomicRedViewTkoOp!(cb, token_type, view, index, value;
+                               token, memory_ordering, memory_scope, mode) -> Value
+
+Atomic read-modify-write of `value` into the tile selected by `index` within
+`view`. Unlike `AtomicRMWPtrOp`, it does not return the old value — only the
+ordering token.
+Opcode: 117 (Tile IR v13.3+)
+"""
+function encode_AtomicRedViewTkoOp!(cb::CodeBuilder,
+                                    token_type::TypeId,
+                                    view::Value,
+                                    index::Vector{Value},
+                                    value::Value;
+                                    token::Union{Value, Nothing}=nothing,
+                                    memory_ordering::MemoryOrderingSemantics.T=MemoryOrderingSemantics.Relaxed,
+                                    memory_scope::MemoryScope.T=MemoryScope.Device,
+                                    mode::AtomicRMWMode.T=AtomicRMWMode.ADD)
+    cb.version >= v"13.3" ||
+        throw(IRError("AtomicRedViewTkoOp requires Tile IR v13.3+, got v$(cb.version)"))
+    encode_varint!(cb.buf, Opcode.AtomicRedViewTkoOp)
+    # Variadic result types (just token)
+    encode_typeid_seq!(cb.buf, [token_type])
+
+    # Flags
+    flags = token !== nothing ? 1 : 0
+    encode_varint!(cb.buf, flags)
+
+    # Attributes
+    encode_enum!(cb.buf, memory_ordering)
+    encode_enum!(cb.buf, memory_scope)
+    encode_enum!(cb.buf, mode)
+
+    # Operands
+    encode_operand!(cb.buf, view)
+    encode_sized_operands!(cb.buf, index)
+    encode_operand!(cb.buf, value)
+    encode_optional_operand!(cb.buf, token)
+
+    return new_op!(cb)
 end
 
 #=============================================================================

--- a/src/compiler/analysis/effects.jl
+++ b/src/compiler/analysis/effects.jl
@@ -30,7 +30,7 @@ function classify_memory_op(resolved_func)
         return MEM_STORE
     elseif resolved_func === Intrinsics.print_tko
         return MEM_STORE
-    elseif is_atomic_intrinsic(resolved_func)
+    elseif is_atomic_intrinsic(resolved_func) || is_atomic_red_view(resolved_func)
         return MEM_STORE
     else
         return MEM_NONE
@@ -41,6 +41,18 @@ function is_atomic_intrinsic(func)
     isdefined(Intrinsics, :atomic_cas) && func === Intrinsics.atomic_cas && return true
     for op in (:atomic_xchg, :atomic_add, :atomic_max, :atomic_min,
                :atomic_or, :atomic_and, :atomic_xor)
+        isdefined(Intrinsics, op) && func === getfield(Intrinsics, op) && return true
+    end
+    return false
+end
+
+# View-based atomic reductions are relaxed-only and carry no memory_order
+# operand, so they are treated as plain (token-ordered) stores rather than as
+# `is_atomic_intrinsic` — no acquire/release fence handling, never eligible for
+# the parallel-store optimization (get_parallel_stores).
+function is_atomic_red_view(func)
+    for op in (:atomic_red_view_add, :atomic_red_view_max, :atomic_red_view_min,
+               :atomic_red_view_or, :atomic_red_view_and, :atomic_red_view_xor)
         isdefined(Intrinsics, op) && func === getfield(Intrinsics, op) && return true
     end
     return false

--- a/src/compiler/analysis/effects.jl
+++ b/src/compiler/analysis/effects.jl
@@ -46,10 +46,7 @@ function is_atomic_intrinsic(func)
     return false
 end
 
-# View-based atomic reductions are relaxed-only and carry no memory_order
-# operand, so they are treated as plain (token-ordered) stores rather than as
-# `is_atomic_intrinsic` — no acquire/release fence handling, never eligible for
-# the parallel-store optimization (get_parallel_stores).
+# Relaxed view atomics use ordinary store token ordering.
 function is_atomic_red_view(func)
     for op in (:atomic_red_view_add, :atomic_red_view_max, :atomic_red_view_min,
                :atomic_red_view_or, :atomic_red_view_and, :atomic_red_view_xor)

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -104,6 +104,25 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.atomic_cas), args)
     CGVal(old_val, result_tile_type, Tile{elem_type, TupleType(julia_shape)}, shape)
 end
 
+"""
+    select_rmw_mode(base_mode, elem_type) -> AtomicRMWMode.T
+
+Refine a base RMW mode for `elem_type`, mirroring Python's `_select_rmw_mode`:
+floating-point `add` selects `ADDF`, and unsigned `max`/`min` select the
+unsigned `UMAX`/`UMIN` comparisons. All other modes pass through unchanged
+(signedness is irrelevant to `xchg` and the bitwise ops).
+"""
+function select_rmw_mode(base_mode::AtomicRMWMode.T, @nospecialize(elem_type))
+    if elem_type <: AbstractFloat
+        base_mode == AtomicRMWMode.ADD ? AtomicRMWMode.ADDF : base_mode
+    elseif elem_type <: Unsigned
+        base_mode == AtomicRMWMode.MAX ? AtomicRMWMode.UMAX :
+        base_mode == AtomicRMWMode.MIN ? AtomicRMWMode.UMIN : base_mode
+    else
+        base_mode
+    end
+end
+
 # cuda_tile.atomic_rmw_tko (shared helper for atomic RMW operations)
 function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode.T)
     cb = ctx.cb
@@ -136,11 +155,9 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode.
     result_tile_type = tile_type!(tt, dtype, shape)
     token_type = Token(tt)
 
-    # Use float add mode for floating point types
-    actual_mode = mode
-    if mode == AtomicRMWMode.ADD && elem_type <: AbstractFloat
-        actual_mode = AtomicRMWMode.ADDF
-    end
+    # Refine mode for element signedness: float add → ADDF, unsigned
+    # max/min → UMAX/UMIN.
+    actual_mode = select_rmw_mode(mode, elem_type)
 
     # Emit atomic RMW
     mem_ordering = convert_enum(MemoryOrderingSemantics, memory_order)
@@ -170,8 +187,8 @@ end
 # cuda_tile.atomic_rmw_tko variants
 for (op, mode, desc) in ((:xchg, AtomicRMWMode.XCHG, "exchange (`val`, returning the old value)"),
                          (:add,  AtomicRMWMode.ADD,  "integer addition (or floating-point addition for AbstractFloat element types, via `cuda_tile.atomic_rmw_tko`'s `addf` mode)"),
-                         (:max,  AtomicRMWMode.MAX,  "signed maximum"),
-                         (:min,  AtomicRMWMode.MIN,  "signed minimum"),
+                         (:max,  AtomicRMWMode.MAX,  "maximum (signed for `Signed`, unsigned via `umax` for `Unsigned`)"),
+                         (:min,  AtomicRMWMode.MIN,  "minimum (signed for `Signed`, unsigned via `umin` for `Unsigned`)"),
                          (:or,   AtomicRMWMode.OR,   "bitwise OR"),
                          (:and,  AtomicRMWMode.AND,  "bitwise AND"),
                          (:xor,  AtomicRMWMode.XOR,  "bitwise XOR"))

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -104,14 +104,6 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.atomic_cas), args)
     CGVal(old_val, result_tile_type, Tile{elem_type, TupleType(julia_shape)}, shape)
 end
 
-"""
-    select_rmw_mode(base_mode, elem_type) -> AtomicRMWMode.T
-
-Refine a base RMW mode for `elem_type`, mirroring Python's `_select_rmw_mode`:
-floating-point `add` selects `ADDF`, and unsigned `max`/`min` select the
-unsigned `UMAX`/`UMIN` comparisons. All other modes pass through unchanged
-(signedness is irrelevant to `xchg` and the bitwise ops).
-"""
 function select_rmw_mode(base_mode::AtomicRMWMode.T, @nospecialize(elem_type))
     if elem_type <: AbstractFloat
         base_mode == AtomicRMWMode.ADD ? AtomicRMWMode.ADDF : base_mode
@@ -155,8 +147,6 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode.
     result_tile_type = tile_type!(tt, dtype, shape)
     token_type = Token(tt)
 
-    # Refine mode for element signedness: float add → ADDF, unsigned
-    # max/min → UMAX/UMIN.
     actual_mode = select_rmw_mode(mode, elem_type)
     check_atomic_bf16_support(cb, actual_mode, elem_type)
 
@@ -220,36 +210,26 @@ for (op, mode, desc) in ((:xchg, AtomicRMWMode.XCHG, "exchange (`val`, returning
     end
 end
 
-# cuda_tile.atomic_red_view_tko (view-based atomic reduction)
-
-# Element types accepted by each reduction mode (operations.md:5247-5253).
+# cuda_tile.atomic_red_view_tko
 const RED_VIEW_INT_DTYPES = (Int32, Int64, UInt32, UInt64)
 const RED_VIEW_ADD_DTYPES = (RED_VIEW_INT_DTYPES..., Float16, BFloat16, Float32, Float64)
 
-# ADDF on bf16 requires bytecode ≥ 13.3 (13.3 release note); shared with the
-# rmw path, which can reach ADDF+bf16 on older bytecode.
 function check_atomic_bf16_support(cb::CodeBuilder, mode::AtomicRMWMode.T, @nospecialize(elem_type))
     if mode == AtomicRMWMode.ADDF && elem_type === BFloat16 && cb.version < v"13.3"
         throw(IRError("atomic add on BFloat16 requires Tile IR bytecode ≥ 13.3, got v$(cb.version)"))
     end
 end
 
-# Shared emission for the six `atomic_red_view_*` intrinsics. Mirrors the
-# view-store side of views.jl (view + index + value, single token result), but
-# fixes the ordering to relaxed/device and carries a reduction mode.
 function emit_atomic_red_view!(ctx::CGCtx, args::AbstractVector,
                                base_mode::AtomicRMWMode.T, name::String)
     cb = ctx.cb
     tt = ctx.tt
 
-    # Friendly version gate ahead of the encoder's hard IRError.
     cb.version >= v"13.3" ||
         throw(IRError("$name requires Tile IR bytecode ≥ 13.3 (tileiras too old), got v$(cb.version)"))
 
-    # Input token appended by token_order_pass!.
     input_token = extract_token_arg!(ctx, args)
 
-    # args: (view, value, indices)
     view_arg = emit_value!(ctx, args[1])
     view_arg === nothing && throw(IRError("$name requires a view argument"))
     view_arg.v === nothing && throw(IRError("$name requires a materialized view"))
@@ -294,10 +274,8 @@ for (op, mode) in ((:add, AtomicRMWMode.ADD), (:max, AtomicRMWMode.MAX), (:min, 
     docstring = """
         Intrinsics.$name(view, value::Tile, indices::NTuple) -> Nothing
 
-    Token-ordered atomic reduction ($op) into the tile of `view` selected by
-    `indices`; lowers to `cuda_tile.atomic_red_view_tko` (relaxed, device).
-    Returns nothing — unlike `atomic_rmw_tko`, the old value is not read back.
-    The token argument is appended by `token_order_pass!`.
+    Apply an atomic $op reduction to a tile of `view`. Uses relaxed,
+    device-wide ordering and returns `nothing`.
     """
     @eval begin
         @doc $docstring @intrinsic $name(view, value, indices)

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -158,6 +158,7 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode.
     # Refine mode for element signedness: float add → ADDF, unsigned
     # max/min → UMAX/UMIN.
     actual_mode = select_rmw_mode(mode, elem_type)
+    check_atomic_bf16_support(cb, actual_mode, elem_type)
 
     # Emit atomic RMW
     mem_ordering = convert_enum(MemoryOrderingSemantics, memory_order)

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -218,3 +218,92 @@ for (op, mode, desc) in ((:xchg, AtomicRMWMode.XCHG, "exchange (`val`, returning
         end
     end
 end
+
+# cuda_tile.atomic_red_view_tko (view-based atomic reduction)
+
+# Element types accepted by each reduction mode (operations.md:5247-5253).
+const RED_VIEW_INT_DTYPES = (Int32, Int64, UInt32, UInt64)
+const RED_VIEW_ADD_DTYPES = (RED_VIEW_INT_DTYPES..., Float16, BFloat16, Float32, Float64)
+
+# ADDF on bf16 requires bytecode ≥ 13.3 (13.3 release note); shared with the
+# rmw path, which can reach ADDF+bf16 on older bytecode.
+function check_atomic_bf16_support(cb::CodeBuilder, mode::AtomicRMWMode.T, @nospecialize(elem_type))
+    if mode == AtomicRMWMode.ADDF && elem_type === BFloat16 && cb.version < v"13.3"
+        throw(IRError("atomic add on BFloat16 requires Tile IR bytecode ≥ 13.3, got v$(cb.version)"))
+    end
+end
+
+# Shared emission for the six `atomic_red_view_*` intrinsics. Mirrors the
+# view-store side of views.jl (view + index + value, single token result), but
+# fixes the ordering to relaxed/device and carries a reduction mode.
+function emit_atomic_red_view!(ctx::CGCtx, args::AbstractVector,
+                               base_mode::AtomicRMWMode.T, name::String)
+    cb = ctx.cb
+    tt = ctx.tt
+
+    # Friendly version gate ahead of the encoder's hard IRError.
+    cb.version >= v"13.3" ||
+        throw(IRError("$name requires Tile IR bytecode ≥ 13.3 (tileiras too old), got v$(cb.version)"))
+
+    # Input token appended by token_order_pass!.
+    input_token = extract_token_arg!(ctx, args)
+
+    # args: (view, value, indices)
+    view_arg = emit_value!(ctx, args[1])
+    view_arg === nothing && throw(IRError("$name requires a view argument"))
+    view_arg.v === nothing && throw(IRError("$name requires a materialized view"))
+    view_arg.constant === nothing && throw(IRError("$name: view missing ndim info"))
+    ndim = something(view_arg.constant)
+
+    value_tv = emit_value!(ctx, args[2])
+    value_tv === nothing && throw(IRError("$name requires a value"))
+    elem_type = eltype(CC.widenconst(value_tv.jltype))
+
+    supported = base_mode == AtomicRMWMode.ADD ? RED_VIEW_ADD_DTYPES : RED_VIEW_INT_DTYPES
+    elem_type in supported ||
+        throw(IRError("$name: unsupported element type $elem_type"))
+
+    mode = select_rmw_mode(base_mode, elem_type)
+    check_atomic_bf16_support(cb, mode, elem_type)
+
+    index_tvs = resolve_tuple(ctx, args[3], "$name indices")
+    index_vals = Value[tv.v for tv in index_tvs]
+    index_jl_types = Type[tv.jltype for tv in index_tvs]
+    unique_types = unique(index_jl_types)
+    length(unique_types) <= 1 || throw(IRError("All index types must match, got: $unique_types"))
+    isempty(unique_types) && ndim > 0 && throw(IRError("$name: indices required for $(ndim)D view"))
+    index_jl_type = isempty(unique_types) ? Int32 : unique_types[1]
+    index_type = tile_type_for_julia!(ctx, index_jl_type)
+    index_vals = pad_indices(ctx, index_vals, ndim, index_type, index_jl_type)
+    reverse!(index_vals)
+
+    token_type = Token(tt)
+    result_token = encode_AtomicRedViewTkoOp!(cb, token_type, view_arg.v, index_vals, value_tv.v;
+                                              token=input_token,
+                                              memory_ordering=MemoryOrderingSemantics.Relaxed,
+                                              memory_scope=MemoryScope.Device,
+                                              mode=mode)
+    ctx.result_tokens[ctx.current_ssa_idx] = result_token
+    return nothing
+end
+
+for (op, mode) in ((:add, AtomicRMWMode.ADD), (:max, AtomicRMWMode.MAX), (:min, AtomicRMWMode.MIN),
+                   (:or, AtomicRMWMode.OR), (:and, AtomicRMWMode.AND), (:xor, AtomicRMWMode.XOR))
+    name = Symbol(:atomic_red_view_, op)
+    docstring = """
+        Intrinsics.$name(view, value::Tile, indices::NTuple) -> Nothing
+
+    Token-ordered atomic reduction ($op) into the tile of `view` selected by
+    `indices`; lowers to `cuda_tile.atomic_red_view_tko` (relaxed, device).
+    Returns nothing — unlike `atomic_rmw_tko`, the old value is not read back.
+    The token argument is appended by `token_order_pass!`.
+    """
+    @eval begin
+        @doc $docstring @intrinsic $name(view, value, indices)
+        tfunc(𝕃, ::typeof(Intrinsics.$name), @nospecialize args...) = Nothing
+        efunc(::typeof(Intrinsics.$name), effects::CC.Effects) =
+            CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+        emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.$name), args) =
+            emit_atomic_red_view!(ctx, args, $mode, $(string(name)))
+    end
+end

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -148,7 +148,7 @@ function emit_atomic_rmw!(ctx::CGCtx, args::AbstractVector, mode::AtomicRMWMode.
     token_type = Token(tt)
 
     actual_mode = select_rmw_mode(mode, elem_type)
-    check_atomic_bf16_support(cb, actual_mode, elem_type)
+    check_atomic_bf16_support(ctx, actual_mode, elem_type)
 
     # Emit atomic RMW
     mem_ordering = convert_enum(MemoryOrderingSemantics, memory_order)
@@ -214,9 +214,18 @@ end
 const RED_VIEW_INT_DTYPES = (Int32, Int64, UInt32, UInt64)
 const RED_VIEW_ADD_DTYPES = (RED_VIEW_INT_DTYPES..., Float16, BFloat16, Float32, Float64)
 
-function check_atomic_bf16_support(cb::CodeBuilder, mode::AtomicRMWMode.T, @nospecialize(elem_type))
-    if mode == AtomicRMWMode.ADDF && elem_type === BFloat16 && cb.version < v"13.3"
-        throw(IRError("atomic add on BFloat16 requires Tile IR bytecode ≥ 13.3, got v$(cb.version)"))
+function check_atomic_bf16_support(ctx::CGCtx, mode::AtomicRMWMode.T, @nospecialize(elem_type))
+    mode == AtomicRMWMode.ADDF && elem_type === BFloat16 || return
+
+    if ctx.sm_arch !== nothing && ctx.sm_arch < v"9"
+        throw(IRError(
+            "atomic add on BFloat16 requires Hopper (sm_90) or newer, got " *
+            format_sm_arch(ctx.sm_arch)))
+    end
+    if ctx.cb.version < v"13.3"
+        throw(IRError(
+            "atomic add on BFloat16 requires Tile IR bytecode ≥ 13.3, got " *
+            "v$(ctx.cb.version)"))
     end
 end
 
@@ -245,7 +254,7 @@ function emit_atomic_red_view!(ctx::CGCtx, args::AbstractVector,
         throw(IRError("$name: unsupported element type $elem_type"))
 
     mode = select_rmw_mode(base_mode, elem_type)
-    check_atomic_bf16_support(cb, mode, elem_type)
+    check_atomic_bf16_support(ctx, mode, elem_type)
 
     index_tvs = resolve_tuple(ctx, args[3], "$name indices")
     index_vals = Value[tv.v for tv in index_tvs]

--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -89,7 +89,6 @@ public divmod
 @inline Base.:(-)(a::Tile{T, S}, b::Tile{T, S}) where {T <: AbstractFloat, S} = Intrinsics.subf(a, b)
 @inline Base.:(-)(a::Tile{T, S}, b::Tile{T, S}) where {T <: Integer, S} = Intrinsics.subi(a, b)
 
-# unary negation
 @inline Base.:(-)(a::Tile{T}) where {T <: AbstractFloat} = Intrinsics.negf(a)
 @inline Base.:(-)(a::Tile{T}) where {T <: Integer} = Intrinsics.negi(a)
 

--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -89,6 +89,10 @@ public divmod
 @inline Base.:(-)(a::Tile{T, S}, b::Tile{T, S}) where {T <: AbstractFloat, S} = Intrinsics.subf(a, b)
 @inline Base.:(-)(a::Tile{T, S}, b::Tile{T, S}) where {T <: Integer, S} = Intrinsics.subi(a, b)
 
+# unary negation
+@inline Base.:(-)(a::Tile{T}) where {T <: AbstractFloat} = Intrinsics.negf(a)
+@inline Base.:(-)(a::Tile{T}) where {T <: Integer} = Intrinsics.negi(a)
+
 # All other tile arithmetic (*, -, /, ^, comparisons, ifelse, etc.) is handled
 # by the generic Broadcast.copy → map path: scalar @overlay methods or Julia's
 # native implementations provide the element-wise logic, and map handles

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -152,7 +152,8 @@ function atomic_xchg end
     atomic_max(array::TileArray, index, val; memory_order, memory_scope) -> T
 
 Atomic maximum. Atomically replaces the value at `index` with `max(old, val)`
-and returns the original value. Index is 1-indexed.
+and returns the original value. Index is 1-indexed. The comparison is signed
+for `Signed` element types and unsigned for `Unsigned` ones.
 """
 function atomic_max end
 
@@ -160,7 +161,8 @@ function atomic_max end
     atomic_min(array::TileArray, index, val; memory_order, memory_scope) -> T
 
 Atomic minimum. Atomically replaces the value at `index` with `min(old, val)`
-and returns the original value. Index is 1-indexed.
+and returns the original value. Index is 1-indexed. The comparison is signed
+for `Signed` element types and unsigned for `Unsigned` ones.
 """
 function atomic_min end
 

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -208,9 +208,7 @@ for op in (:add, :xchg, :max, :min, :or, :and, :xor)
     end
 
     if bitwise
-        # Bitwise atomics require the update to exactly match the array element
-        # type — no implicit conversion (mirrors cuTile Python's
-        # `_cast_rmw_update_dtype`). add/max/min/xchg convert below.
+        # Bitwise atomics do not convert the update.
         @eval @inline function $fname(array::TileArray{T}, indices, val::TileOrScalar;
                                        kwargs...) where {T}
             throw(ArgumentError($("$fname requires the update value to exactly match " *
@@ -226,43 +224,30 @@ for op in (:add, :xchg, :max, :min, :or, :and, :xor)
     end
 end
 
-# ============================================================================
-# View-based atomic reductions (atomic_store_add/max/min/or/and/xor)
-#
-# Reduce a whole tile into a view and return `nothing`, without reading back
-# the old values; these lower to `cuda_tile.atomic_red_view_tko` (relaxed,
-# device). Unlike the pointer-style `atomic_*`, they take no
-# `memory_order`/`memory_scope`/`mask`/`check_bounds` keywords. Out-of-bounds
-# handling comes from the view: partial tiles are clipped, and a tile that lies
-# entirely out of bounds is undefined. Requires Tile IR bytecode ≥ 13.3.
-# ============================================================================
+# View-based atomic reductions
 
 """
     atomic_store_add(dst, index, update) -> Nothing
 
-Atomically reduce `update` into the tile of `dst` selected by `index`, without
-reading back the old values. `dst` is a `TileArray` (the update tile's shape
-selects the partition) or a `TiledView` from [`eachtile`](@ref). `update`
-broadcasts to the view's tile shape. The reduction is relaxed/device-scoped.
+Reduce `update` into a tile of `dst` without returning its previous value.
+`dst` may be a `TileArray` or a `TiledView` from [`eachtile`](@ref). Updates
+broadcast to the tile shape. The operation uses relaxed, device-wide ordering.
 
 Also available: `atomic_store_max`, `atomic_store_min`, `atomic_store_or`,
-`atomic_store_and`, `atomic_store_xor`. The bitwise variants require `update`
-to exactly match the destination element type; `add`/`max`/`min` convert.
+`atomic_store_and`, and `atomic_store_xor`. Bitwise updates must have the
+destination element type.
 
 Requires Tile IR bytecode ≥ 13.3.
 """
 function atomic_store_add end
 
-# Coerce an update tile to `Target` element type: arithmetic ops convert,
-# bitwise ops require an exact match (mirrors Python's `_cast_rmw_update_dtype`).
-@inline _red_update(::Type{Target}, tile::Tile{Target}, bitwise::Bool) where {Target} = tile
-@inline function _red_update(::Type{Target}, tile::Tile, bitwise::Bool) where {Target}
+@inline atomic_red_update(::Type{Target}, tile::Tile{Target}, bitwise::Bool) where {Target} = tile
+@inline function atomic_red_update(::Type{Target}, tile::Tile, bitwise::Bool) where {Target}
     bitwise && throw(ArgumentError("bitwise atomic reduction requires the update tile element type to exactly match the destination; no implicit conversion"))
     convert(Tile{Target}, tile)
 end
 
-# Atomic reductions cannot use views with a padding value. Preserve the
-# TiledView's partition/strided layout, but materialize it without load padding.
+# Tile IR atomic views cannot carry padding.
 @inline function make_atomic_tile_view(
         tiles::TiledView{A, RequestedShape, Shape, Shape}) where {A, RequestedShape, Shape}
     parent = tiles.parent
@@ -284,9 +269,8 @@ for op in (:add, :max, :min, :or, :and, :xor)
     intrinsic = Symbol(:atomic_red_view_, op)
     bitwise = op in (:or, :and, :xor)
 
-    # TileArray: the update tile's shape drives the partition view.
     @eval @inline function $fname(arr::TileArray{T}, index, tile::Tile) where {T}
-        update = _red_update(T, tile, $bitwise)
+        update = atomic_red_update(T, tile, $bitwise)
         reshaped = _reshape_to_rank(update, Val(ndims(arr)))
         tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
         pv = Intrinsics.make_partition_view(tv, size(reshaped), PaddingMode.Undetermined, nothing)
@@ -295,9 +279,6 @@ for op in (:add, :max, :min, :or, :and, :xor)
     end
     @eval @inline $fname(arr::TileArray{T}, index::Integer, tile::Tile) where {T} =
         $fname(arr, (index,), tile)
-    # Scalar update → 1-element tile. Arithmetic converts to the array element
-    # type; bitwise requires an exact match. (A single `Number` method — a
-    # diagonal `val::T` method would be shadowed by this one.)
     if bitwise
         @eval @inline function $fname(arr::TileArray{T}, index, val::Number) where {T}
             val isa T || throw(ArgumentError($("$fname requires the update value to exactly " *
@@ -312,11 +293,10 @@ for op in (:add, :max, :min, :or, :and, :xor)
         end
     end
 
-    # TiledView: update broadcasts to the view's tile shape (eachtile windows).
     @eval @inline function $fname(tiles::TiledView{A}, index::NTuple{N, <:Integer},
                                   tile::Tile) where {A, N}
         N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
-        update = _red_update(eltype(A), tile, $bitwise)
+        update = atomic_red_update(eltype(A), tile, $bitwise)
         view = make_atomic_tile_view(tiles)
         Intrinsics.$intrinsic(view, broadcast_to(update, tiled_view_shape(tiles)),
                               promote(index...) .- One())
@@ -326,83 +306,59 @@ for op in (:add, :max, :min, :or, :and, :xor)
         $fname(tiles, (index,), tile)
 end
 
-# ============================================================================
-# `@atomic` — Base-style atomic operators
-#
-# Statement forms (`A[i] += v`, `A[i] = op(A[i], v)`) return `nothing`. Value
-# forms (`A[i] + v`, `max(A[i], v)`) follow Base and return `old => new`.
-#
-# The two forms use different default orderings (see the macro docstring):
-# statement forms default to Relaxed, so a tile or view target lowers to
-# `atomic_red_view_tko`; value forms default to AcqRel, matching the
-# `ct.atomic_*` functions.
-# ============================================================================
+# `@atomic`
 
 public @atomic
 
-const _TileIndex = Union{Integer, Tuple{Vararg{Integer}}}
-const _GatherIndex = Union{Tile, Tuple{Vararg{Tile}}}
+const AtomicTileIndex = Union{Integer, Tuple{Vararg{Integer}}}
+const AtomicGatherIndex = Union{Tile, Tuple{Vararg{Tile}}}
 
-# op function → (view-reduction fn, fetching fn, update transform). `-` negates
-# the update and adds (Tile IR has no atomic subtract).
-_red_op(::typeof(+))   = (atomic_store_add, atomic_add, identity)
-_red_op(::typeof(-))   = (atomic_store_add, atomic_add, -)
-_red_op(::typeof(max)) = (atomic_store_max, atomic_max, identity)
-_red_op(::typeof(min)) = (atomic_store_min, atomic_min, identity)
-_red_op(::typeof(&))   = (atomic_store_and, atomic_and, identity)
-_red_op(::typeof(|))   = (atomic_store_or,  atomic_or,  identity)
-_red_op(::typeof(xor)) = (atomic_store_xor, atomic_xor, identity)
+atomic_red_op(::typeof(+))   = (atomic_store_add, atomic_add, identity)
+atomic_red_op(::typeof(-))   = (atomic_store_add, atomic_add, -)
+atomic_red_op(::typeof(max)) = (atomic_store_max, atomic_max, identity)
+atomic_red_op(::typeof(min)) = (atomic_store_min, atomic_min, identity)
+atomic_red_op(::typeof(&))   = (atomic_store_and, atomic_and, identity)
+atomic_red_op(::typeof(|))   = (atomic_store_or,  atomic_or,  identity)
+atomic_red_op(::typeof(xor)) = (atomic_store_xor, atomic_xor, identity)
 
-# Statement-form lowering. The macro picks the relaxed or ordered path at
-# expansion time (it knows the ordering literally); the choice between a view
-# reduction and a fetching atomic below is by target type only, so no branch on
-# the ordering value is emitted inside the kernel.
-
-# Relaxed: a tile or view target reduces into the view; a gather target fetches.
 @inline function atomic_reduce_relaxed!(target::Union{TileArray, TiledView},
-                                        index::_TileIndex, op::F, val) where {F}
-    store_fn, _, transform = _red_op(op)
+                                        index::AtomicTileIndex, op::F, val) where {F}
+    store_fn, _, transform = atomic_red_op(op)
     store_fn(target, index, transform(val))
     return nothing
 end
-@inline function atomic_reduce_relaxed!(target::TileArray, index::_GatherIndex,
+@inline function atomic_reduce_relaxed!(target::TileArray, index::AtomicGatherIndex,
                                         op::F, val) where {F}
-    _, fetch_fn, transform = _red_op(op)
+    _, fetch_fn, transform = atomic_red_op(op)
     fetch_fn(target, index, transform(val); memory_order=MemoryOrder.Relaxed)
     return nothing
 end
 
-# Stronger ordering: read the old value and discard it (a TiledView cannot).
 @inline function atomic_reduce_ordered!(target::TileArray, index, op::F, val, order) where {F}
-    _, fetch_fn, transform = _red_op(op)
+    _, fetch_fn, transform = atomic_red_op(op)
     fetch_fn(target, index, transform(val); memory_order=order)
     return nothing
 end
 @inline atomic_reduce_ordered!(::TiledView, index, op, val, order) =
-    throw(ArgumentError("@atomic on a TiledView must use the default (relaxed) ordering: a view reduction does not return the old value"))
+    throw(ArgumentError("@atomic on TiledView only supports relaxed ordering"))
 
-# Value-form lowering: fetch the old value, recompute `new` elementwise, and
-# return the `old => new` pair (matching Base).
-@inline _atomic_update(::Type{T}, op, val::Tile) where {T} = convert(Tile{T}, val)
-@inline _atomic_update(::Type{T}, op, val) where {T} = convert(T, val)
-@inline _atomic_update(::Type, ::typeof(&), val) = val
-@inline _atomic_update(::Type, ::typeof(|), val) = val
-@inline _atomic_update(::Type, ::typeof(xor), val) = val
+@inline atomic_update(::Type{T}, op, val::Tile) where {T} = convert(Tile{T}, val)
+@inline atomic_update(::Type{T}, op, val) where {T} = convert(T, val)
+@inline atomic_update(::Type, ::typeof(&), val) = val
+@inline atomic_update(::Type, ::typeof(|), val) = val
+@inline atomic_update(::Type, ::typeof(xor), val) = val
 
 @inline function atomic_fetch(target::TileArray{T}, index, op::F, val, order) where {T, F}
-    _, fetch_fn, transform = _red_op(op)
-    update = _atomic_update(T, op, val)
+    _, fetch_fn, transform = atomic_red_op(op)
+    update = atomic_update(T, op, val)
     old = fetch_fn(target, index, transform(update); memory_order=order)
     return old => op(old, update)
 end
 
-# --- macro parsing (runs at expansion time) ---
+const ATOMIC_OPASSIGN = Dict(Symbol("+=") => :+, Symbol("-=") => :-, Symbol("&=") => :&,
+                             Symbol("|=") => :|, Symbol("⊻=") => :⊻)
 
-const _OPASSIGN_SYM = Dict(Symbol("+=") => :+, Symbol("-=") => :-, Symbol("&=") => :&,
-                           Symbol("|=") => :|, Symbol("⊻=") => :⊻)
-
-# Map an operator symbol to its function value, rejecting unsupported ops.
-function _atomic_op_fn(sym)
+function atomic_op(sym)
     sym === :+ && return Base.:+
     sym === :- && return Base.:-
     sym === :max && return Base.max
@@ -413,8 +369,7 @@ function _atomic_op_fn(sym)
     error("@atomic: unsupported operator `$sym`; expected +, -, max, min, &, |, or ⊻")
 end
 
-# Map an ordering symbol to a MemoryOrder value; `nothing` when none was given.
-function _atomic_order(order_arg)
+function atomic_order(order_arg)
     order_arg === nothing && return nothing
     sym = order_arg isa QuoteNode ? order_arg.value : order_arg
     sym isa Symbol || error("@atomic: ordering must be a symbol, e.g. :monotonic")
@@ -427,9 +382,7 @@ function _atomic_order(order_arg)
     error("@atomic: unknown ordering :$sym")
 end
 
-# Build the statement-form call. Statement default is Relaxed; the relaxed vs
-# ordered choice is made here so the ordering is never compared inside the kernel.
-function _atomic_statement(target, idx, op, val, order)
+function atomic_statement(target, idx, op, val, order)
     if order === nothing || order === MemoryOrder.Relaxed
         :($atomic_reduce_relaxed!($target, $idx, $op, $val))
     else
@@ -437,8 +390,7 @@ function _atomic_statement(target, idx, op, val, order)
     end
 end
 
-# `A[i]` / `A[i,j]` → (target, index-expr). Errors on any other LHS.
-function _atomic_target(ref)
+function atomic_target(ref)
     ref isa Expr && ref.head === :ref ||
         error("@atomic: expected an indexed reference like A[i] on the left, got `$ref`")
     inds = ref.args[2:end]
@@ -446,24 +398,22 @@ function _atomic_target(ref)
     return ref.args[1], idx
 end
 
-function _atomic_macro(order_arg, ex)
-    order = _atomic_order(order_arg)
+function atomic_macro(order_arg, ex)
+    order = atomic_order(order_arg)
     head = ex isa Expr ? ex.head : nothing
 
-    # Statement form: A[i] op= v
-    if haskey(_OPASSIGN_SYM, head)
-        target, idx = _atomic_target(ex.args[1])
-        op = _atomic_op_fn(_OPASSIGN_SYM[head])
-        return esc(_atomic_statement(target, idx, op, ex.args[2], order))
+    if haskey(ATOMIC_OPASSIGN, head)
+        target, idx = atomic_target(ex.args[1])
+        op = atomic_op(ATOMIC_OPASSIGN[head])
+        return esc(atomic_statement(target, idx, op, ex.args[2], order))
     end
 
-    # Statement form: A[i] = op(A[i], v)
     if head === :(=)
         lhs, rhs = ex.args
         (rhs isa Expr && rhs.head === :call && length(rhs.args) == 3) ||
             error("@atomic: plain `A[i] = v` is unsupported; write `A[i] op= v` or `A[i] = op(A[i], v)`")
-        target, idx = _atomic_target(lhs)
-        op = _atomic_op_fn(rhs.args[1])
+        target, idx = atomic_target(lhs)
+        op = atomic_op(rhs.args[1])
         a, b = rhs.args[2], rhs.args[3]
         if a != lhs
             b == lhs &&
@@ -471,13 +421,12 @@ function _atomic_macro(order_arg, ex)
             error("@atomic: the right-hand `op(...)` must reference the left-hand `$lhs`")
         end
         val = b
-        return esc(_atomic_statement(target, idx, op, val, order))
+        return esc(atomic_statement(target, idx, op, val, order))
     end
 
-    # Value form: A[i] + v  or  op(A[i], v)  → old => new
     if head === :call && length(ex.args) == 3
-        op = _atomic_op_fn(ex.args[1])
-        target, idx = _atomic_target(ex.args[2])
+        op = atomic_op(ex.args[1])
+        target, idx = atomic_target(ex.args[2])
         ord = order === nothing ? MemoryOrder.AcqRel : order
         return esc(:($atomic_fetch($target, $idx, $op, $(ex.args[3]), $ord)))
     end
@@ -500,18 +449,17 @@ Value forms follow Base and return `old => new`:
     pair = @atomic A[i] + v        # pair.first == old, pair.second == new
 
 An optional leading ordering symbol maps to Tile IR memory orderings:
-`:monotonic`→Relaxed, `:acquire`, `:release`, `:acquire_release`→AcqRel.
+`:monotonic` maps to Relaxed; `:acquire`, `:release`, and
+`:acquire_release` map directly.
 `:sequentially_consistent` is rejected (no Tile IR equivalent).
 
-The two forms use different default orderings. **Statement forms default to
-`:monotonic` (Relaxed)**, so a tile or view target reduces into the view via
-`atomic_red_view_tko`. **Value forms default to `:acquire_release`**, matching
-`ct.atomic_*`. Under a stronger ordering a statement instead reads the old
-value with `atomic_*` and discards it.
+Statement forms default to `:monotonic`; value forms default to
+`:acquire_release`. Stronger statement orderings use `atomic_*` and discard
+the result.
 """
 macro atomic(ex)
-    _atomic_macro(nothing, ex)
+    atomic_macro(nothing, ex)
 end
 macro atomic(order, ex)
-    _atomic_macro(order, ex)
+    atomic_macro(order, ex)
 end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -447,8 +447,12 @@ function _atomic_macro(order_arg, ex)
         target, idx = _atomic_target(lhs)
         op = _atomic_op_fn(rhs.args[1])
         a, b = rhs.args[2], rhs.args[3]
-        val = a == lhs ? b : b == lhs ? a :
-              error("@atomic: the right-hand `op(...)` must reference the left-hand `$lhs`")
+        if a != lhs
+            b == lhs &&
+                error("@atomic: the first argument to `op(...)` must be the left-hand `$lhs`")
+            error("@atomic: the right-hand `op(...)` must reference the left-hand `$lhs`")
+        end
+        val = b
         return esc(_atomic_statement(target, idx, op, val, order))
     end
 

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -193,6 +193,7 @@ function atomic_xor end
 for op in (:add, :xchg, :max, :min, :or, :and, :xor)
     fname = Symbol(:atomic_, op)
     intrinsic = Symbol(:atomic_, op)
+    bitwise = op in (:or, :and, :xor)
 
     @eval @inline function $fname(array::TileArray{T}, indices, val::TileOrScalar{T};
                                    check_bounds::Bool=true,
@@ -204,10 +205,21 @@ for op in (:add, :xchg, :max, :min, :or, :and, :xor)
         S === () ? Intrinsics.to_scalar(result) : result
     end
 
-    @eval @inline function $fname(array::TileArray{T}, indices, val::TileOrScalar;
-                                   check_bounds::Bool=true,
-                                   memory_order::MemoryOrder.T=MemoryOrder.AcqRel,
-                                   memory_scope::MemScope.T=MemScope.Device) where {T}
-        $fname(array, indices, T(val); check_bounds, memory_order, memory_scope)
+    if bitwise
+        # Bitwise atomics require the update to exactly match the array element
+        # type — no implicit conversion (mirrors cuTile Python's
+        # `_cast_rmw_update_dtype`). add/max/min/xchg convert below.
+        @eval @inline function $fname(array::TileArray{T}, indices, val::TileOrScalar;
+                                       kwargs...) where {T}
+            throw(ArgumentError($("$fname requires the update value to exactly match " *
+                "the array element type; bitwise atomics do not convert implicitly")))
+        end
+    else
+        @eval @inline function $fname(array::TileArray{T}, indices, val::TileOrScalar;
+                                       check_bounds::Bool=true,
+                                       memory_order::MemoryOrder.T=MemoryOrder.AcqRel,
+                                       memory_scope::MemScope.T=MemScope.Device) where {T}
+            $fname(array, indices, T(val); check_bounds, memory_order, memory_scope)
+        end
     end
 end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -127,7 +127,8 @@ end
     atomic_add(array::TileArray, index, val; memory_order, memory_scope) -> T
 
 Atomic addition. Atomically adds `val` to the value at `index` and returns
-the original value. Index is 1-indexed.
+the original value. Index is 1-indexed. `BFloat16` requires Tile IR bytecode
+≥ 13.3 and Hopper (sm_90) or newer.
 
 # Example
 ```julia
@@ -237,7 +238,8 @@ Also available: `atomic_store_max`, `atomic_store_min`, `atomic_store_or`,
 `atomic_store_and`, and `atomic_store_xor`. Bitwise updates must have the
 destination element type.
 
-Requires Tile IR bytecode ≥ 13.3.
+Requires Tile IR bytecode ≥ 13.3. `BFloat16` addition requires Hopper (sm_90)
+or newer.
 """
 function atomic_store_add end
 

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -261,6 +261,24 @@ function atomic_store_add end
     convert(Tile{Target}, tile)
 end
 
+# Atomic reductions cannot use views with a padding value. Preserve the
+# TiledView's partition/strided layout, but materialize it without load padding.
+@inline function make_atomic_tile_view(
+        tiles::TiledView{A, RequestedShape, Shape, Shape}) where {A, RequestedShape, Shape}
+    parent = tiles.parent
+    tv = Intrinsics.make_tensor_view(typeof(parent), parent.ptr, parent.sizes, parent.strides)
+    Intrinsics.make_partition_view(
+        tv, tiled_view_shape(tiles), PaddingMode.Undetermined, tiled_view_order(tiles))
+end
+@inline function make_atomic_tile_view(
+        tiles::TiledView{A, RequestedShape, Shape, Step}) where {A, RequestedShape, Shape, Step}
+    parent = tiles.parent
+    tv = Intrinsics.make_tensor_view(typeof(parent), parent.ptr, parent.sizes, parent.strides)
+    Intrinsics.make_strided_view(
+        tv, tiled_view_shape(tiles), tiled_view_step(tiles),
+        PaddingMode.Undetermined, tiled_view_order(tiles))
+end
+
 for op in (:add, :max, :min, :or, :and, :xor)
     fname = Symbol(:atomic_store_, op)
     intrinsic = Symbol(:atomic_red_view_, op)
@@ -299,7 +317,7 @@ for op in (:add, :max, :min, :or, :and, :xor)
                                   tile::Tile) where {A, N}
         N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
         update = _red_update(eltype(A), tile, $bitwise)
-        view = make_tile_view(tiles)
+        view = make_atomic_tile_view(tiles)
         Intrinsics.$intrinsic(view, broadcast_to(update, tiled_view_shape(tiles)),
                               promote(index...) .- One())
         return nothing

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -3,6 +3,8 @@
 # Provides atomic compare-and-swap, exchange, and add operations for TileArrays.
 
 public atomic_cas, atomic_xchg, atomic_add, atomic_max, atomic_min, atomic_or, atomic_and, atomic_xor
+public atomic_store_add, atomic_store_max, atomic_store_min,
+       atomic_store_or, atomic_store_and, atomic_store_xor
 
 """
 Memory ordering for atomic operations.
@@ -222,4 +224,74 @@ for op in (:add, :xchg, :max, :min, :or, :and, :xor)
             $fname(array, indices, T(val); check_bounds, memory_order, memory_scope)
         end
     end
+end
+
+# ============================================================================
+# View-based atomic reductions (atomic_store_add/max/min/or/and/xor)
+#
+# Reduce a whole tile into a view and return `nothing`, without reading back
+# the old values; these lower to `cuda_tile.atomic_red_view_tko` (relaxed,
+# device). Unlike the pointer-style `atomic_*`, they take no
+# `memory_order`/`memory_scope`/`mask`/`check_bounds` keywords. Out-of-bounds
+# handling comes from the view: partial tiles are clipped, and a tile that lies
+# entirely out of bounds is undefined. Requires Tile IR bytecode ≥ 13.3.
+# ============================================================================
+
+"""
+    atomic_store_add(dst, index, update) -> Nothing
+
+Atomically reduce `update` into the tile of `dst` selected by `index`, without
+reading back the old values. `dst` is a `TileArray` (the update tile's shape
+selects the partition) or a `TiledView` from [`eachtile`](@ref). `update`
+broadcasts to the view's tile shape. The reduction is relaxed/device-scoped.
+
+Also available: `atomic_store_max`, `atomic_store_min`, `atomic_store_or`,
+`atomic_store_and`, `atomic_store_xor`. The bitwise variants require `update`
+to exactly match the destination element type; `add`/`max`/`min` convert.
+
+Requires Tile IR bytecode ≥ 13.3.
+"""
+function atomic_store_add end
+
+# Coerce an update tile to `Target` element type: arithmetic ops convert,
+# bitwise ops require an exact match (mirrors Python's `_cast_rmw_update_dtype`).
+@inline _red_update(::Type{Target}, tile::Tile{Target}, bitwise::Bool) where {Target} = tile
+@inline function _red_update(::Type{Target}, tile::Tile, bitwise::Bool) where {Target}
+    bitwise && throw(ArgumentError("bitwise atomic reduction requires the update tile element type to exactly match the destination; no implicit conversion"))
+    convert(Tile{Target}, tile)
+end
+
+for op in (:add, :max, :min, :or, :and, :xor)
+    fname = Symbol(:atomic_store_, op)
+    intrinsic = Symbol(:atomic_red_view_, op)
+    bitwise = op in (:or, :and, :xor)
+
+    # TileArray: the update tile's shape drives the partition view.
+    @eval @inline function $fname(arr::TileArray{T}, index, tile::Tile) where {T}
+        update = _red_update(T, tile, $bitwise)
+        reshaped = _reshape_to_rank(update, Val(ndims(arr)))
+        tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
+        pv = Intrinsics.make_partition_view(tv, size(reshaped), PaddingMode.Undetermined, nothing)
+        Intrinsics.$intrinsic(pv, reshaped, promote(index...) .- One())
+        return nothing
+    end
+    @eval @inline $fname(arr::TileArray{T}, index::Integer, tile::Tile) where {T} =
+        $fname(arr, (index,), tile)
+    @eval @inline function $fname(arr::TileArray{T}, index, val::T) where {T}
+        shape = ntuple(_ -> 1, Val(ndims(arr)))
+        $fname(arr, index, reshape(Intrinsics.from_scalar(val, Tuple{}), shape))
+    end
+
+    # TiledView: update broadcasts to the view's tile shape (eachtile windows).
+    @eval @inline function $fname(tiles::TiledView{A}, index::NTuple{N, <:Integer},
+                                  tile::Tile) where {A, N}
+        N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
+        update = _red_update(eltype(A), tile, $bitwise)
+        view = make_tile_view(tiles)
+        Intrinsics.$intrinsic(view, broadcast_to(update, tiled_view_shape(tiles)),
+                              promote(index...) .- One())
+        return nothing
+    end
+    @eval @inline $fname(tiles::TiledView, index::Integer, tile::Tile) =
+        $fname(tiles, (index,), tile)
 end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -277,9 +277,21 @@ for op in (:add, :max, :min, :or, :and, :xor)
     end
     @eval @inline $fname(arr::TileArray{T}, index::Integer, tile::Tile) where {T} =
         $fname(arr, (index,), tile)
-    @eval @inline function $fname(arr::TileArray{T}, index, val::T) where {T}
-        shape = ntuple(_ -> 1, Val(ndims(arr)))
-        $fname(arr, index, reshape(Intrinsics.from_scalar(val, Tuple{}), shape))
+    # Scalar update → 1-element tile. Arithmetic converts to the array element
+    # type; bitwise requires an exact match. (A single `Number` method — a
+    # diagonal `val::T` method would be shadowed by this one.)
+    if bitwise
+        @eval @inline function $fname(arr::TileArray{T}, index, val::Number) where {T}
+            val isa T || throw(ArgumentError($("$fname requires the update value to exactly " *
+                "match the destination element type; bitwise reductions do not convert implicitly")))
+            shape = ntuple(_ -> 1, Val(ndims(arr)))
+            $fname(arr, index, reshape(Intrinsics.from_scalar(val, Tuple{}), shape))
+        end
+    else
+        @eval @inline function $fname(arr::TileArray{T}, index, val::Number) where {T}
+            shape = ntuple(_ -> 1, Val(ndims(arr)))
+            $fname(arr, index, reshape(Intrinsics.from_scalar(convert(T, val), Tuple{}), shape))
+        end
     end
 
     # TiledView: update broadcasts to the view's tile shape (eachtile windows).
@@ -294,4 +306,183 @@ for op in (:add, :max, :min, :or, :and, :xor)
     end
     @eval @inline $fname(tiles::TiledView, index::Integer, tile::Tile) =
         $fname(tiles, (index,), tile)
+end
+
+# ============================================================================
+# `@atomic` — Base-style atomic operators
+#
+# Statement forms (`A[i] += v`, `A[i] = op(A[i], v)`) return `nothing`. Value
+# forms (`A[i] + v`, `max(A[i], v)`) follow Base and return `old => new`.
+#
+# The two forms use different default orderings (see the macro docstring):
+# statement forms default to Relaxed, so a tile or view target lowers to
+# `atomic_red_view_tko`; value forms default to AcqRel, matching the
+# `ct.atomic_*` functions.
+# ============================================================================
+
+public @atomic
+
+const _TileIndex = Union{Integer, Tuple{Vararg{Integer}}}
+const _GatherIndex = Union{Tile, Tuple{Vararg{Tile}}}
+
+# op function → (view-reduction fn, fetching fn, update transform). `-` negates
+# the update and adds (Tile IR has no atomic subtract).
+_red_op(::typeof(+))   = (atomic_store_add, atomic_add, identity)
+_red_op(::typeof(-))   = (atomic_store_add, atomic_add, -)
+_red_op(::typeof(max)) = (atomic_store_max, atomic_max, identity)
+_red_op(::typeof(min)) = (atomic_store_min, atomic_min, identity)
+_red_op(::typeof(&))   = (atomic_store_and, atomic_and, identity)
+_red_op(::typeof(|))   = (atomic_store_or,  atomic_or,  identity)
+_red_op(::typeof(xor)) = (atomic_store_xor, atomic_xor, identity)
+
+# Statement-form lowering. The macro picks the relaxed or ordered path at
+# expansion time (it knows the ordering literally); the choice between a view
+# reduction and a fetching atomic below is by target type only, so no branch on
+# the ordering value is emitted inside the kernel.
+
+# Relaxed: a tile or view target reduces into the view; a gather target fetches.
+@inline function atomic_reduce_relaxed!(target::Union{TileArray, TiledView},
+                                        index::_TileIndex, op::F, val) where {F}
+    store_fn, _, transform = _red_op(op)
+    store_fn(target, index, transform(val))
+    return nothing
+end
+@inline function atomic_reduce_relaxed!(target::TileArray, index::_GatherIndex,
+                                        op::F, val) where {F}
+    _, fetch_fn, transform = _red_op(op)
+    fetch_fn(target, index, transform(val); memory_order=MemoryOrder.Relaxed)
+    return nothing
+end
+
+# Stronger ordering: read the old value and discard it (a TiledView cannot).
+@inline function atomic_reduce_ordered!(target::TileArray, index, op::F, val, order) where {F}
+    _, fetch_fn, transform = _red_op(op)
+    fetch_fn(target, index, transform(val); memory_order=order)
+    return nothing
+end
+@inline atomic_reduce_ordered!(::TiledView, index, op, val, order) =
+    throw(ArgumentError("@atomic on a TiledView must use the default (relaxed) ordering: a view reduction does not return the old value"))
+
+# Value-form lowering: fetch the old value, recompute `new` elementwise, and
+# return the `old => new` pair (matching Base).
+@inline function atomic_fetch(target, index, op::F, val, order) where {F}
+    _, fetch_fn, transform = _red_op(op)
+    old = fetch_fn(target, index, transform(val); memory_order=order)
+    return old => op(old, val)
+end
+
+# --- macro parsing (runs at expansion time) ---
+
+const _OPASSIGN_SYM = Dict(Symbol("+=") => :+, Symbol("-=") => :-, Symbol("&=") => :&,
+                           Symbol("|=") => :|, Symbol("⊻=") => :⊻)
+
+# Map an operator symbol to its function value, rejecting unsupported ops.
+function _atomic_op_fn(sym)
+    sym === :+ && return Base.:+
+    sym === :- && return Base.:-
+    sym === :max && return Base.max
+    sym === :min && return Base.min
+    sym === :& && return Base.:&
+    sym === :| && return Base.:|
+    (sym === :⊻ || sym === :xor) && return Base.xor
+    error("@atomic: unsupported operator `$sym`; expected +, -, max, min, &, |, or ⊻")
+end
+
+# Map an ordering symbol to a MemoryOrder value; `nothing` when none was given.
+function _atomic_order(order_arg)
+    order_arg === nothing && return nothing
+    sym = order_arg isa QuoteNode ? order_arg.value : order_arg
+    sym isa Symbol || error("@atomic: ordering must be a symbol, e.g. :monotonic")
+    sym === :monotonic && return MemoryOrder.Relaxed
+    sym === :acquire && return MemoryOrder.Acquire
+    sym === :release && return MemoryOrder.Release
+    sym === :acquire_release && return MemoryOrder.AcqRel
+    sym === :sequentially_consistent &&
+        error("@atomic: :sequentially_consistent has no Tile IR equivalent")
+    error("@atomic: unknown ordering :$sym")
+end
+
+# Build the statement-form call. Statement default is Relaxed; the relaxed vs
+# ordered choice is made here so the ordering is never compared inside the kernel.
+function _atomic_statement(target, idx, op, val, order)
+    if order === nothing || order === MemoryOrder.Relaxed
+        :($atomic_reduce_relaxed!($target, $idx, $op, $val))
+    else
+        :($atomic_reduce_ordered!($target, $idx, $op, $val, $order))
+    end
+end
+
+# `A[i]` / `A[i,j]` → (target, index-expr). Errors on any other LHS.
+function _atomic_target(ref)
+    ref isa Expr && ref.head === :ref ||
+        error("@atomic: expected an indexed reference like A[i] on the left, got `$ref`")
+    inds = ref.args[2:end]
+    idx = length(inds) == 1 ? inds[1] : Expr(:tuple, inds...)
+    return ref.args[1], idx
+end
+
+function _atomic_macro(order_arg, ex)
+    order = _atomic_order(order_arg)
+    head = ex isa Expr ? ex.head : nothing
+
+    # Statement form: A[i] op= v
+    if haskey(_OPASSIGN_SYM, head)
+        target, idx = _atomic_target(ex.args[1])
+        op = _atomic_op_fn(_OPASSIGN_SYM[head])
+        return esc(_atomic_statement(target, idx, op, ex.args[2], order))
+    end
+
+    # Statement form: A[i] = op(A[i], v)
+    if head === :(=)
+        lhs, rhs = ex.args
+        (rhs isa Expr && rhs.head === :call && length(rhs.args) == 3) ||
+            error("@atomic: plain `A[i] = v` is unsupported; write `A[i] op= v` or `A[i] = op(A[i], v)`")
+        target, idx = _atomic_target(lhs)
+        op = _atomic_op_fn(rhs.args[1])
+        a, b = rhs.args[2], rhs.args[3]
+        val = a == lhs ? b : b == lhs ? a :
+              error("@atomic: the right-hand `op(...)` must reference the left-hand `$lhs`")
+        return esc(_atomic_statement(target, idx, op, val, order))
+    end
+
+    # Value form: A[i] + v  or  op(A[i], v)  → old => new
+    if head === :call && length(ex.args) == 3
+        op = _atomic_op_fn(ex.args[1])
+        target, idx = _atomic_target(ex.args[2])
+        ord = order === nothing ? MemoryOrder.AcqRel : order
+        return esc(:($atomic_fetch($target, $idx, $op, $(ex.args[3]), $ord)))
+    end
+
+    error("@atomic: unsupported expression `$ex`")
+end
+
+"""
+    @atomic [order] expr
+
+Atomic reductions over a `TileArray`, `TiledView`, or gather target.
+
+Statement forms return `nothing`:
+
+    @atomic A[i] += v          # also -=, &=, |=, ⊻=
+    @atomic A[i] = max(A[i], v)  # op ∈ + - max min & | ⊻; RHS must reference A[i]
+
+Value forms follow Base and return `old => new`:
+
+    pair = @atomic A[i] + v        # pair.first == old, pair.second == new
+
+An optional leading ordering symbol maps to Tile IR memory orderings:
+`:monotonic`→Relaxed, `:acquire`, `:release`, `:acquire_release`→AcqRel.
+`:sequentially_consistent` is rejected (no Tile IR equivalent).
+
+The two forms use different default orderings. **Statement forms default to
+`:monotonic` (Relaxed)**, so a tile or view target reduces into the view via
+`atomic_red_view_tko`. **Value forms default to `:acquire_release`**, matching
+`ct.atomic_*`. Under a stronger ordering a statement instead reads the old
+value with `atomic_*` and discards it.
+"""
+macro atomic(ex)
+    _atomic_macro(nothing, ex)
+end
+macro atomic(order, ex)
+    _atomic_macro(order, ex)
 end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -365,10 +365,17 @@ end
 
 # Value-form lowering: fetch the old value, recompute `new` elementwise, and
 # return the `old => new` pair (matching Base).
-@inline function atomic_fetch(target, index, op::F, val, order) where {F}
+@inline _atomic_update(::Type{T}, op, val::Tile) where {T} = convert(Tile{T}, val)
+@inline _atomic_update(::Type{T}, op, val) where {T} = convert(T, val)
+@inline _atomic_update(::Type, ::typeof(&), val) = val
+@inline _atomic_update(::Type, ::typeof(|), val) = val
+@inline _atomic_update(::Type, ::typeof(xor), val) = val
+
+@inline function atomic_fetch(target::TileArray{T}, index, op::F, val, order) where {T, F}
     _, fetch_fn, transform = _red_op(op)
-    old = fetch_fn(target, index, transform(val); memory_order=order)
-    return old => op(old, val)
+    update = _atomic_update(T, op, val)
+    old = fetch_fn(target, index, transform(update); memory_order=order)
+    return old => op(old, update)
 end
 
 # --- macro parsing (runs at expansion time) ---

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2305,7 +2305,6 @@ end
             end
         end
 
-        # bf16 add uses ADDF and requires bytecode 13.3.
         spec_bf16 = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
@@ -2329,7 +2328,6 @@ end
 
     @testset "atomic_red_view_tko" begin
         spec2d = ct.ArraySpec{2}(16, true)
-        # TiledView (partition), 2D → relaxed device addf reduction.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
@@ -2342,7 +2340,6 @@ end
             end
         end
 
-        # TileArray direct, 1D.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
@@ -2354,7 +2351,6 @@ end
             end
         end
 
-        # Stepped (overlapping) eachtile → strided view, still relaxed device.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
@@ -2367,8 +2363,7 @@ end
             end
         end
 
-        # Load padding is not carried into the atomic view: Tile IR rejects a
-        # padding_value on atomic_red_view_tko.
+        # Atomic views ignore TiledView padding.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
@@ -2394,7 +2389,6 @@ end
             end
         end
 
-        # Unsigned max → umax mode.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}}) do a
@@ -2406,7 +2400,6 @@ end
             end
         end
 
-        # Token wiring: an atomic reduction after a store carries a token.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
@@ -2420,7 +2413,6 @@ end
             end
         end
 
-        # Bitwise reductions require an exact-eltype update tile.
         @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do a
             bid = ct.bid(1)
             val = ct.broadcast_to(ct.Tile(Int32(1)), (16,))  # Int32 into Int64
@@ -2428,7 +2420,6 @@ end
             return
         end
 
-        # Wrong-rank tile index for a TiledView.
         @test_throws "expected" code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
             tiles = ct.eachtile(a, (16, 16))
             val = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
@@ -2440,7 +2431,6 @@ end
     @testset "@atomic macro" begin
         spec2d = ct.ArraySpec{2}(16, true)
 
-        # Statement form, default (relaxed) on a tile/view target → view reduction.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
@@ -2452,7 +2442,6 @@ end
             end
         end
 
-        # Statement form with an explicit stronger order → fetch (atomic_rmw_tko).
         @test @filecheck begin
             @check_label "entry"
             @check_not "atomic_red_view_tko"
@@ -2464,7 +2453,6 @@ end
             end
         end
 
-        # Value form → fetch with the old => new pair consumed.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
@@ -2477,7 +2465,6 @@ end
             end
         end
 
-        # Macro-expansion errors.
         @test_throws "sequentially_consistent" macroexpand(@__MODULE__,
             :(ct.@atomic :sequentially_consistent a[1] += 1))
         @test_throws "indexed reference" macroexpand(@__MODULE__,
@@ -2490,8 +2477,7 @@ end
             :(ct.@atomic a[1] = 2))
     end
 
-    # Unsigned max/min select the umax/umin comparison modes.
-    @testset "unsigned atomic_max/min → umax/umin" begin
+    @testset "unsigned atomic_max/min modes" begin
         for T in (UInt32, UInt64)
             @test @filecheck begin
                 @check_label "entry"
@@ -2505,7 +2491,6 @@ end
                 end
             end
         end
-        # Signed stays signed.
         @test @filecheck begin
             @check_label "entry"
             @check_not "umax"
@@ -2518,14 +2503,12 @@ end
         end
     end
 
-    # Bitwise atomics require the update to exactly match the array eltype.
     @testset "reject bitwise atomic dtype mismatch" begin
         @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr
             bid = ct.bid(1)
             ct.atomic_or(arr, bid, Int32(1))  # Int32 update into Int64 array
             return
         end
-        # add/max/min still convert implicitly.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2306,6 +2306,34 @@ end
         end
     end
 
+    # Unsigned max/min select the umax/umin comparison modes.
+    @testset "unsigned atomic_max/min → umax/umin" begin
+        for T in (UInt32, UInt64)
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{T,1,spec1d}}) do arr
+                    bid = ct.bid(1)
+                    @check "atomic_rmw_tko{{.*}}umax"
+                    ct.atomic_max(arr, bid, zero(eltype(arr)))
+                    @check "atomic_rmw_tko{{.*}}umin"
+                    ct.atomic_min(arr, bid, zero(eltype(arr)))
+                    return
+                end
+            end
+        end
+        # Signed stays signed.
+        @test @filecheck begin
+            @check_label "entry"
+            @check_not "umax"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do arr
+                bid = ct.bid(1)
+                @check "atomic_rmw_tko{{.*}}max"
+                ct.atomic_max(arr, bid, Int32(0))
+                return
+            end
+        end
+    end
+
     # `weak` ordering is not supported on atomics; reject at the boundary.
     @testset "reject MemoryOrder.Weak" begin
         spec = ct.ArraySpec{1}(16, true)

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2334,6 +2334,25 @@ end
         end
     end
 
+    # Bitwise atomics require the update to exactly match the array eltype.
+    @testset "reject bitwise atomic dtype mismatch" begin
+        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr
+            bid = ct.bid(1)
+            ct.atomic_or(arr, bid, Int32(1))  # Int32 update into Int64 array
+            return
+        end
+        # add/max/min still convert implicitly.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr
+                bid = ct.bid(1)
+                @check "atomic_rmw_tko"
+                ct.atomic_add(arr, bid, Int32(1))
+                return
+            end
+        end
+    end
+
     # `weak` ordering is not supported on atomics; reject at the boundary.
     @testset "reject MemoryOrder.Weak" begin
         spec = ct.ArraySpec{1}(16, true)

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2306,6 +2306,89 @@ end
         end
     end
 
+    @testset "atomic_red_view_tko" begin
+        spec2d = ct.ArraySpec{2}(16, true)
+        # TiledView (partition), 2D → relaxed device addf reduction.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                tiles = ct.eachtile(a, (16, 16))
+                val = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
+                @check "make_partition_view"
+                @check "atomic_red_view_tko relaxed device{{.*}}addf"
+                ct.atomic_store_add(tiles, (1, 1), val)
+                return
+            end
+        end
+
+        # TileArray direct, 1D.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+                bid = ct.bid(1)
+                val = ct.broadcast_to(ct.Tile(Int32(1)), (16,))
+                @check "atomic_red_view_tko relaxed device{{.*}}, add,"
+                ct.atomic_store_add(a, bid, val)
+                return
+            end
+        end
+
+        # Stepped (overlapping) eachtile → strided view, still relaxed device.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                tiles = ct.eachtile(a, (16,); step=(8,))
+                val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
+                @check "make_strided_view"
+                @check "atomic_red_view_tko relaxed device{{.*}}addf"
+                ct.atomic_store_add(tiles, 1, val)
+                return
+            end
+        end
+
+        # Unsigned max → umax mode.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}}) do a
+                bid = ct.bid(1)
+                val = ct.broadcast_to(ct.Tile(UInt32(1)), (16,))
+                @check "atomic_red_view_tko relaxed device{{.*}}umax"
+                ct.atomic_store_max(a, bid, val)
+                return
+            end
+        end
+
+        # Token wiring: an atomic reduction after a store carries a token.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                bid = ct.bid(1)
+                tile = ct.load(a, bid, (16,))
+                @check "store_view_tko{{.*}}token = [[TOK:%[^ ]+]]"
+                ct.store(a, bid, tile)
+                @check "atomic_red_view_tko{{.*}}token ="
+                ct.atomic_store_add(a, bid, tile)
+                return
+            end
+        end
+
+        # Bitwise reductions require an exact-eltype update tile.
+        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do a
+            bid = ct.bid(1)
+            val = ct.broadcast_to(ct.Tile(Int32(1)), (16,))  # Int32 into Int64
+            ct.atomic_store_or(a, bid, val)
+            return
+        end
+
+        # Wrong-rank tile index for a TiledView.
+        @test_throws "expected" code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            tiles = ct.eachtile(a, (16, 16))
+            val = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
+            ct.atomic_store_add(tiles, (1, 1, 1), val)  # 3 indices for a 2D view
+            return
+        end
+    end
+
     # Unsigned max/min select the umax/umin comparison modes.
     @testset "unsigned atomic_max/min → umax/umin" begin
         for T in (UInt32, UInt64)

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2304,6 +2304,27 @@ end
                 return
             end
         end
+
+        # bf16 add uses ADDF and requires bytecode 13.3.
+        spec_bf16 = ct.ArraySpec{1}(16, true)
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(
+                    Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                    bytecode_version=v"13.3") do arr
+                indices = ct.arange(16; dtype=Int)
+                @check "atomic_rmw_tko{{.*}}addf"
+                ct.atomic_add(arr, indices, ct.BFloat16(1))
+                return
+            end
+        end
+        @test_throws "BFloat16 requires Tile IR bytecode ≥ 13.3" code_tiled(
+                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                bytecode_version=v"13.2") do arr
+            indices = ct.arange(16; dtype=Int)
+            ct.atomic_add(arr, indices, ct.BFloat16(1))
+            return
+        end
     end
 
     @testset "atomic_red_view_tko" begin

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2310,6 +2310,7 @@ end
             @check_label "entry"
             code_tiled(
                     Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                    sm_arch=v"9.0",
                     bytecode_version=v"13.3") do arr
                 indices = ct.arange(16; dtype=Int)
                 @check "atomic_rmw_tko{{.*}}addf"
@@ -2317,8 +2318,17 @@ end
                 return
             end
         end
+        @test_throws "requires Hopper (sm_90) or newer, got sm_80" code_tiled(
+                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                sm_arch=v"8.0",
+                bytecode_version=v"13.3") do arr
+            indices = ct.arange(16; dtype=Int)
+            ct.atomic_add(arr, indices, ct.BFloat16(1))
+            return
+        end
         @test_throws "BFloat16 requires Tile IR bytecode ≥ 13.3" code_tiled(
                 Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                sm_arch=v"9.0",
                 bytecode_version=v"13.2") do arr
             indices = ct.arange(16; dtype=Int)
             ct.atomic_add(arr, indices, ct.BFloat16(1))
@@ -2398,6 +2408,16 @@ end
                 ct.atomic_store_max(a, bid, val)
                 return
             end
+        end
+
+        spec_bf16 = ct.ArraySpec{1}(16, true)
+        @test_throws "requires Hopper (sm_90) or newer, got sm_80" code_tiled(
+                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                sm_arch=v"8.0",
+                bytecode_version=v"13.3") do a
+            val = ct.broadcast_to(ct.Tile(ct.BFloat16(1)), (16,))
+            ct.atomic_store_add(a, 1, val)
+            return
         end
 
         @test @filecheck begin

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2436,6 +2436,8 @@ end
             :(ct.@atomic a += 1))
         @test_throws "must reference" macroexpand(@__MODULE__,
             :(ct.@atomic a[1] = min(b[1], 2)))
+        @test_throws "first argument" macroexpand(@__MODULE__,
+            :(ct.@atomic a[1] = 2 - a[1]))
         @test_throws "plain" macroexpand(@__MODULE__,
             :(ct.@atomic a[1] = 2))
     end

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2346,6 +2346,33 @@ end
             end
         end
 
+        # Load padding is not carried into the atomic view: Tile IR rejects a
+        # padding_value on atomic_red_view_tko.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                tiles = ct.eachtile(a, (16,); padding_mode=ct.PaddingMode.Zero)
+                val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
+                @check "make_partition_view"
+                @check "atomic_red_view_tko relaxed device{{.*}}addf"
+                ct.atomic_store_add(tiles, 1, val)
+                return
+            end
+        end
+
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                tiles = ct.eachtile(
+                    a, (16,); step=(8,), padding_mode=ct.PaddingMode.Zero)
+                val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
+                @check "make_strided_view"
+                @check "atomic_red_view_tko relaxed device{{.*}}addf"
+                ct.atomic_store_add(tiles, 1, val)
+                return
+            end
+        end
+
         # Unsigned max → umax mode.
         @test @filecheck begin
             @check_label "entry"

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2389,6 +2389,57 @@ end
         end
     end
 
+    @testset "@atomic macro" begin
+        spec2d = ct.ArraySpec{2}(16, true)
+
+        # Statement form, default (relaxed) on a tile/view target → view reduction.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                tiles = ct.eachtile(a, (16, 16))
+                v = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
+                @check "atomic_red_view_tko relaxed device{{.*}}addf"
+                ct.@atomic tiles[1, 1] += v
+                return
+            end
+        end
+
+        # Statement form with an explicit stronger order → fetch (atomic_rmw_tko).
+        @test @filecheck begin
+            @check_label "entry"
+            @check_not "atomic_red_view_tko"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+                bid = ct.bid(1)
+                @check "atomic_rmw_tko acq_rel"
+                ct.@atomic :acquire_release a[bid] += Int32(1)
+                return
+            end
+        end
+
+        # Value form → fetch with the old => new pair consumed.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+                bid = ct.bid(1)
+                @check "atomic_rmw_tko"
+                pair = ct.@atomic a[bid] + Int32(3)
+                Base.donotdelete(pair.first)
+                Base.donotdelete(pair.second)
+                return
+            end
+        end
+
+        # Macro-expansion errors.
+        @test_throws "sequentially_consistent" macroexpand(@__MODULE__,
+            :(ct.@atomic :sequentially_consistent a[1] += 1))
+        @test_throws "indexed reference" macroexpand(@__MODULE__,
+            :(ct.@atomic a += 1))
+        @test_throws "must reference" macroexpand(@__MODULE__,
+            :(ct.@atomic a[1] = min(b[1], 2)))
+        @test_throws "plain" macroexpand(@__MODULE__,
+            :(ct.@atomic a[1] = 2))
+    end
+
     # Unsigned max/min select the umax/umin comparison modes.
     @testset "unsigned atomic_max/min → umax/umin" begin
         for T in (UInt32, UInt64)

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -446,6 +446,157 @@ end
     @test result == expected
 end
 
+# ============================================================================
+# View-based atomic reductions (atomic_store_*, cuda_tile.atomic_red_view_tko)
+# ============================================================================
+
+@testset "atomic_store reductions (multi-block)" begin
+    N = 16
+    n_blocks = 16
+
+    # add (Int32)
+    function k_add(a::ct.TileArray{Int32,1})
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(Int32(1)), (16,)))
+        return
+    end
+    a = CUDA.zeros(Int32, N)
+    @cuda backend=cuTile blocks=n_blocks k_add(a)
+    @test all(Array(a) .== n_blocks)
+
+    # add (Float32)
+    function k_addf(a::ct.TileArray{Float32,1})
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(1.5f0), (16,)))
+        return
+    end
+    af = CUDA.zeros(Float32, N)
+    @cuda backend=cuTile blocks=n_blocks k_addf(af)
+    @test all(isapprox.(Array(af), n_blocks * 1.5f0))
+
+    # max
+    function k_max(a::ct.TileArray{Int32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_max(tiles, 1, ct.broadcast_to(ct.Tile(Int32(bid)), (16,)))
+        return
+    end
+    a = CUDA.zeros(Int32, N)
+    @cuda backend=cuTile blocks=n_blocks k_max(a)
+    @test all(Array(a) .== n_blocks)
+
+    # min
+    function k_min(a::ct.TileArray{Int32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_min(tiles, 1, ct.broadcast_to(ct.Tile(Int32(bid)), (16,)))
+        return
+    end
+    a = CUDA.fill(Int32(999), N)
+    @cuda backend=cuTile blocks=n_blocks k_min(a)
+    @test all(Array(a) .== 1)
+
+    # or (bitwise; exact eltype)
+    function k_or(a::ct.TileArray{Int32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_or(tiles, 1, ct.broadcast_to(ct.Tile(Int32(bid)), (16,)))
+        return
+    end
+    a = CUDA.zeros(Int32, N)
+    @cuda backend=cuTile blocks=n_blocks k_or(a)
+    @test all(Array(a) .== reduce(|, Int32(1):Int32(n_blocks)))
+
+    # and (bitwise; exact eltype)
+    function k_and(a::ct.TileArray{Int32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_and(tiles, 1, ct.broadcast_to(ct.Tile(Int32(bid)), (16,)))
+        return
+    end
+    a = CUDA.fill(Int32(-1), N)
+    @cuda backend=cuTile blocks=n_blocks k_and(a)
+    @test all(Array(a) .== foldl(&, Int32(1):Int32(n_blocks); init=Int32(-1)))
+
+    # xor (bitwise; exact eltype)
+    function k_xor(a::ct.TileArray{Int32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_xor(tiles, 1, ct.broadcast_to(ct.Tile(Int32(bid)), (16,)))
+        return
+    end
+    a = CUDA.zeros(Int32, N)
+    @cuda backend=cuTile blocks=n_blocks k_xor(a)
+    @test all(Array(a) .== reduce(xor, Int32(1):Int32(n_blocks)))
+end
+
+@testset "atomic_store_add broadcast update shapes" begin
+    # 16x16 view; updates of shape (), (1,16), (16,1) each broadcast to the tile.
+    function k_scalar(a::ct.TileArray{Float32,2})
+        ct.atomic_store_add(ct.eachtile(a, (16, 16)), (1, 1), ct.Tile(1.0f0))
+        return
+    end
+    function k_row(a::ct.TileArray{Float32,2})
+        ct.atomic_store_add(ct.eachtile(a, (16, 16)), (1, 1),
+                            ct.broadcast_to(ct.Tile(1.0f0), (1, 16)))
+        return
+    end
+    function k_col(a::ct.TileArray{Float32,2})
+        ct.atomic_store_add(ct.eachtile(a, (16, 16)), (1, 1),
+                            ct.broadcast_to(ct.Tile(1.0f0), (16, 1)))
+        return
+    end
+    n_blocks = 8
+    for k in (k_scalar, k_row, k_col)
+        a = CUDA.zeros(Float32, 16, 16)
+        @cuda backend=cuTile blocks=n_blocks k(a)
+        @test all(isapprox.(Array(a), Float32(n_blocks)))
+    end
+end
+
+@testset "atomic_store_add boundary partial tile" begin
+    # 20-element array, tile 16 → tile 2 is partial (only elements 17..20 exist).
+    function k(a::ct.TileArray{Float32,1})
+        tiles = ct.eachtile(a, (16,))
+        ct.atomic_store_add(tiles, 2, ct.broadcast_to(ct.Tile(1.0f0), (16,)))
+        return
+    end
+    a = CUDA.zeros(Float32, 20)
+    @cuda backend=cuTile k(a)
+    r = Array(a)
+    @test all(r[1:16] .== 0)   # tile 1 untouched
+    @test all(r[17:20] .== 1)  # tile 2's in-bounds part; OOB clipped
+end
+
+@testset "atomic_store_add stepped (overlapping) windows" begin
+    # tile 16, step 8 over 24 elements → 3 windows, overlap gets summed twice.
+    function k(a::ct.TileArray{Float32,1})
+        bid = ct.bid(1)
+        tiles = ct.eachtile(a, (16,); step=(8,))
+        ct.atomic_store_add(tiles, bid, ct.broadcast_to(ct.Tile(1.0f0), (16,)))
+        return
+    end
+    a = CUDA.zeros(Float32, 24)
+    @cuda backend=cuTile blocks=3 k(a)
+    r = Array(a)
+    @test all(r[1:8] .== 1)    # window 1 only
+    @test all(r[9:24] .== 2)   # covered by two windows
+end
+
+@testset "atomic_store_add f16/bf16" begin
+    for T in (Float16, ct.BFloat16)
+        function k(a::ct.TileArray{T,1}) where {T}
+            tiles = ct.eachtile(a, (16,))
+            ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(one(eltype(a))), (16,)))
+            return
+        end
+        n_blocks = 8
+        a = CUDA.zeros(T, 16)
+        @cuda backend=cuTile blocks=n_blocks k(a)
+        @test all(Array(a) .== T(n_blocks))
+    end
+end
+
 @testset "1D gather - simple" begin
     # Simple 1D gather: copy first 16 elements using gather
     function gather_simple_kernel(src::ct.TileArray{Float32,1}, dst::ct.TileArray{Float32,1})

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -369,8 +369,6 @@ end
 end
 
 @testset "atomic_max/min UInt32 (unsigned compare)" begin
-    # 0x80000000 has the high bit set: largest as unsigned, negative as signed.
-    # A signed max/min would disagree with the expected unsigned result.
     function atomic_umax_kernel(out::ct.TileArray{UInt32,1})
         ct.atomic_max(out, 1, 0x80000000; memory_order=ct.MemoryOrder.AcqRel)
         return
@@ -382,11 +380,11 @@ end
 
     out_max = CUDA.fill(0x00000001, 1)
     @cuda backend=cuTile blocks=8 atomic_umax_kernel(out_max)
-    @test Array(out_max)[1] == 0x80000000  # umax; signed would keep 0x00000001
+    @test Array(out_max)[1] == 0x80000000
 
     out_min = CUDA.fill(0x80000000, 1)
     @cuda backend=cuTile blocks=8 atomic_umin_kernel(out_min)
-    @test Array(out_min)[1] == 0x00000001  # umin; signed would keep 0x80000000
+    @test Array(out_min)[1] == 0x00000001
 end
 
 @testset "atomic_or Int" begin
@@ -428,8 +426,6 @@ end
 @testset "atomic_xor Int" begin
     function atomic_xor_kernel(out::ct.TileArray{Int,1})
         bid = ct.bid(1)
-        # XOR with bid — each bid XORs once. `Int(bid)` matches the array
-        # element type: bitwise atomics require an exact-type update.
         ct.atomic_xor(out, 1, Int(bid);
                      memory_order=ct.MemoryOrder.AcqRel)
         return
@@ -446,15 +442,12 @@ end
     @test result == expected
 end
 
-# ============================================================================
-# View-based atomic reductions (atomic_store_*, cuda_tile.atomic_red_view_tko)
-# ============================================================================
+# View-based atomic reductions
 
 @testset "atomic_store reductions (multi-block)" begin
     N = 16
     n_blocks = 16
 
-    # add (Int32)
     function k_add(a::ct.TileArray{Int32,1})
         tiles = ct.eachtile(a, (16,))
         ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(Int32(1)), (16,)))
@@ -464,7 +457,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_add(a)
     @test all(Array(a) .== n_blocks)
 
-    # add (Float32)
     function k_addf(a::ct.TileArray{Float32,1})
         tiles = ct.eachtile(a, (16,))
         ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(1.5f0), (16,)))
@@ -474,7 +466,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_addf(af)
     @test all(isapprox.(Array(af), n_blocks * 1.5f0))
 
-    # max
     function k_max(a::ct.TileArray{Int32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,))
@@ -485,7 +476,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_max(a)
     @test all(Array(a) .== n_blocks)
 
-    # min
     function k_min(a::ct.TileArray{Int32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,))
@@ -496,7 +486,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_min(a)
     @test all(Array(a) .== 1)
 
-    # or (bitwise; exact eltype)
     function k_or(a::ct.TileArray{Int32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,))
@@ -507,7 +496,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_or(a)
     @test all(Array(a) .== reduce(|, Int32(1):Int32(n_blocks)))
 
-    # and (bitwise; exact eltype)
     function k_and(a::ct.TileArray{Int32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,))
@@ -518,7 +506,6 @@ end
     @cuda backend=cuTile blocks=n_blocks k_and(a)
     @test all(Array(a) .== foldl(&, Int32(1):Int32(n_blocks); init=Int32(-1)))
 
-    # xor (bitwise; exact eltype)
     function k_xor(a::ct.TileArray{Int32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,))
@@ -531,7 +518,6 @@ end
 end
 
 @testset "atomic_store_add broadcast update shapes" begin
-    # 16x16 view; updates of shape (), (1,16), (16,1) each broadcast to the tile.
     function k_scalar(a::ct.TileArray{Float32,2})
         ct.atomic_store_add(ct.eachtile(a, (16, 16)), (1, 1), ct.Tile(1.0f0))
         return
@@ -555,7 +541,6 @@ end
 end
 
 @testset "atomic_store_add boundary partial tile" begin
-    # 20-element array, tile 16 → tile 2 is partial (only elements 17..20 exist).
     function k(a::ct.TileArray{Float32,1})
         tiles = ct.eachtile(a, (16,))
         ct.atomic_store_add(tiles, 2, ct.broadcast_to(ct.Tile(1.0f0), (16,)))
@@ -564,12 +549,11 @@ end
     a = CUDA.zeros(Float32, 20)
     @cuda backend=cuTile k(a)
     r = Array(a)
-    @test all(r[1:16] .== 0)   # tile 1 untouched
-    @test all(r[17:20] .== 1)  # tile 2's in-bounds part; OOB clipped
+    @test all(r[1:16] .== 0)
+    @test all(r[17:20] .== 1)
 end
 
 @testset "atomic_store_add stepped (overlapping) windows" begin
-    # tile 16, step 8 over 24 elements → 3 windows, overlap gets summed twice.
     function k(a::ct.TileArray{Float32,1})
         bid = ct.bid(1)
         tiles = ct.eachtile(a, (16,); step=(8,))
@@ -579,8 +563,8 @@ end
     a = CUDA.zeros(Float32, 24)
     @cuda backend=cuTile blocks=3 k(a)
     r = Array(a)
-    @test all(r[1:8] .== 1)    # window 1 only
-    @test all(r[9:24] .== 2)   # covered by two windows
+    @test all(r[1:8] .== 1)
+    @test all(r[9:24] .== 2)
 end
 
 @testset "atomic_store_add f16/bf16" begin
@@ -598,7 +582,6 @@ end
 end
 
 @testset "@atomic macro" begin
-    # Statement form, default relaxed → view reduction on a TiledView.
     function k_stmt(a::ct.TileArray{Float32,1})
         tiles = ct.eachtile(a, (16,))
         ct.@atomic tiles[1] += ct.broadcast_to(ct.Tile(1.0f0), (16,))
@@ -608,7 +591,6 @@ end
     @cuda backend=cuTile blocks=10 k_stmt(a)
     @test all(Array(a) .== 10)
 
-    # Statement form with an explicit stronger order → fetching path.
     function k_ordered(c::ct.TileArray{Int,1})
         ct.@atomic :acquire_release c[1] += 1
         return
@@ -617,7 +599,6 @@ end
     @cuda backend=cuTile blocks=100 k_ordered(c)
     @test Array(c)[1] == 100
 
-    # Subtraction lowers to add-of-negated.
     function k_sub(c::ct.TileArray{Int,1})
         ct.@atomic c[1] -= 2
         return
@@ -626,7 +607,6 @@ end
     @cuda backend=cuTile blocks=10 k_sub(c)
     @test Array(c)[1] == -20
 
-    # `= op(A[i], v)` statement form (max).
     function k_max(c::ct.TileArray{Int,1})
         bid = ct.bid(1)
         ct.@atomic c[1] = max(c[1], bid)
@@ -636,11 +616,10 @@ end
     @cuda backend=cuTile blocks=50 k_max(c)
     @test Array(c)[1] == 50
 
-    # Value form returns old => new.
     function k_value(c::ct.TileArray{Int,1}, out::ct.TileArray{Int,1})
         pair = ct.@atomic c[1] + 5
-        ct.store(out, 1, pair.first)   # old
-        ct.store(out, 2, pair.second)  # new
+        ct.store(out, 1, pair.first)
+        ct.store(out, 2, pair.second)
         return
     end
     c = CUDA.fill(Int(7), 1)
@@ -649,8 +628,6 @@ end
     @test Array(out) == [7, 12]
     @test Array(c)[1] == 12
 
-    # `new` uses the update converted to the target dtype, exactly like the
-    # atomic operation itself.
     function k_value_convert(c::ct.TileArray{Float32,1}, out::ct.TileArray{Float32,1})
         pair = ct.@atomic c[1] + 1.0
         ct.store(out, 1, pair.second)

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -569,6 +569,8 @@ end
 
 @testset "atomic_store_add f16/bf16" begin
     for T in (Float16, ct.BFloat16)
+        T === ct.BFloat16 && capability(device()) < v"9" && continue
+
         function k(a::ct.TileArray{T,1}) where {T}
             tiles = ct.eachtile(a, (16,))
             ct.atomic_store_add(tiles, 1, ct.broadcast_to(ct.Tile(one(eltype(a))), (16,)))

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -648,6 +648,19 @@ end
     @cuda backend=cuTile k_value(c, out)
     @test Array(out) == [7, 12]
     @test Array(c)[1] == 12
+
+    # `new` uses the update converted to the target dtype, exactly like the
+    # atomic operation itself.
+    function k_value_convert(c::ct.TileArray{Float32,1}, out::ct.TileArray{Float32,1})
+        pair = ct.@atomic c[1] + 1.0
+        ct.store(out, 1, pair.second)
+        return
+    end
+    c = CUDA.fill(Float32(16777216), 1)
+    out = CUDA.zeros(Float32, 1)
+    @cuda backend=cuTile k_value_convert(c, out)
+    @test Array(c)[1] == Float32(16777216)
+    @test Array(out)[1] == Array(c)[1]
 end
 
 @testset "1D gather - simple" begin

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -428,8 +428,9 @@ end
 @testset "atomic_xor Int" begin
     function atomic_xor_kernel(out::ct.TileArray{Int,1})
         bid = ct.bid(1)
-        # XOR with bid — each bid XORs once
-        ct.atomic_xor(out, 1, bid;
+        # XOR with bid — each bid XORs once. `Int(bid)` matches the array
+        # element type: bitwise atomics require an exact-type update.
+        ct.atomic_xor(out, 1, Int(bid);
                      memory_order=ct.MemoryOrder.AcqRel)
         return
     end

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -597,6 +597,59 @@ end
     end
 end
 
+@testset "@atomic macro" begin
+    # Statement form, default relaxed → view reduction on a TiledView.
+    function k_stmt(a::ct.TileArray{Float32,1})
+        tiles = ct.eachtile(a, (16,))
+        ct.@atomic tiles[1] += ct.broadcast_to(ct.Tile(1.0f0), (16,))
+        return
+    end
+    a = CUDA.zeros(Float32, 16)
+    @cuda backend=cuTile blocks=10 k_stmt(a)
+    @test all(Array(a) .== 10)
+
+    # Statement form with an explicit stronger order → fetching path.
+    function k_ordered(c::ct.TileArray{Int,1})
+        ct.@atomic :acquire_release c[1] += 1
+        return
+    end
+    c = CUDA.zeros(Int, 1)
+    @cuda backend=cuTile blocks=100 k_ordered(c)
+    @test Array(c)[1] == 100
+
+    # Subtraction lowers to add-of-negated.
+    function k_sub(c::ct.TileArray{Int,1})
+        ct.@atomic c[1] -= 2
+        return
+    end
+    c = CUDA.zeros(Int, 1)
+    @cuda backend=cuTile blocks=10 k_sub(c)
+    @test Array(c)[1] == -20
+
+    # `= op(A[i], v)` statement form (max).
+    function k_max(c::ct.TileArray{Int,1})
+        bid = ct.bid(1)
+        ct.@atomic c[1] = max(c[1], bid)
+        return
+    end
+    c = CUDA.zeros(Int, 1)
+    @cuda backend=cuTile blocks=50 k_max(c)
+    @test Array(c)[1] == 50
+
+    # Value form returns old => new.
+    function k_value(c::ct.TileArray{Int,1}, out::ct.TileArray{Int,1})
+        pair = ct.@atomic c[1] + 5
+        ct.store(out, 1, pair.first)   # old
+        ct.store(out, 2, pair.second)  # new
+        return
+    end
+    c = CUDA.fill(Int(7), 1)
+    out = CUDA.zeros(Int, 2)
+    @cuda backend=cuTile k_value(c, out)
+    @test Array(out) == [7, 12]
+    @test Array(c)[1] == 12
+end
+
 @testset "1D gather - simple" begin
     # Simple 1D gather: copy first 16 elements using gather
     function gather_simple_kernel(src::ct.TileArray{Float32,1}, dst::ct.TileArray{Float32,1})

--- a/test/device/atomics.jl
+++ b/test/device/atomics.jl
@@ -368,6 +368,27 @@ end
     @test result == 1
 end
 
+@testset "atomic_max/min UInt32 (unsigned compare)" begin
+    # 0x80000000 has the high bit set: largest as unsigned, negative as signed.
+    # A signed max/min would disagree with the expected unsigned result.
+    function atomic_umax_kernel(out::ct.TileArray{UInt32,1})
+        ct.atomic_max(out, 1, 0x80000000; memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+    function atomic_umin_kernel(out::ct.TileArray{UInt32,1})
+        ct.atomic_min(out, 1, 0x00000001; memory_order=ct.MemoryOrder.AcqRel)
+        return
+    end
+
+    out_max = CUDA.fill(0x00000001, 1)
+    @cuda backend=cuTile blocks=8 atomic_umax_kernel(out_max)
+    @test Array(out_max)[1] == 0x80000000  # umax; signed would keep 0x00000001
+
+    out_min = CUDA.fill(0x80000000, 1)
+    @cuda backend=cuTile blocks=8 atomic_umin_kernel(out_min)
+    @test Array(out_min)[1] == 0x00000001  # umin; signed would keep 0x80000000
+end
+
 @testset "atomic_or Int" begin
     function atomic_or_kernel(out::ct.TileArray{Int,1})
         bid = ct.bid(1)


### PR DESCRIPTION
Add tile-level atomic reductions backed by Tile IR 13.3's `atomic_red_view_tko`, including `atomic_store_add`, `atomic_store_max`, `atomic_store_min`, and the bitwise variants.

Add a Base-style `ct.@atomic` interface for statement and value forms, with explicit memory-order support. Statement forms use the no-return reduction path when possible, while value forms return `old => new`.

This also aligns the existing atomic operations with Tile IR for unsigned min/max, bitwise update types, and BFloat16 support.

Closes https://github.com/JuliaGPU/cuTile.jl/issues/50