### PR TITLE
Support for CUDA 13.4

### DIFF
--- a/docs/src/man/compatibility.md
+++ b/docs/src/man/compatibility.md
@@ -75,6 +75,7 @@ Everything not listed here works at v13.1.
 |---------|-------|
 | `ct.insert` | Replace a non-overlapping sub-tile |
 | `check_bounds=false` | On `ct.load` and `ct.store` only; on `ct.gather`/`ct.scatter` it merely skips the bounds mask |
+| `ct.Intrinsics.powi` | Integer exponents through `cuda_tile.fpowi` |
 
 
 ## Features by architecture

--- a/docs/src/man/debugging.md
+++ b/docs/src/man/debugging.md
@@ -76,7 +76,14 @@ Setting `JULIA_CUTILE_DUMP_BYTECODE` writes the emitted Tile IR bytecode to disk
 Dumping TILEIR bytecode to file: /tmp/julia_tiles/example.ln42.cutile
 ```
 
-The resulting files can be disassembled with NVIDIA's `cuda-tile-translate`:
+The resulting files can be disassembled with NVIDIA's `tileirdisasm`:
+
+```
+❯ tileirdisasm /tmp/julia_tiles/example.ln42.cutile
+```
+
+CUDA toolkits older than 13.4 ship `cuda-tile-translate` instead, which needs an
+explicit flag and cannot read bytecode newer than its own version:
 
 ```
 ❯ cuda-tile-translate --cudatilebc-to-mlir /tmp/julia_tiles/example.ln42.cutile

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -104,6 +104,9 @@ module Opcode
     const MakeStridedViewOp = 116 # since 13.3
     const AtomicRedViewTkoOp = 117 # since 13.3
     const InsertOp = 118     # since 13.4
+    # 119-121, 128-129 (Gdc*, Multimem*) not implemented
+    const FPowIOp = 130      # since 13.4
+    # 131 (MemoryFenceAliasTkoOp) not implemented
 end
 
 # Enums for operation attributes
@@ -894,6 +897,22 @@ Opcode: 84
 """
 function encode_PowOp!(cb::CodeBuilder, result_type::TypeId, base::Value, exponent::Value)
     encode_varint!(cb.buf, Opcode.PowOp)
+    encode_typeid!(cb.buf, result_type)
+    encode_operand!(cb.buf, base)
+    encode_operand!(cb.buf, exponent)
+    return new_op!(cb)
+end
+
+"""
+    encode_FPowIOp!(cb, result_type, base, exponent) -> Value
+
+Floating-point power with an integer exponent (base^exponent).
+Opcode: 130
+"""
+function encode_FPowIOp!(cb::CodeBuilder, result_type::TypeId, base::Value, exponent::Value)
+    cb.version >= v"13.4" ||
+        throw(IRError("cuda_tile.fpowi requires Tile IR v13.4+, got v$(cb.version)"))
+    encode_varint!(cb.buf, Opcode.FPowIOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, base)
     encode_operand!(cb.buf, exponent)

--- a/src/compiler/intrinsics/arithmetic.jl
+++ b/src/compiler/intrinsics/arithmetic.jl
@@ -2,20 +2,26 @@
 
 ## Helpers
 
+# Broadcast `tv` to `target_shape`, keeping its own element type.
+function broadcast_to_shape!(cb, tt, tv::CGVal, target_shape)
+    elem_type = eltype(CC.widenconst(tv.jltype))
+    dtype = lookup_dtype!(tt, elem_type)
+    bv = broadcast_tile_to_shape!(cb, tt, tv, target_shape, dtype)
+    jltype = similar_type(CC.widenconst(tv.jltype), elem_type, Tuple(target_shape))
+    CGVal(bv, tile_type!(tt, dtype, target_shape), jltype, target_shape,
+          nothing, tv.constant, nothing)
+end
+
 # Broadcast the smaller-shaped operand to match the larger when shapes differ.
 # This handles 0D constants meeting shaped tiles after constant folding.
-function _broadcast_match_shapes!(cb, tt, lhs::CGVal, rhs::CGVal)
+# Operands may differ in element type (`fpowi` takes an integer exponent), so
+# each side is broadcast under its own dtype.
+function broadcast_match_shapes!(cb, tt, lhs::CGVal, rhs::CGVal)
     lhs.shape == rhs.shape && return (lhs, rhs)
-    elem_type = eltype(CC.widenconst(lhs.jltype))
-    dtype = lookup_dtype!(tt, elem_type)
     if length(lhs.shape) < length(rhs.shape)
-        bv = broadcast_tile_to_shape!(cb, tt, lhs, rhs.shape, dtype)
-        lhs = CGVal(bv, tile_type!(tt, dtype, rhs.shape), rhs.jltype, rhs.shape,
-                    nothing, lhs.constant, nothing)
+        lhs = broadcast_to_shape!(cb, tt, lhs, rhs.shape)
     else
-        bv = broadcast_tile_to_shape!(cb, tt, rhs, lhs.shape, dtype)
-        rhs = CGVal(bv, tile_type!(tt, dtype, lhs.shape), lhs.jltype, lhs.shape,
-                    nothing, rhs.constant, nothing)
+        rhs = broadcast_to_shape!(cb, tt, rhs, lhs.shape)
     end
     return (lhs, rhs)
 end
@@ -79,7 +85,7 @@ function emit_binop!(ctx::CGCtx, args, encoder::Function; kwargs...)
 
     # Broadcast smaller-shaped operand to match the larger (e.g., 0D constant
     # meeting a shaped tile after constant folding removes reshape/broadcast)
-    lhs_tv, rhs_tv = _broadcast_match_shapes!(cb, tt, lhs_tv, rhs_tv)
+    lhs_tv, rhs_tv = broadcast_match_shapes!(cb, tt, lhs_tv, rhs_tv)
     result_shape = lhs_tv.shape
     result_jltype = lhs_tv.jltype
 
@@ -191,7 +197,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.cmpi), args)
     signedness = @something get_constant(ctx, args[4]) throw(IRError("cmpi: requires compile-time signedness"))
 
     # Broadcast mismatched shapes (e.g., 0D constant vs shaped tile)
-    lhs, rhs = _broadcast_match_shapes!(cb, tt, lhs, rhs)
+    lhs, rhs = broadcast_match_shapes!(cb, tt, lhs, rhs)
 
     result_shape = lhs.shape
 
@@ -475,7 +481,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.cmpf), args)
     end
 
     # Broadcast mismatched shapes (e.g., 0D constant vs shaped tile)
-    lhs, rhs = _broadcast_match_shapes!(cb, tt, lhs, rhs)
+    lhs, rhs = broadcast_match_shapes!(cb, tt, lhs, rhs)
 
     result_shape = lhs.shape
 

--- a/src/compiler/intrinsics/math.jl
+++ b/src/compiler/intrinsics/math.jl
@@ -224,6 +224,40 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.pow), args)
 end
 
 """
+    Intrinsics.powi(x::Tile{T}, n::Tile{<:Integer}) -> Tile{T}  where {T<:AbstractFloat}
+
+Element-wise exponentiation by an integer power (`x^n`); lowers to
+`cuda_tile.fpowi` (Tile IR v13.4+).
+
+Cheaper than [`Intrinsics.pow`](@ref), which needs the exponent converted to
+floating point, but computed by repeated squaring at the working precision:
+expect it to drift for large `|n|` where `pow` stays within an ulp. `^` uses
+`pow` for that reason, so reach for this only when the speed is worth it.
+
+Also invocable with scalars, promoted to 0-D tiles before codegen.
+Mismatched-shape operands are broadcast to a common shape.
+"""
+@intrinsic powi(x::T, n::Integer) where {T<:AbstractFloat}
+@intrinsic powi(x::Tile{T}, n::Tile{<:Integer}) where {T<:AbstractFloat}
+tfunc(𝕃, ::typeof(Intrinsics.powi), @nospecialize(x), @nospecialize(n)) = CC.widenconst(x)
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.powi), args)
+    cb, tt = ctx.cb, ctx.tt
+
+    base = emit_value!(ctx, args[1])
+    exponent = emit_value!(ctx, args[2])
+    (base === nothing || exponent === nothing) && return missing
+
+    # The operands differ in element type, so only the shapes are matched up.
+    base, exponent = broadcast_match_shapes!(cb, tt, base, exponent)
+
+    elem_type = eltype(CC.widenconst(base.jltype))
+    result_type_id = tile_type!(tt, lookup_dtype!(tt, elem_type), base.shape)
+    result_v = encode_FPowIOp!(cb, result_type_id, base.v, exponent.v)
+
+    CGVal(result_v, result_type_id, base.jltype, base.shape)
+end
+
+"""
     Intrinsics.atan2(x::Tile{T}, y::Tile{T}) -> Tile{T}  where {T<:AbstractFloat}
 
 Element-wise principal-value `atan2(x, y)`; lowers to `cuda_tile.atan2`

--- a/src/compiler/intrinsics/math.jl
+++ b/src/compiler/intrinsics/math.jl
@@ -224,15 +224,14 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.pow), args)
 end
 
 """
-    Intrinsics.powi(x::Tile{T}, n::Tile{<:Integer}) -> Tile{T}  where {T<:AbstractFloat}
+    Intrinsics.powi(x::Tile{T}, n::Tile{I}) -> Tile{T}
+        where {T<:AbstractFloat, I<:Union{Bool,Int8,UInt8,Int16,UInt16,Int32}}
 
 Element-wise exponentiation by an integer power (`x^n`); lowers to
 `cuda_tile.fpowi` (Tile IR v13.4+).
 
-Cheaper than [`Intrinsics.pow`](@ref), which needs the exponent converted to
-floating point, but computed by repeated squaring at the working precision:
-expect it to drift for large `|n|` where `pow` stays within an ulp. `^` uses
-`pow` for that reason, so reach for this only when the speed is worth it.
+`UInt8` and `UInt16` exponents are widened to a signed type. Wider integer
+types are not supported by Tile IR.
 
 Also invocable with scalars, promoted to 0-D tiles before codegen.
 Mismatched-shape operands are broadcast to a common shape.
@@ -247,7 +246,18 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.powi), args)
     exponent = emit_value!(ctx, args[2])
     (base === nothing || exponent === nothing) && return missing
 
-    # The operands differ in element type, so only the shapes are matched up.
+    exponent_type = eltype(CC.widenconst(exponent.jltype))
+    if exponent_type === UInt8 || exponent_type === UInt16
+        target_type = exponent_type === UInt8 ? Int16 : Int32
+        result_type_id = tile_type!(tt, lookup_dtype!(tt, target_type), exponent.shape)
+        result_v = encode_ExtIOp!(cb, result_type_id, exponent.v;
+                                 signedness=Signedness.Unsigned)
+        jltype = similar_type(CC.widenconst(exponent.jltype), target_type)
+        exponent = CGVal(result_v, result_type_id, jltype, exponent.shape)
+    elseif !(exponent_type <: Union{Bool,Int8,Int16,Int32})
+        throw(IRError("cuda_tile.fpowi does not support $exponent_type exponents"))
+    end
+
     base, exponent = broadcast_match_shapes!(cb, tt, base, exponent)
 
     elem_type = eltype(CC.widenconst(base.jltype))

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -6,14 +6,13 @@ export code_tiled
 public code_typed, code_ircode, code_structured
 
 function disassemble_tileir(bytecode::Vector{UInt8}; debuginfo::Bool=false)::String
+    disasm = @something tileir_disassembler(; debuginfo) throw(ErrorException(
+        "no `tileirdisasm` next to $(tileiras_path()); disassembling Tile IR " *
+        "requires a CUDA 13.4+ toolkit when the `tileiras` preference is set"))
     mktempdir() do dir
         input_path = joinpath(dir, "kernel.tile")
         write(input_path, bytecode)
-        flags = `--cudatilebc-to-mlir`
-        if debuginfo
-            flags = `$flags --mlir-print-debuginfo`
-        end
-        read(`$(cuda_tile_translate()) $flags $input_path`, String)
+        read(`$disasm $input_path`, String)
     end
 end
 

--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -42,7 +42,8 @@ end
 # Use `pow` for accuracy and restore the sign from the integer exponent.
 @overlay function Base.:^(x::T, y::ScalarInt) where {T <: ScalarFloat}
     magnitude = Intrinsics.pow(abs(x), T(y))
-    ifelse(signbit(x) & isodd(y), -magnitude, magnitude)
+    odd = (y & one(y)) != zero(y)
+    ifelse(signbit(x) & odd, -magnitude, magnitude)
 end
 
 # integer != (Julia expands to not_int(===) — 2 ops; overlay gives 1 op)

--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -42,22 +42,21 @@ end
 # float-by-integer power. Base's `^(::Float, ::Int)` calls `power_by_squaring`,
 # whose `trailing_zeros` loop emits `cttz_int` (no Tile IR equivalent) for
 # runtime exponents and refuses to const-fold for literal exponents on 1.11.
-@overlay function Base.:^(x::Float32, y::Int64)
-    y == -1 && return inv(x)
-    y == 0 && return one(x)
-    y == 1 && return x
-    y == 2 && return x*x
-    y == 3 && return x*x*x
-    x ^ Float32(y)
-end
-@overlay function Base.:^(x::Float64, y::Int64)
-    y == -1 && return inv(x)
-    y == 0 && return one(x)
-    y == 1 && return x
-    y == 2 && return x*x
-    y == 3 && return x*x*x
-    x ^ Float64(y)
-end
+#
+# The old branch ladder here (`y == 2 && return x*x`, ...) only ever folded
+# away for a compile-time `y`; with a tile exponent the comparisons became
+# control flow and codegen failed outright. Convert and defer to `pow`, which
+# IEEE-defines a negative base raised to an integral exponent just as Julia's
+# `^(::Float, ::Integer)` does.
+#
+# Tile IR v13.4 grew `fpowi` for exactly this case, and cuTile Python routes
+# integer exponents to it, but it is not what Base does: `pow_body` widens to
+# Float64 for a Float32 base and uses compensated squaring for a Float64 one,
+# so `fpowi` drifts to ~20 ulp (f32) / ~100 ulp (f64) for large exponents where
+# `pow` stays under 1. `Intrinsics.powi` exposes it for callers that want the
+# cheaper op. Literal exponents never reach here — `x .^ 2` goes through
+# `Base.literal_pow`.
+@overlay Base.:^(x::T, y::ScalarInt) where {T <: ScalarFloat} = Intrinsics.pow(x, T(y))
 
 # integer != (Julia expands to not_int(===) — 2 ops; overlay gives 1 op)
 @overlay Base.:(!=)(x::T, y::T) where {T <: ScalarInt} = Intrinsics.cmpi(x, y, ComparisonPredicate.NotEqual, Signedness.Signed)

--- a/src/language/arithmetic.jl
+++ b/src/language/arithmetic.jl
@@ -39,24 +39,11 @@ end
 # float power (expands to dozens of intrinsics in Julia — complex)
 @overlay Base.:^(x::T, y::T) where {T <: ScalarFloat} = Intrinsics.pow(x, y)
 
-# float-by-integer power. Base's `^(::Float, ::Int)` calls `power_by_squaring`,
-# whose `trailing_zeros` loop emits `cttz_int` (no Tile IR equivalent) for
-# runtime exponents and refuses to const-fold for literal exponents on 1.11.
-#
-# The old branch ladder here (`y == 2 && return x*x`, ...) only ever folded
-# away for a compile-time `y`; with a tile exponent the comparisons became
-# control flow and codegen failed outright. Convert and defer to `pow`, which
-# IEEE-defines a negative base raised to an integral exponent just as Julia's
-# `^(::Float, ::Integer)` does.
-#
-# Tile IR v13.4 grew `fpowi` for exactly this case, and cuTile Python routes
-# integer exponents to it, but it is not what Base does: `pow_body` widens to
-# Float64 for a Float32 base and uses compensated squaring for a Float64 one,
-# so `fpowi` drifts to ~20 ulp (f32) / ~100 ulp (f64) for large exponents where
-# `pow` stays under 1. `Intrinsics.powi` exposes it for callers that want the
-# cheaper op. Literal exponents never reach here — `x .^ 2` goes through
-# `Base.literal_pow`.
-@overlay Base.:^(x::T, y::ScalarInt) where {T <: ScalarFloat} = Intrinsics.pow(x, T(y))
+# Use `pow` for accuracy and restore the sign from the integer exponent.
+@overlay function Base.:^(x::T, y::ScalarInt) where {T <: ScalarFloat}
+    magnitude = Intrinsics.pow(abs(x), T(y))
+    ifelse(signbit(x) & isodd(y), -magnitude, magnitude)
+end
 
 # integer != (Julia expands to not_int(===) — 2 ops; overlay gives 1 op)
 @overlay Base.:(!=)(x::T, y::T) where {T <: ScalarInt} = Intrinsics.cmpi(x, y, ComparisonPredicate.NotEqual, Signedness.Signed)

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -170,14 +170,8 @@ end
 """
     tileir_disassembler(; debuginfo=false) -> Union{Cmd, Nothing}
 
-Command that disassembles a Tile IR bytecode file to MLIR, or `nothing` when
-no usable disassembler is available.
-
-A disassembler can only read bytecode up to its own version, so it has to come
-from the same toolkit as `tileiras`. With the `tileiras` preference set we use
-the `tileirdisasm` sitting next to it; CUDA 13.4 introduced that binary to
-replace `cuda-tile-translate`, which is what `CUDA_Tile_jll` still ships and
-what we fall back to without an override.
+Return a disassembler matching the selected `tileiras`. An override requires
+`tileirdisasm` in the same directory.
 """
 function tileir_disassembler(; debuginfo::Bool=false)
     if tileiras_override !== nothing

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -167,6 +167,28 @@ function tileiras_cmd(args...)
     return addenv(cmd, "CUDA_ROOT" => tileiras_root())
 end
 
+"""
+    tileir_disassembler(; debuginfo=false) -> Union{Cmd, Nothing}
+
+Command that disassembles a Tile IR bytecode file to MLIR, or `nothing` when
+no usable disassembler is available.
+
+A disassembler can only read bytecode up to its own version, so it has to come
+from the same toolkit as `tileiras`. With the `tileiras` preference set we use
+the `tileirdisasm` sitting next to it; CUDA 13.4 introduced that binary to
+replace `cuda-tile-translate`, which is what `CUDA_Tile_jll` still ships and
+what we fall back to without an override.
+"""
+function tileir_disassembler(; debuginfo::Bool=false)
+    if tileiras_override !== nothing
+        disasm = joinpath(dirname(tileiras_override), "tileirdisasm")
+        isfile(disasm) || return nothing
+        return debuginfo ? `$disasm --print-debug-info` : `$disasm`
+    end
+    translate = `$(CUDA_Tile_jll.cuda_tile_translate()) --cudatilebc-to-mlir`
+    return debuginfo ? `$translate --mlir-print-debuginfo` : translate
+end
+
 function run_and_collect(cmd)
     stdout = Pipe()
     proc = run(pipeline(ignorestatus(cmd); stdout, stderr=stdout), wait=false)

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -322,6 +322,20 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
         end
 
+        # Insert a slice back into the tile it was extracted from (v13.4+)
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (4, 8))
+                @check "extract"
+                extracted = ct.extract(tile, (2, 2), (2, 4))
+                @check "insert"
+                ct.store(b, pid, ct.insert(tile, (1, 1), extracted))
+                return
+            end
+        end
+
         # Scalar tile getindex
         @test @filecheck begin
             @check_label "entry"
@@ -376,6 +390,32 @@ spec4d = ct.ArraySpec{4}(16, true)
             tile = ct.load(a, 1, (16,))
             ct.store(a, 1, tile; check_bounds=false)
             return
+        end
+
+        # On v13.4+ the promise is carried as an `inbounds` flag per dimension.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                pid = ct.bid(1)
+                @check "load_view{{.*}}inbounds = [true]"
+                tile = ct.load(a, pid, (16,); check_bounds=false)
+                @check "store_view{{.*}}inbounds = [true]"
+                ct.store(a, pid, tile; check_bounds=false)
+                return
+            end
+        end
+
+        # Bounds-checked accesses (the default) carry no `inbounds` flag.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                pid = ct.bid(1)
+                @check "load_view"
+                @check_not "inbounds"
+                tile = ct.load(a, pid, (16,))
+                ct.store(a, pid, tile)
+                return
+            end
         end
     end
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1980,8 +1980,6 @@ end
             end
         end
 
-        # A runtime integer exponent converts and uses `pow`, matching Base's
-        # accuracy; `fpowi` drifts too far for large exponents to stand in.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
@@ -1992,6 +1990,7 @@ end
                 @check "itof"
                 @check "pow"
                 @check_not "fpowi"
+                @check "select"
                 Base.donotdelete(tile .^ exponent)
                 return
             end
@@ -2019,6 +2018,31 @@ end
             exponent = ct.load(e, pid, (16,))
             Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
             return
+        end
+
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
+                             ct.TileArray{UInt16,1,spec1d}}) do a, e
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                exponent = ct.load(e, pid, (16,))
+                @check "exti"
+                @check "fpowi"
+                Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+                return
+            end
+        end
+
+        for T in (Int64, UInt32, UInt64)
+            @test_throws "does not support $T exponents" code_tiled(
+                Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{T,1,spec1d}}) do a, e
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                exponent = ct.load(e, pid, (16,))
+                Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+                return
+            end
         end
     end
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -322,16 +322,18 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
         end
 
-        @test @filecheck begin
-            @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
-                pid = ct.bid(1)
-                tile = ct.load(a, pid, (4, 8))
-                @check "extract"
-                extracted = ct.extract(tile, (2, 2), (2, 4))
-                @check "insert"
-                ct.store(b, pid, ct.insert(tile, (1, 1), extracted))
-                return
+        if ct.bytecode_version() >= v"13.4"
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (4, 8))
+                    @check "extract"
+                    extracted = ct.extract(tile, (2, 2), (2, 4))
+                    @check "insert"
+                    ct.store(b, pid, ct.insert(tile, (1, 1), extracted))
+                    return
+                end
             end
         end
 
@@ -391,15 +393,17 @@ spec4d = ct.ArraySpec{4}(16, true)
             return
         end
 
-        @test @filecheck begin
-            @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
-                pid = ct.bid(1)
-                @check "load_view{{.*}}inbounds = [true]"
-                tile = ct.load(a, pid, (16,); check_bounds=false)
-                @check "store_view{{.*}}inbounds = [true]"
-                ct.store(a, pid, tile; check_bounds=false)
-                return
+        if ct.bytecode_version() >= v"13.4"
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                    pid = ct.bid(1)
+                    @check "load_view{{.*}}inbounds = [true]"
+                    tile = ct.load(a, pid, (16,); check_bounds=false)
+                    @check "store_view{{.*}}inbounds = [true]"
+                    ct.store(a, pid, tile; check_bounds=false)
+                    return
+                end
             end
         end
 
@@ -1987,22 +1991,25 @@ end
                 @check "itof"
                 @check "pow"
                 @check_not "fpowi"
+                @check "andi"
                 @check "select"
                 Base.donotdelete(tile .^ exponent)
                 return
             end
         end
 
-        @test @filecheck begin
-            @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                             ct.TileArray{Int32,1,spec1d}}) do a, e
-                pid = ct.bid(1)
-                tile = ct.load(a, pid, (16,))
-                exponent = ct.load(e, pid, (16,))
-                @check "fpowi"
-                Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
-                return
+        if ct.bytecode_version() >= v"13.4"
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
+                                 ct.TileArray{Int32,1,spec1d}}) do a, e
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    exponent = ct.load(e, pid, (16,))
+                    @check "fpowi"
+                    Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+                    return
+                end
             end
         end
 
@@ -2016,17 +2023,19 @@ end
             return
         end
 
-        @test @filecheck begin
-            @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                             ct.TileArray{UInt16,1,spec1d}}) do a, e
-                pid = ct.bid(1)
-                tile = ct.load(a, pid, (16,))
-                exponent = ct.load(e, pid, (16,))
-                @check "exti"
-                @check "fpowi"
-                Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
-                return
+        if ct.bytecode_version() >= v"13.4"
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
+                                 ct.TileArray{UInt16,1,spec1d}}) do a, e
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    exponent = ct.load(e, pid, (16,))
+                    @check "exti"
+                    @check "fpowi"
+                    Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+                    return
+                end
             end
         end
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1979,6 +1979,47 @@ end
                 return
             end
         end
+
+        # A runtime integer exponent converts and uses `pow`, matching Base's
+        # accuracy; `fpowi` drifts too far for large exponents to stand in.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
+                             ct.TileArray{Int32,1,spec1d}}) do a, e
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                exponent = ct.load(e, pid, (16,))
+                @check "itof"
+                @check "pow"
+                @check_not "fpowi"
+                Base.donotdelete(tile .^ exponent)
+                return
+            end
+        end
+
+        # `fpowi` itself is available as an intrinsic (Tile IR v13.4+)
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
+                             ct.TileArray{Int32,1,spec1d}}) do a, e
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                exponent = ct.load(e, pid, (16,))
+                @check "fpowi"
+                Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+                return
+            end
+        end
+
+        @test_throws "cuda_tile.fpowi requires Tile IR v13.4+" code_tiled(
+            Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Int32,1,spec1d}};
+            bytecode_version=v"13.3") do a, e
+            pid = ct.bid(1)
+            tile = ct.load(a, pid, (16,))
+            exponent = ct.load(e, pid, (16,))
+            Base.donotdelete(ct.Intrinsics.powi(tile, exponent))
+            return
+        end
     end
 
     @testset "scalar math functions" begin

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -322,7 +322,6 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
         end
 
-        # Insert a slice back into the tile it was extracted from (v13.4+)
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
@@ -392,7 +391,6 @@ spec4d = ct.ArraySpec{4}(16, true)
             return
         end
 
-        # On v13.4+ the promise is carried as an `inbounds` flag per dimension.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
@@ -405,7 +403,6 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
         end
 
-        # Bounds-checked accesses (the default) carry no `inbounds` flag.
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
@@ -1996,7 +1993,6 @@ end
             end
         end
 
-        # `fpowi` itself is available as an intrinsic (Tile IR v13.4+)
         @test @filecheck begin
             @check_label "entry"
             code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},

--- a/test/device/hints.jl
+++ b/test/device/hints.jl
@@ -265,6 +265,7 @@ end
     @test Array(b) ≈ Array(a)
 end
 
+if cuTile.bytecode_version() >= v"13.4"
 @testset "load/store with check_bounds=false" begin
     function vadd_unchecked(a::ct.TileArray{Float32,1},
                             b::ct.TileArray{Float32,1},
@@ -301,6 +302,7 @@ end
     @cuda backend=cuTile blocks=cld(m, 32) copy_unchecked(a, b)
 
     @test Array(b) ≈ Array(a)
+end
 end
 
 end

--- a/test/device/hints.jl
+++ b/test/device/hints.jl
@@ -265,4 +265,45 @@ end
     @test Array(b) ≈ Array(a)
 end
 
+# `check_bounds=false` promises the whole tile is in bounds, and lowers to the
+# per-dimension `inbounds` flag on load_view/store_view (Tile IR v13.4+).
+@testset "load/store with check_bounds=false" begin
+    function vadd_unchecked(a::ct.TileArray{Float32,1},
+                            b::ct.TileArray{Float32,1},
+                            c::ct.TileArray{Float32,1})
+        pid = ct.bid(1)
+        ta = ct.load(a, pid, (16,); check_bounds=false)
+        tb = ct.load(b, pid, (16,); check_bounds=false)
+        ct.store(c, pid, ta + tb; check_bounds=false)
+        return nothing
+    end
+
+    # Exactly divisible by the tile shape, so no access is ever out of bounds
+    n = 1024
+    a = CUDA.rand(Float32, n)
+    b = CUDA.rand(Float32, n)
+    c = CUDA.zeros(Float32, n)
+
+    @cuda backend=cuTile blocks=64 vadd_unchecked(a, b, c)
+
+    @test Array(c) ≈ Array(a) + Array(b)
+end
+
+@testset "2D load/store with check_bounds=false" begin
+    function copy_unchecked(a::ct.TileArray{Float32,2}, b::ct.TileArray{Float32,2})
+        pid = ct.bid(1)
+        tile = ct.load(a, (pid, 1), (32, 32); check_bounds=false)
+        ct.store(b, (pid, 1), tile; check_bounds=false)
+        return nothing
+    end
+
+    m, n = 128, 32
+    a = CUDA.rand(Float32, m, n)
+    b = CUDA.zeros(Float32, m, n)
+
+    @cuda backend=cuTile blocks=cld(m, 32) copy_unchecked(a, b)
+
+    @test Array(b) ≈ Array(a)
+end
+
 end

--- a/test/device/hints.jl
+++ b/test/device/hints.jl
@@ -265,8 +265,6 @@ end
     @test Array(b) ≈ Array(a)
 end
 
-# `check_bounds=false` promises the whole tile is in bounds, and lowers to the
-# per-dimension `inbounds` flag on load_view/store_view (Tile IR v13.4+).
 @testset "load/store with check_bounds=false" begin
     function vadd_unchecked(a::ct.TileArray{Float32,1},
                             b::ct.TileArray{Float32,1},
@@ -278,7 +276,6 @@ end
         return nothing
     end
 
-    # Exactly divisible by the tile shape, so no access is ever out of bounds
     n = 1024
     a = CUDA.rand(Float32, n)
     b = CUDA.rand(Float32, n)

--- a/test/device/math.jl
+++ b/test/device/math.jl
@@ -164,3 +164,70 @@ end
 
     @test Array(out) == Float32.(isnan.(Array(a)))
 end
+
+# `x ^ n` with a runtime integer exponent. Used to fail codegen outright: the
+# overlay branched on the exponent, which is control flow once it is a tile.
+@testset "float ^ integer exponent" begin
+    function pow_int_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int32,1},
+                            out::ct.TileArray{Float32,1})
+        pid = ct.bid(1)
+        ct.store(out, pid, ct.load(a, pid, (16,)) .^ ct.load(e, pid, (16,)))
+        return
+    end
+
+    # Negative bases, signed zero, infinities and NaN — Base defines all of
+    # these for an integer exponent, including `x^0 == 1` for any `x`.
+    bases = Float32[2, -2, 0.5, -0.5, 0, -0.0, 1, -1, 3, -3, Inf, -Inf, NaN, 7, -7, 1f10]
+    exps = Int32[0, 1, 2, 3, -1, -2, 5, -3, 0, 4, 0, 3, 0, 7, 7, 3]
+
+    a = CuArray(bases)
+    e = CuArray(exps)
+    out = CUDA.zeros(Float32, 16)
+
+    @cuda backend=cuTile pow_int_kernel(a, e, out)
+
+    got = Array(out)
+    want = bases .^ exps
+    @test all(got[i] === want[i] || (isnan(got[i]) && isnan(want[i])) ||
+              isapprox(got[i], want[i]; rtol=1f-5) for i in eachindex(got))
+end
+
+@testset "float ^ Int64 exponent" begin
+    # Int64 is Julia's default integer, so it is the common case here.
+    function pow_int64_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int64,1},
+                              out::ct.TileArray{Float32,1})
+        pid = ct.bid(1)
+        ct.store(out, pid, ct.load(a, pid, (16,)) .^ ct.load(e, pid, (16,)))
+        return
+    end
+
+    n = 256
+    a = CUDA.rand(Float32, n) .+ 0.5f0
+    e = CuArray(rand(-4:8, n))
+    out = CUDA.zeros(Float32, n)
+
+    @cuda backend=cuTile blocks=cld(n, 16) pow_int64_kernel(a, e, out)
+
+    @test Array(out) ≈ Array(a) .^ Array(e) rtol=1f-4
+end
+
+# fpowi is cheaper than converting and calling pow, but drifts for large
+# exponents, so `^` does not use it; check the intrinsic itself still works.
+@testset "Intrinsics.powi" begin
+    function powi_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int32,1},
+                         out::ct.TileArray{Float32,1})
+        pid = ct.bid(1)
+        ct.store(out, pid, ct.Intrinsics.powi(ct.load(a, pid, (16,)),
+                                              ct.load(e, pid, (16,))))
+        return
+    end
+
+    n = 256
+    a = CUDA.rand(Float32, n) .+ 0.5f0
+    e = CuArray(Int32.(rand(-4:8, n)))
+    out = CUDA.zeros(Float32, n)
+
+    @cuda backend=cuTile blocks=cld(n, 16) powi_kernel(a, e, out)
+
+    @test Array(out) ≈ Array(a) .^ Array(e) rtol=1f-3
+end

--- a/test/device/math.jl
+++ b/test/device/math.jl
@@ -185,7 +185,8 @@ end
     got = Array(out)
     want = bases .^ exps
     @test all(got[i] === want[i] || (isnan(got[i]) && isnan(want[i])) ||
-              isapprox(got[i], want[i]; rtol=1f-5) for i in eachindex(got))
+              isapprox(got[i], want[i]; rtol=1f-5) for i in firstindex(got):lastindex(got)-1)
+    @test got[end] === -1f0
 end
 
 @testset "float ^ Int64 exponent" begin
@@ -206,6 +207,7 @@ end
     @test Array(out) ≈ Array(a) .^ Array(e) rtol=1f-4
 end
 
+if cuTile.bytecode_version() >= v"13.4"
 @testset "Intrinsics.powi" begin
     function powi_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int32,1},
                          out::ct.TileArray{Float32,1})
@@ -223,4 +225,5 @@ end
     @cuda backend=cuTile blocks=cld(n, 16) powi_kernel(a, e, out)
 
     @test Array(out) ≈ Array(a) .^ Array(e) rtol=1f-3
+end
 end

--- a/test/device/math.jl
+++ b/test/device/math.jl
@@ -189,7 +189,6 @@ end
 end
 
 @testset "float ^ Int64 exponent" begin
-    # Int64 is Julia's default integer, so it is the common case here.
     function pow_int64_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int64,1},
                               out::ct.TileArray{Float32,1})
         pid = ct.bid(1)

--- a/test/device/math.jl
+++ b/test/device/math.jl
@@ -165,8 +165,6 @@ end
     @test Array(out) == Float32.(isnan.(Array(a)))
 end
 
-# `x ^ n` with a runtime integer exponent. Used to fail codegen outright: the
-# overlay branched on the exponent, which is control flow once it is a tile.
 @testset "float ^ integer exponent" begin
     function pow_int_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int32,1},
                             out::ct.TileArray{Float32,1})
@@ -175,10 +173,8 @@ end
         return
     end
 
-    # Negative bases, signed zero, infinities and NaN — Base defines all of
-    # these for an integer exponent, including `x^0 == 1` for any `x`.
-    bases = Float32[2, -2, 0.5, -0.5, 0, -0.0, 1, -1, 3, -3, Inf, -Inf, NaN, 7, -7, 1f10]
-    exps = Int32[0, 1, 2, 3, -1, -2, 5, -3, 0, 4, 0, 3, 0, 7, 7, 3]
+    bases = Float32[2, -2, 0.5, -0.5, 0, -0.0, 1, -1, 3, -3, Inf, -Inf, NaN, 7, -7, -1]
+    exps = Int32[0, 1, 2, 3, -1, -2, 5, -3, 0, 4, 0, 3, 0, 7, 7, 16_777_217]
 
     a = CuArray(bases)
     e = CuArray(exps)
@@ -211,8 +207,6 @@ end
     @test Array(out) ≈ Array(a) .^ Array(e) rtol=1f-4
 end
 
-# fpowi is cheaper than converting and calling pow, but drifts for large
-# exponents, so `^` does not use it; check the intrinsic itself still works.
 @testset "Intrinsics.powi" begin
     function powi_kernel(a::ct.TileArray{Float32,1}, e::ct.TileArray{Int32,1},
                          out::ct.TileArray{Float32,1})

--- a/test/device/tile.jl
+++ b/test/device/tile.jl
@@ -824,6 +824,7 @@ end
     end
 end
 
+if cuTile.bytecode_version() >= v"13.4"
 @testset "insert" begin
     @testset "insert replaces one slice" begin
         function insert_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
@@ -885,6 +886,7 @@ end
         end
         @test Array(y) ≈ expected
     end
+end
 end
 
 @testset "scalar tile getindex" begin

--- a/test/device/tile.jl
+++ b/test/device/tile.jl
@@ -824,13 +824,11 @@ end
     end
 end
 
-# `insert` is the inverse of `extract` and needs Tile IR v13.4+ (opcode 118).
 @testset "insert" begin
     @testset "insert replaces one slice" begin
         function insert_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
             bid = ct.bid(1)
             tile = ct.load(x, (bid, 1), (8, 8))
-            # Scale the bottom-right quadrant of the 2x2 slice grid in place
             quadrant = ct.extract(tile, (2, 2), (4, 4))
             ct.store(y, (bid, 1), ct.insert(tile, (2, 2), quadrant .* 10f0))
             return
@@ -868,8 +866,6 @@ end
     end
 
     @testset "insert of a scalar writes a single element" begin
-        # A scalar value becomes a 0-d tile, so the slice grid is per-element
-        # and `index` addresses one element rather than a subtile.
         function insert_scalar_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
             bid = ct.bid(1)
             tile = ct.load(x, (bid, 1), (8, 8))

--- a/test/device/tile.jl
+++ b/test/device/tile.jl
@@ -824,6 +824,73 @@ end
     end
 end
 
+# `insert` is the inverse of `extract` and needs Tile IR v13.4+ (opcode 118).
+@testset "insert" begin
+    @testset "insert replaces one slice" begin
+        function insert_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
+            bid = ct.bid(1)
+            tile = ct.load(x, (bid, 1), (8, 8))
+            # Scale the bottom-right quadrant of the 2x2 slice grid in place
+            quadrant = ct.extract(tile, (2, 2), (4, 4))
+            ct.store(y, (bid, 1), ct.insert(tile, (2, 2), quadrant .* 10f0))
+            return
+        end
+
+        m, n = 64, 8
+        x = CUDA.rand(Float32, m, n)
+        y = CUDA.zeros(Float32, m, n)
+
+        @cuda backend=cuTile blocks=cld(m, 8) insert_kernel(x, y)
+
+        expected = Array(x)
+        for tilestart in 1:8:m
+            rows = tilestart+4 : tilestart+7
+            expected[rows, 5:8] .*= 10f0
+        end
+        @test Array(y) ≈ expected
+    end
+
+    @testset "insert of a full-shape slice is identity" begin
+        function insert_identity_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
+            bid = ct.bid(1)
+            tile = ct.load(x, (bid, 1), (4, 8))
+            ct.store(y, (bid, 1), ct.insert(tile, (1, 1), tile))
+            return
+        end
+
+        m, n = 64, 8
+        x = CUDA.rand(Float32, m, n)
+        y = CUDA.zeros(Float32, m, n)
+
+        @cuda backend=cuTile blocks=cld(m, 4) insert_identity_kernel(x, y)
+
+        @test Array(y) ≈ Array(x)
+    end
+
+    @testset "insert of a scalar writes a single element" begin
+        # A scalar value becomes a 0-d tile, so the slice grid is per-element
+        # and `index` addresses one element rather than a subtile.
+        function insert_scalar_kernel(x::ct.TileArray{Float32,2}, y::ct.TileArray{Float32,2})
+            bid = ct.bid(1)
+            tile = ct.load(x, (bid, 1), (8, 8))
+            ct.store(y, (bid, 1), ct.insert(tile, (3, 2), 7f0))
+            return
+        end
+
+        m, n = 64, 8
+        x = CUDA.rand(Float32, m, n)
+        y = CUDA.zeros(Float32, m, n)
+
+        @cuda backend=cuTile blocks=cld(m, 8) insert_scalar_kernel(x, y)
+
+        expected = Array(x)
+        for tilestart in 1:8:m
+            expected[tilestart+2, 2] = 7f0
+        end
+        @test Array(y) ≈ expected
+    end
+end
+
 @testset "scalar tile getindex" begin
     function tile_getindex_kernel(x::ct.TileArray{Float32,1}, y::ct.TileArray{Float32,1})
         tile = ct.load(x, 1, (8,))


### PR DESCRIPTION
Add some tests now that I could actually run things through `tileiras` from CUDA 13.4.
That version of CUDA will also ship `tileirdisasm`.