### PR TITLE
Support large TileArrays with Int64 indexing

### DIFF
--- a/docs/src/lib/essentials.md
+++ b/docs/src/lib/essentials.md
@@ -13,6 +13,7 @@ ArraySpec
 Tile
 Constant
 similar_type
+indextype
 ```
 
 ## Element types

--- a/docs/src/man/debugging.md
+++ b/docs/src/man/debugging.md
@@ -26,9 +26,9 @@ These are debugging aids and are not optimized for performance.
 The generated Tile IR can be inspected with `ct.code_tiled`:
 
 ```julia
-ct.code_tiled(vadd, Tuple{ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
-                          ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
-                          ct.TileArray{Float32, 1, ct.ArraySpec{1}(128, true, (0,), (32,))},
+ct.code_tiled(vadd, Tuple{ct.TileArray{Float32, 1, Int32, ct.ArraySpec{1}(128, true, (0,), (32,))},
+                          ct.TileArray{Float32, 1, Int32, ct.ArraySpec{1}(128, true, (0,), (32,))},
+                          ct.TileArray{Float32, 1, Int32, ct.ArraySpec{1}(128, true, (0,), (32,))},
                           ct.Constant{Int64, 16}})
 ```
 
@@ -44,7 +44,7 @@ the argument types from the actual `CuArray`s:
 
 ```julia-repl
 julia> ct.@device_code_tiled @cuda backend=cuTile blocks=cld(vector_size, tile_size) vadd(a, b, c, ct.Constant(tile_size))
-// vadd(cuTile.TileArray{Float32, 1, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, …)
+// vadd(cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, …)
 
 cuda_tile.module @kernels {
   entry @vadd(%arg0: tile<ptr<f32>>, …) {

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -46,13 +46,18 @@ first:
 
 | Host argument | Kernel parameter |
 |---------------|------------------|
-| `CuArray{T,N}` | [`ct.TileArray{T,N,Spec}`](programming_model.md#Arrays-and-tiles) |
+| `CuArray{T,N}` | [`ct.TileArray{T,N,I,Spec}`](programming_model.md#Arrays-and-tiles) |
 | `ct.Constant(x)` | `x` with its ordinary type, and no runtime parameter |
 | other `isbits` values | themselves, as a by-value parameter |
 
 A `TileArray` is then flattened further: its base pointer, sizes and strides
 each become a separate kernel parameter. This is why a kernel taking three
 vectors and a constant tile size has nine runtime parameters rather than four.
+
+Array sizes and strides use `Int32` when they fit, and switch to `Int64`
+automatically when either exceeds the 32-bit range. The index width is part of
+the converted argument type, so crossing that boundary compiles a new kernel.
+Use `ct.TileArray(array; index=Int64)` to select the wide path explicitly.
 
 
 ## Compile-time arguments
@@ -91,6 +96,10 @@ Three things therefore trigger a recompile:
 
 **The element type and rank of each array**, as you would expect.
 
+**Each array's index width.** Sizes and strides normally use `Int32`, but an
+array with a size or stride outside that range uses `Int64` and therefore has a
+different converted type.
+
 **Each `Constant` value**, since it lands in the type. `ct.Constant(64)` and
 `ct.Constant(128)` have types `Constant{Int64,64}` and `Constant{Int64,128}`, so
 a tile-size sweep compiles a kernel per size, which is the point, but worth
@@ -110,10 +119,10 @@ one down. But they do mean that arrays which look interchangeable are not:
 
 ```julia-repl
 julia> typeof(ct.TileArray(CUDA.rand(Float32, 1024)))
-cuTile.TileArray{Float32, 1, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}
+cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}
 
 julia> typeof(ct.TileArray(view(CUDA.rand(Float32, 2048), 1:2:2048)))
-cuTile.TileArray{Float32, 1, cuTile.ArraySpec{1, 128, false, (0,), (16,), false}()}
+cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, false, (0,), (16,), false}()}
 ```
 
 The strided view is not contiguous, so it compiles to a second, more

--- a/docs/src/man/programming_model.md
+++ b/docs/src/man/programming_model.md
@@ -19,7 +19,7 @@ memory accelerator.
 Two data structures show up in every kernel, and the difference between them
 matters:
 
-**Arrays** ([`ct.TileArray{T,N,Spec}`](@ref cuTile.TileArray)) live in global
+**Arrays** ([`ct.TileArray{T,N,I,Spec}`](@ref cuTile.TileArray)) live in global
 memory. They are mutable, have a strided memory layout, and their shapes are
 *runtime* values. Inside a kernel they support only a limited set of operations,
 mostly [loading and storing](memory.md) tiles and deriving views. A `CuArray`

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -542,6 +542,7 @@ function tfunc(𝕃, ::typeof(Intrinsics.make_tensor_view),
                @nospecialize(T_arg), @nospecialize args...)
     T_outer = CC.widenconst(T_arg)
     T_outer isa DataType && T_outer <: Type || return nothing
+    isempty(T_outer.parameters) && return nothing
     T = T_outer.parameters[1]
     T isa Type && T <: TileArray || return nothing
     TensorView{eltype(T), ndims(T)}

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -272,15 +272,20 @@ function gather_scatter_index_values(ctx::CGCtx, indices_arg, view_shape::Tuple,
     1 <= sparse_dim <= ndim ||
         throw(IRError("$name has invalid sparse dimension $sparse_dim for rank $ndim"))
 
+    index_element_type = nothing
     for (dim, index_tv) in enumerate(index_tvs)
         index_type = CC.widenconst(index_tv.jltype)
         index_type <: Tile ||
-            throw(IRError("$name at dimension $dim must be a Tile{Int32}"))
-        eltype(index_type) === Int32 ||
-            throw(IRError("$name at dimension $dim must have Int32 elements, got $(eltype(index_type))"))
+            throw(IRError("$name at dimension $dim must be an integer Tile"))
+        I = eltype(index_type)
+        I === Int32 || I === Int64 ||
+            throw(IRError("$name at dimension $dim must have Int32 or Int64 elements, got $I"))
+        index_element_type === nothing || index_element_type === I ||
+            throw(IRError("$name indices must have matching element types"))
+        index_element_type = I
         expected_rank = dim == sparse_dim ? 1 : 0
         ndims(index_type) == expected_rank ||
-            throw(IRError("$name at dimension $dim must be a $(expected_rank)D Int32 tile"))
+            throw(IRError("$name at dimension $dim must be a $(expected_rank)D integer tile"))
         if dim == sparse_dim
             size(index_type, 1) == view_shape[dim] ||
                 throw(IRError("$name sparse index length $(size(index_type, 1)) does not match view shape $(view_shape[dim]) at dimension $dim"))
@@ -554,6 +559,9 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_tensor_view), args
     elem_T = eltype(T)
     ndim = ndims(T)
     spec = array_spec(T)
+    I = indextype(T)
+    I === Int64 && tt.version < v"13.3" &&
+        throw(IRError("Int64-indexed TileArray requires Tile IR bytecode v13.3+, got v$(tt.version)"))
     dtype = lookup_dtype!(tt, elem_T)
 
     # Resolve operands. ptr is a single Value; sizes/strides expand to N values.

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -37,36 +37,38 @@ end
 # ============================================================================
 
 # Scalar index -> 0D pointer tile, no mask
-@inline function _atomic_ptr_and_mask(array::TileArray{T}, index::Integer; check_bounds::Bool=true) where {T}
-    idx_0 = Tile(Int32(index - One()))
+@inline function _atomic_ptr_and_mask(array::TileArray{T, <:Any, I}, index::Integer;
+                                      check_bounds::Bool=true) where {T, I}
+    idx_0 = Tile(I(index) - one(I))
     ptr_tile = Intrinsics.offset(Tile(array.ptr), idx_0)
     (ptr_tile, nothing, ())
 end
 
 # N-D tile indices -> N-D pointer tile with optional bounds mask
-@inline function _atomic_ptr_and_mask(array::TileArray{T, N},
+@inline function _atomic_ptr_and_mask(array::TileArray{T, N, I},
                                        indices::NTuple{N, Tile{<:Integer}};
-                                       check_bounds::Bool=true) where {T, N}
+                                       check_bounds::Bool=true) where {T, N, I}
     indices_0 = ntuple(Val(N)) do d
         indices[d] .- one(eltype(indices[d]))
     end
 
     S = reduce(broadcast_shape, ntuple(d -> size(indices[d]), Val(N)))
 
-    indices_i32 = ntuple(Val(N)) do d
-        convert(Tile{Int32}, broadcast_to(indices_0[d], S))
+    array_indices = ntuple(Val(N)) do d
+        convert(Tile{I}, broadcast_to(indices_0[d], S))
     end
 
     linear_idx = reduce(.+, ntuple(Val(N)) do d
-        indices_i32[d] .* broadcast_to(Tile(array.strides[d]), S)
+        array_indices[d] .* broadcast_to(Tile(array.strides[d]), S)
     end)
 
     ptr_tile = Intrinsics.offset(Tile(array.ptr), linear_idx)
 
     mask = if check_bounds
-        zero_bc = broadcast_to(Tile(Int32(0)), S)
+        zero_bc = broadcast_to(Tile(zero(I)), S)
         reduce(.&, ntuple(Val(N)) do d
-            (indices_i32[d] .>= zero_bc) .& (indices_i32[d] .< broadcast_to(Tile(size(array, d)), S))
+            (array_indices[d] .>= zero_bc) .&
+                (array_indices[d] .< broadcast_to(Tile(size(array, d)), S))
         end)
     else
         nothing
@@ -284,7 +286,7 @@ for op in (:add, :max, :min, :or, :and, :xor)
         reshaped = _reshape_to_rank(update, Val(ndims(arr)))
         tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
         pv = Intrinsics.make_partition_view(tv, size(reshaped), PaddingMode.Undetermined, nothing)
-        Intrinsics.$intrinsic(pv, reshaped, promote(index...) .- One())
+        Intrinsics.$intrinsic(pv, reshaped, zero_based_indices(arr, index))
         return nothing
     end
     @eval @inline $fname(arr::TileArray{T}, index::Integer, tile::Tile) where {T} =
@@ -309,7 +311,7 @@ for op in (:add, :max, :min, :or, :and, :xor)
         update = atomic_red_update(eltype(A), tile, $bitwise)
         view = make_atomic_tile_view(tiles)
         Intrinsics.$intrinsic(view, broadcast_to(update, tiled_view_shape(tiles)),
-                              promote(index...) .- One())
+                              zero_based_indices(tiles.parent, index))
         return nothing
     end
     @eval @inline $fname(tiles::TiledView, index::Integer, tile::Tile) =

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -399,9 +399,10 @@ end
     Int32(cld(size(arr, axis), shape[axis]))
 end
 
-@inline zero_based_indices(::Type{Int32}, indices::Tuple) = promote(indices...) .- One()
+@inline zero_based_indices(::Type{Int32}, indices::Tuple{Vararg{Integer, N}}) where {N} =
+    promote(indices...) .- One()
 @generated function zero_based_indices(::Type{Int64},
-                                       indices::NTuple{N, <:Integer}) where {N}
+                                       indices::Tuple{Vararg{Integer, N}}) where {N}
     Expr(:tuple, [:(Int64(indices[$d]) - Int64(1)) for d in 1:N]...)
 end
 @inline zero_based_indices(arr::TileArray, indices::Tuple) =

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -399,6 +399,14 @@ end
     Int32(cld(size(arr, axis), shape[axis]))
 end
 
+@inline zero_based_indices(::Type{Int32}, indices::Tuple) = promote(indices...) .- One()
+@generated function zero_based_indices(::Type{Int64},
+                                       indices::NTuple{N, <:Integer}) where {N}
+    Expr(:tuple, [:(Int64(indices[$d]) - Int64(1)) for d in 1:N]...)
+end
+@inline zero_based_indices(arr::TileArray, indices::Tuple) =
+    zero_based_indices(indextype(arr), indices)
+
 # Match a shape tuple to a target rank N by padding trailing 1s or squeezing trailing singletons.
 @generated function _match_shape(::Val{Shape}, ::Val{N}) where {Shape, N}
     M = length(Shape)
@@ -531,7 +539,8 @@ end
     N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
     view = check_bounds ? make_tile_view(tiles) :
                           make_tile_view(tiles, PaddingMode.Undetermined)
-    tile = load_tile_view(view, latency, allow_tma, promote(index...) .- One(), check_bounds)
+    tile = load_tile_view(view, latency, allow_tma,
+                          zero_based_indices(tiles.parent, index), check_bounds)
     reshape(tile, tiled_view_requested_shape(tiles))
 end
 @inline function load(tiles::TiledView, index::Integer; kwargs...)
@@ -548,7 +557,8 @@ end
     N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
     reshaped = _reshape_to_rank(tile, Val(ndims(tiles)))
     view = make_tile_view(tiles)
-    store_tile_view(view, reshaped, latency, allow_tma, promote(index...) .- One(), check_bounds)
+    store_tile_view(view, reshaped, latency, allow_tma,
+                    zero_based_indices(tiles.parent, index), check_bounds)
     return tile
 end
 @inline function store(tiles::TiledView, index::Integer, tile::Tile; kwargs...)
@@ -639,7 +649,7 @@ tile = ct.load(arr, (bidy, bidx), (TN, TM); order=(2, 1))
          Intrinsics.make_partition_view(tv, matched, padding_mode, order) :
          Intrinsics.make_partition_view(tv, matched, PaddingMode.Undetermined, order)
     tile = Intrinsics.load_partition_view(
-        pv, latency, allow_tma, promote(index...) .- One(), check_bounds)
+        pv, latency, allow_tma, zero_based_indices(arr, index), check_bounds)
     reshape(tile, shape)
 end
 
@@ -648,16 +658,18 @@ end
     load(arr, (index,), shape; kwargs...)
 end
 
-@inline function _gather_scatter_sparse_index(index::Tile{I}) where {I<:Integer}
-    convert(Tile{Int32}, index .- one(I))
+@inline function _gather_scatter_sparse_index(::Type{I}, index::Tile{J}) where
+        {I<:Integer, J<:Integer}
+    convert(Tile{I}, index .- one(J))
 end
 
-Base.@constprop :aggressive function _gather_scatter_dense_index(index::AbstractUnitRange{I}) where {I<:Integer}
-    Intrinsics.assert(first(index) >= one(I), "GatherScatterView: dense range start must be ≥ 1")
-    Int32(first(index) - One())
+Base.@constprop :aggressive function _gather_scatter_dense_index(
+        ::Type{I}, index::AbstractUnitRange{J}) where {I<:Integer, J<:Integer}
+    Intrinsics.assert(first(index) >= one(J), "GatherScatterView: dense range start must be ≥ 1")
+    I(first(index)) - one(I)
 end
 # `:` starts at element 1 (0-based 0); its extent comes from the load/store shape.
-_gather_scatter_dense_index(::Colon) = Int32(0)
+_gather_scatter_dense_index(::Type{I}, ::Colon) where {I<:Integer} = zero(I)
 
 Base.@constprop :aggressive function _check_gather_scatter_dense_shape(
         index::AbstractUnitRange{I}, expected::Integer) where {I<:Integer}
@@ -671,11 +683,12 @@ _check_gather_scatter_dense_shape(::Colon, ::Integer) = nothing
 @generated function _gather_scatter_indices(view::GatherScatterTileView{A, I, SparseDim}) where
         {A, I <: Tuple, SparseDim}
     expressions = Any[]
+    index_type = indextype(A)
     for dim in 1:length(I.parameters)
         if dim == SparseDim
-            push!(expressions, :(_gather_scatter_sparse_index(view.indices[$dim])))
+            push!(expressions, :(_gather_scatter_sparse_index($index_type, view.indices[$dim])))
         else
-            push!(expressions, :(_gather_scatter_dense_index(view.indices[$dim])))
+            push!(expressions, :(_gather_scatter_dense_index($index_type, view.indices[$dim])))
         end
     end
     Expr(:tuple, expressions...)
@@ -730,7 +743,7 @@ end
     shape = ntuple(_ -> 1, Val(N))
     pv = Intrinsics.make_partition_view(tv, shape, PaddingMode.Undetermined, nothing)
     tile = Intrinsics.load_partition_view(
-        pv, nothing, nothing, promote(indices...) .- One(), true)
+        pv, nothing, nothing, zero_based_indices(arr, indices), true)
     Intrinsics.to_scalar(reshape(tile, ()))
 end
 
@@ -794,7 +807,8 @@ behavior is undefined.
                        allow_tma::Union{Bool, Nothing}=nothing) where {T}
     reshaped = _reshape_to_rank(tile, Val(ndims(arr)))
     _store_reshaped(
-        arr, reshaped, order, check_bounds, latency, allow_tma, promote(index...) .- One())
+        arr, reshaped, order, check_bounds, latency, allow_tma,
+        zero_based_indices(arr, index))
     return tile  # XXX: enables constant folding; remove when possible (see "constant folding" test)
 end
 
@@ -873,16 +887,18 @@ end
 # 1D bounds mask: index < size (unsigned comparison catches negative indices)
 # After 1→0 index conversion, valid indices are >= 0. Reinterpreting as unsigned
 # makes negative values wrap to large values, so a single .< catches both cases.
-@inline function _bounds_mask_1d(indices_i32, array)
-    reinterpret.(UInt32, indices_i32) .< reinterpret(UInt32, Int32(size(array, 1)))
+@inline function _bounds_mask_1d(indices::Tile{I}, array) where {I<:Integer}
+    U = unsigned(I)
+    reinterpret.(U, indices) .< reinterpret(U, size(array, 1))
 end
 
 # 2D bounds mask: idx0 < size0 && idx1 < size1 (unsigned)
-@inline function _bounds_mask_2d(idx0_i32, idx1_i32, array, S)
-    size0_bc = broadcast_to(Tile(reinterpret(UInt32, Int32(size(array, 1)))), S)
-    size1_bc = broadcast_to(Tile(reinterpret(UInt32, Int32(size(array, 2)))), S)
-    mask0 = reinterpret.(UInt32, idx0_i32) .< size0_bc
-    mask1 = reinterpret.(UInt32, idx1_i32) .< size1_bc
+@inline function _bounds_mask_2d(idx0::Tile{I}, idx1::Tile{I}, array, S) where {I<:Integer}
+    U = unsigned(I)
+    size0_bc = broadcast_to(Tile(reinterpret(U, size(array, 1))), S)
+    size1_bc = broadcast_to(Tile(reinterpret(U, size(array, 2))), S)
+    mask0 = reinterpret.(U, idx0) .< size0_bc
+    mask1 = reinterpret.(U, idx1) .< size1_bc
     mask0 .& mask1
 end
 
@@ -927,16 +943,17 @@ indices = base .+ ct.arange(TILE)
 tile = ct.gather(arr, indices; mask=valid_mask, padding_value=-1.0f0)
 ```
 """
-@inline function gather(array::TileArray{T, 1}, indices::Tile{I};
+@inline function gather(array::TileArray{T, 1, I}, indices::Tile{J};
                         mask=nothing,
                         padding_value=nothing,
                         check_bounds::Bool=true,
-                        latency::Union{Int, Nothing}=nothing) where {T, I <: Integer}
-    indices_0 = indices .- one(I)
-    indices_i32 = convert(Tile{Int32}, indices_0)
-    ptr_tile = Intrinsics.offset(Tile(array.ptr), indices_i32)
+                        latency::Union{Int, Nothing}=nothing) where
+        {T, I, J <: Integer}
+    indices_0 = indices .- one(J)
+    array_indices = convert(Tile{I}, indices_0)
+    ptr_tile = Intrinsics.offset(Tile(array.ptr), array_indices)
 
-    bounds_mask = check_bounds ? _bounds_mask_1d(indices_i32, array) : nothing
+    bounds_mask = check_bounds ? _bounds_mask_1d(array_indices, array) : nothing
     final_mask = _combine_masks(bounds_mask, mask)
     _gather_load(ptr_tile, latency, final_mask, padding_value, T, size(indices))
 end
@@ -954,30 +971,31 @@ Indices are 1-indexed. Index tiles are broadcast to a common shape.
   when indices are known to be in-bounds to skip the comparisons.
 - `latency`: Optional latency hint (1-10), or nothing for compiler default
 """
-@inline function gather(array::TileArray{T, 2}, indices::Tuple{Tile{I0}, Tile{I1}};
+@inline function gather(array::TileArray{T, 2, I}, indices::Tuple{Tile{J0}, Tile{J1}};
                         mask=nothing,
                         padding_value=nothing,
                         check_bounds::Bool=true,
-                        latency::Union{Int, Nothing}=nothing) where {T, I0 <: Integer, I1 <: Integer}
-    idx0_0 = indices[1] .- one(I0)
-    idx1_0 = indices[2] .- one(I1)
+                        latency::Union{Int, Nothing}=nothing) where
+        {T, I, J0 <: Integer, J1 <: Integer}
+    idx0_0 = indices[1] .- one(J0)
+    idx1_0 = indices[2] .- one(J1)
 
     S = broadcast_shape(size(indices[1]), size(indices[2]))
     idx0_bc = broadcast_to(idx0_0, S)
     idx1_bc = broadcast_to(idx1_0, S)
 
-    idx0_i32 = convert(Tile{Int32}, idx0_bc)
-    idx1_i32 = convert(Tile{Int32}, idx1_bc)
+    idx0_array = convert(Tile{I}, idx0_bc)
+    idx1_array = convert(Tile{I}, idx1_bc)
 
     stride0_0d = Tile(array.strides[1])
     stride1_0d = Tile(array.strides[2])
     stride0 = broadcast_to(stride0_0d, S)
     stride1 = broadcast_to(stride1_0d, S)
 
-    linear_idx = idx0_i32 .* stride0 + idx1_i32 .* stride1
+    linear_idx = idx0_array .* stride0 + idx1_array .* stride1
     ptr_tile = Intrinsics.offset(Tile(array.ptr), linear_idx)
 
-    bounds_mask = check_bounds ? _bounds_mask_2d(idx0_i32, idx1_i32, array, S) : nothing
+    bounds_mask = check_bounds ? _bounds_mask_2d(idx0_array, idx1_array, array, S) : nothing
     final_mask = _combine_masks(bounds_mask, mask)
     _gather_load(ptr_tile, latency, final_mask, padding_value, T, S)
 end
@@ -1001,15 +1019,16 @@ indices = base .+ ct.arange(TILE)
 ct.scatter(arr, indices, result_tile; mask=valid_mask)
 ```
 """
-@inline function scatter(array::TileArray{T, 1}, indices::Tile{I, S}, tile::Tile{T, S};
+@inline function scatter(array::TileArray{T, 1, I}, indices::Tile{J, S}, tile::Tile{T, S};
                          mask=nothing,
                          check_bounds::Bool=true,
-                         latency::Union{Int, Nothing}=nothing) where {T, I <: Integer, S}
-    indices_0 = indices .- one(I)
-    indices_i32 = convert(Tile{Int32}, indices_0)
-    ptr_tile = Intrinsics.offset(Tile(array.ptr), indices_i32)
+                         latency::Union{Int, Nothing}=nothing) where
+        {T, I, J <: Integer, S}
+    indices_0 = indices .- one(J)
+    array_indices = convert(Tile{I}, indices_0)
+    ptr_tile = Intrinsics.offset(Tile(array.ptr), array_indices)
 
-    bounds_mask = check_bounds ? _bounds_mask_1d(indices_i32, array) : nothing
+    bounds_mask = check_bounds ? _bounds_mask_1d(array_indices, array) : nothing
     final_mask = _combine_masks(bounds_mask, mask)
     _scatter_store(ptr_tile, tile, latency, final_mask)
 end
@@ -1026,13 +1045,14 @@ Indices are 1-indexed. Index tiles and value tile must broadcast to same shape.
   when indices are known to be in-bounds to skip the comparisons.
 - `latency`: Optional latency hint (1-10), or nothing for compiler default
 """
-@inline function scatter(array::TileArray{T, 2}, indices::Tuple{Tile{I0}, Tile{I1}}, tile::Tile{T};
+@inline function scatter(array::TileArray{T, 2, I}, indices::Tuple{Tile{J0}, Tile{J1}}, tile::Tile{T};
                          mask=nothing,
                          check_bounds::Bool=true,
-                         latency::Union{Int, Nothing}=nothing) where {T, I0 <: Integer, I1 <: Integer}
+                         latency::Union{Int, Nothing}=nothing) where
+        {T, I, J0 <: Integer, J1 <: Integer}
     # Convert to 0-indexed
-    idx0_0 = indices[1] .- one(I0)
-    idx1_0 = indices[2] .- one(I1)
+    idx0_0 = indices[1] .- one(J0)
+    idx1_0 = indices[2] .- one(J1)
 
     # Broadcast indices to common shape
     S = broadcast_shape(broadcast_shape(size(indices[1]), size(indices[2])), size(tile))
@@ -1040,9 +1060,8 @@ Indices are 1-indexed. Index tiles and value tile must broadcast to same shape.
     idx1_bc = broadcast_to(idx1_0, S)
     tile_bc = broadcast_to(tile, S)
 
-    # Convert to Int32 for linear index computation
-    idx0_i32 = convert(Tile{Int32}, idx0_bc)
-    idx1_i32 = convert(Tile{Int32}, idx1_bc)
+    idx0_array = convert(Tile{I}, idx0_bc)
+    idx1_array = convert(Tile{I}, idx1_bc)
 
     # Get strides and broadcast to tile shape
     stride0_0d = Tile(array.strides[1])
@@ -1051,10 +1070,10 @@ Indices are 1-indexed. Index tiles and value tile must broadcast to same shape.
     stride1 = broadcast_to(stride1_0d, S)
 
     # Compute linear index = idx0 * stride0 + idx1 * stride1
-    linear_idx = idx0_i32 .* stride0 + idx1_i32 .* stride1
+    linear_idx = idx0_array .* stride0 + idx1_array .* stride1
     ptr_tile = Intrinsics.offset(Tile(array.ptr), linear_idx)
 
-    bounds_mask = check_bounds ? _bounds_mask_2d(idx0_i32, idx1_i32, array, S) : nothing
+    bounds_mask = check_bounds ? _bounds_mask_2d(idx0_array, idx1_array, array, S) : nothing
     final_mask = _combine_masks(bounds_mask, mask)
     _scatter_store(ptr_tile, tile_bc, latency, final_mask)
 end

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -12,7 +12,7 @@
 # and are defined as regular methods on `TileArray` — TileArray is its own
 # type, not an `AbstractArray` subtype, so there's no Base method to shadow
 # and no need for the `@overlay` mechanism. The new aggregate is built via
-# the regular Julia inner constructor `TileArray{T,N,S}(ptr, sizes, strides)`;
+# the regular Julia inner constructor `TileArray{T,N,I,S}(ptr, sizes, strides)`;
 # Julia's SROA pass eliminates the temporary struct so the IR sees direct
 # field references at each downstream use.
 #
@@ -94,7 +94,8 @@ function sliced_arraytype(@nospecialize(SrcT::Type{<:TileArray});
     spec = array_spec(SrcT)
     elem_T = eltype(SrcT)
     N = ndims(SrcT)
-    spec === nothing && return TileArray{elem_T, N}
+    I = indextype(SrcT)
+    spec === nothing && return TileArray{elem_T, N, I}
     # A StepRange scales that axis' element stride. The step is a runtime value
     # not encoded in the type (`2:1:20` is still a StepRange), so column-major
     # axis-1 contiguity must be dropped conservatively even when the step
@@ -102,7 +103,7 @@ function sliced_arraytype(@nospecialize(SrcT::Type{<:TileArray});
     new_contiguous = spec.contiguous && stepped_axis !== 1
     new_spec = ArraySpec{N, 0, new_contiguous, spec.stride_div_by, ntuple(_ -> 0, N),
                          spec.may_alias_internally}()
-    return TileArray{elem_T, N, new_spec}
+    return TileArray{elem_T, N, I, new_spec}
 end
 
 # Empty tuple: all axes walked, return the accumulated slice.
@@ -184,7 +185,7 @@ end
 
 # These derive a new TileArray with adjusted sizes/strides (and sometimes a
 # different rank) without touching the underlying memory. The new aggregate
-# is built via the regular `TileArray{T,N,S}(ptr, sizes, strides)` inner
+# is built via the regular `TileArray{T,N,I,S}(ptr, sizes, strides)` inner
 # constructor; SROA eliminates the temporary so the IR sees direct field
 # references at each downstream use.
 
@@ -201,14 +202,15 @@ function permuted_arraytype(@nospecialize(SrcT::Type{<:TileArray}),
     spec = array_spec(SrcT)
     elem_T = eltype(SrcT)
     N = ndims(SrcT)
-    spec === nothing && return TileArray{elem_T, N}
+    I = indextype(SrcT)
+    spec === nothing && return TileArray{elem_T, N, I}
     new_contiguous = spec.contiguous && Perm[1] == 1
     new_stride_div_by = ntuple(i -> spec.stride_div_by[Perm[i]], Val(N))
     new_shape_div_by  = ntuple(i -> spec.shape_div_by[Perm[i]],  Val(N))
     new_spec = ArraySpec{N, spec.alignment, new_contiguous,
                          new_stride_div_by, new_shape_div_by,
                          spec.may_alias_internally}()
-    return TileArray{elem_T, N, new_spec}
+    return TileArray{elem_T, N, I, new_spec}
 end
 
 function unsafe_permutedims(arr::TileArray{T, N}, ::Val{Perm}) where {T, N, Perm}
@@ -237,6 +239,7 @@ function reshaped_arraytype(@nospecialize(SrcT::Type{<:TileArray}),
                             ::Val{NewShape}) where {NewShape}
     spec = array_spec(SrcT)
     elem_T = eltype(SrcT)
+    I = indextype(SrcT)
     M = length(NewShape)
     new_shape_div_by = ntuple(i -> NewShape[i], Val(M))
     # Reshape recomputes dense column-major strides, so the result layout is
@@ -247,7 +250,7 @@ function reshaped_arraytype(@nospecialize(SrcT::Type{<:TileArray}),
         new_spec = ArraySpec{M, spec.alignment, true,
                              ntuple(_ -> 0, Val(M)), new_shape_div_by, false}()
     end
-    return TileArray{elem_T, M, new_spec}
+    return TileArray{elem_T, M, I, new_spec}
 end
 
 function unsafe_reshape(arr::TileArray{T, N}, ::Val{NewShape}) where {T, N, NewShape}

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -1,4 +1,5 @@
 public AbstractTileArray, TileArray, ArraySpec, Tile, Constant, TFloat32, similar_type,
+       indextype,
        bitwidth,
        ScalarInt, ScalarFloat, IntTile, FloatTile, TileOrInt, TileOrFloat,
        TileOrScalar
@@ -185,7 +186,8 @@ ArraySpec{N} with:
 - `stride_div_by`: Per-dimension stride divisibility (enables vectorized access)
 - `shape_div_by`: Per-dimension shape divisibility (eliminates boundary checks)
 """
-function compute_array_spec(ptr::Ptr{T}, sizes::NTuple{N, Int32}, strides::NTuple{N, Int32}) where {T, N}
+function compute_array_spec(ptr::Ptr{T}, sizes::NTuple{N, <:Integer},
+                            strides::NTuple{N, <:Integer}) where {T, N}
     elem_size = sizeof(T)
 
     # Pointer alignment
@@ -229,10 +231,11 @@ end
 
 
 """
-    TileArray{T, N, S}
+    TileArray{T, N, I, S}
 
 Represents an N-dimensional array argument to a kernel with element type `T`
-and specialization `S::ArraySpec`.
+and index type `I`. `I` is `Int32` unless an array size or stride requires
+`Int64`. `S::ArraySpec` holds layout specialization information.
 
 Unlike raw pointers, TileArray carries size and stride information that is
 passed to the kernel as runtime parameters, enabling dynamic array sizes.
@@ -242,25 +245,28 @@ specializations (e.g., aligned vs unaligned) produce different cubins.
 
 # Fields
 - `ptr::Ptr{T}`: Base pointer to array data
-- `sizes::NTuple{N, Int32}`: Size in each dimension
-- `strides::NTuple{N, Int32}`: Stride in each dimension (in elements)
+- `sizes::NTuple{N, I}`: Size in each dimension
+- `strides::NTuple{N, I}`: Stride in each dimension (in elements)
 """
-struct TileArray{T, N, S} <: AbstractTileArray{T, N}
+struct TileArray{T, N, I<:Union{Int32, Int64}, S} <: AbstractTileArray{T, N}
     ptr::Ptr{T}
-    sizes::NTuple{N, Int32}
-    strides::NTuple{N, Int32}
+    sizes::NTuple{N, I}
+    strides::NTuple{N, I}
 end
 Base.size(arr::TileArray) = arr.sizes
-function Base.size(arr::TileArray{<:Any, N}, d::Integer) where N
+function Base.size(arr::TileArray{<:Any, N, I}, d::Integer) where {N, I}
     d < 1 && error("arraysize: dimension out of range") # from Array method
-    return d > N ? Int32(1) : arr.sizes[d]
+    return d > N ? one(I) : arr.sizes[d]
 end
 Base.length(arr::TileArray) = prod(size(arr))
-# Return the ArraySpec value (third type parameter) if present
+indextype(::Type{<:TileArray{<:Any, <:Any, I}}) where {I} = I
+indextype(arr::TileArray) = indextype(typeof(arr))
+
+# Return the ArraySpec value (fourth type parameter) if present
 function array_spec(@nospecialize(T::Type{<:TileArray}))
     T isa DataType || return nothing  # UnionAll types don't have full parameters
-    length(T.parameters) >= 3 || return nothing
-    S = T.parameters[3]
+    length(T.parameters) >= 4 || return nothing
+    S = T.parameters[4]
     S isa ArraySpec && return S
     nothing
 end
@@ -272,13 +278,25 @@ array_spec(arr::TileArray) = array_spec(typeof(arr))
 Create a TileArray from a pointer, sizes, and strides.
 Computes the ArraySpec automatically based on alignment, contiguity, and divisibility.
 """
-function TileArray(ptr::Ptr{T}, sizes::NTuple{N, Int32}, strides::NTuple{N, Int32}) where {T, N}
+function TileArray(ptr::Ptr{T}, sizes::NTuple{N, I}, strides::NTuple{N, I}) where
+        {T, N, I<:Union{Int32, Int64}}
     spec = compute_array_spec(ptr, sizes, strides)
-    TileArray{T, N, spec}(ptr, sizes, strides)
+    TileArray{T, N, I, spec}(ptr, sizes, strides)
+end
+
+function array_indextype(sizes, strides)
+    all(x -> typemin(Int32) <= x <= typemax(Int32), sizes) &&
+    all(x -> typemin(Int32) <= x <= typemax(Int32), strides) ? Int32 : Int64
+end
+
+function check_indextype(@nospecialize(I))
+    I === Int32 || I === Int64 ||
+        throw(ArgumentError("TileArray index type must be Int32 or Int64, got $I"))
+    return I
 end
 
 """
-    TileArray(arr)
+    TileArray(arr; index=nothing)
 
 Create a TileArray from a device array (CuArray or similar).
 Automatically extracts pointer, sizes, strides, and computes ArraySpec.
@@ -288,15 +306,21 @@ This method works with any array type that supports:
 - `size(arr)` - returns array dimensions
 - `strides(arr)` - returns array strides
 """
-function TileArray(arr::AbstractArray{T, N}) where {T, N}
-    sizes = NTuple{N, Int32}(Int32.(size(arr)))
-    strides_val = NTuple{N, Int32}(Int32.(strides(arr)))
+function TileArray(arr::AbstractArray{T, N}; index=nothing) where {T, N}
+    arr_sizes = size(arr)
+    arr_strides = strides(arr)
+    I = check_indextype(something(index, array_indextype(arr_sizes, arr_strides)))
+    sizes = NTuple{N, I}(I.(arr_sizes))
+    strides_val = NTuple{N, I}(I.(arr_strides))
     TileArray(device_pointer(arr), sizes, strides_val)
 end
 
-function TileArray(arr::PermutedDimsArray{T, N}) where {T, N}
-    sizes = NTuple{N, Int32}(Int32.(size(arr)))
-    strides_val = NTuple{N, Int32}(Int32.(strides(arr)))
+function TileArray(arr::PermutedDimsArray{T, N}; index=nothing) where {T, N}
+    arr_sizes = size(arr)
+    arr_strides = strides(arr)
+    I = check_indextype(something(index, array_indextype(arr_sizes, arr_strides)))
+    sizes = NTuple{N, I}(I.(arr_sizes))
+    strides_val = NTuple{N, I}(I.(arr_strides))
     TileArray(device_pointer(parent(arr)), sizes, strides_val)
 end
 
@@ -455,11 +479,12 @@ function Base.size(tiles::TiledView)
     steps = tiled_view_step(typeof(tiles))
     order = tiled_view_order(typeof(tiles))
     dims = something(order, ntuple(identity, Val(ndims(tiles))))
-    ntuple(i -> cld(size(tiles.parent, dims[i]), Int32(steps[i])), Val(ndims(tiles)))
+    I = indextype(tiles.parent)
+    ntuple(i -> cld(size(tiles.parent, dims[i]), I(steps[i])), Val(ndims(tiles)))
 end
 function Base.size(tiles::TiledView, d::Integer)
     d < 1 && error("arraysize: dimension out of range")
-    d > ndims(tiles) ? Int32(1) : size(tiles)[d]
+    d > ndims(tiles) ? one(indextype(tiles.parent)) : size(tiles)[d]
 end
 
 """

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -300,6 +300,8 @@ end
 
 Create a TileArray from a device array (CuArray or similar).
 Automatically extracts pointer, sizes, strides, and computes ArraySpec.
+Sizes and strides use `Int32` when possible and `Int64` otherwise. Pass
+`index=Int32` or `index=Int64` to select the width explicitly.
 
 This method works with any array type that supports:
 - `pointer(arr)` - returns device pointer

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -259,6 +259,13 @@ function Base.size(arr::TileArray{<:Any, N, I}, d::Integer) where {N, I}
     return d > N ? one(I) : arr.sizes[d]
 end
 Base.length(arr::TileArray) = prod(size(arr))
+
+"""
+    indextype(array_or_type)
+
+Return the integer type used for a `TileArray`'s sizes, strides, and address
+calculations.
+"""
 indextype(::Type{<:TileArray{<:Any, <:Any, I}}) where {I} = I
 indextype(arr::TileArray) = indextype(typeof(arr))
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -56,27 +56,27 @@ import REPL
         # 1D vec_add: load/add/store across float types.
         spec1d = ArraySpec{1}(16, true)
         for T in (Float32, Float16)
-            tt = Tuple{TileArray{T, 1, spec1d},
-                       TileArray{T, 1, spec1d},
-                       TileArray{T, 1, spec1d},
+            tt = Tuple{TileArray{T, 1, Int32, spec1d},
+                       TileArray{T, 1, Int32, spec1d},
+                       TileArray{T, 1, Int32, spec1d},
                        Constant{Int, 1024}}
             precompile_kernel(vadd_1d, tt)
         end
 
         # 2D vec_add: multi-dim block IDs and shapes.
         spec2d = ArraySpec{2}(16, true)
-        let tt = Tuple{TileArray{Float32, 2, spec2d},
-                       TileArray{Float32, 2, spec2d},
-                       TileArray{Float32, 2, spec2d},
+        let tt = Tuple{TileArray{Float32, 2, Int32, spec2d},
+                       TileArray{Float32, 2, Int32, spec2d},
+                       TileArray{Float32, 2, Int32, spec2d},
                        Constant{Int, 32}, Constant{Int, 32}}
             precompile_kernel(vadd_2d, tt)
         end
 
         # Gather/scatter path: arange, broadcast_to, gather, scatter, and
         # the contiguous_gather assume infrastructure.
-        let tt = Tuple{TileArray{Float32, 1, spec1d},
-                       TileArray{Float32, 1, spec1d},
-                       TileArray{Float32, 1, spec1d},
+        let tt = Tuple{TileArray{Float32, 1, Int32, spec1d},
+                       TileArray{Float32, 1, Int32, spec1d},
+                       TileArray{Float32, 1, Int32, spec1d},
                        Constant{Int, 1024}}
             precompile_kernel(vadd_gather, tt)
         end

--- a/test/codegen/assume.jl
+++ b/test/codegen/assume.jl
@@ -12,7 +12,7 @@
     spec1d = ct.ArraySpec{1}(128, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             ct.store(a, 1, ct.load(a, 1, (16,)))
             return
         end
@@ -23,7 +23,7 @@
     spec_unaligned = ct.ArraySpec{1}(0, false)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec_unaligned}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec_unaligned}}) do a
             ct.store(a, 1, ct.load(a, 1, (16,)))
             return
         end
@@ -38,7 +38,7 @@ end
     spec2d = ct.ArraySpec{2}(16, true, (0, 0), (16, 8))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             ct.store(a, (1, 1), ct.load(a, (1, 1), (16, 16)))
             return
         end
@@ -56,7 +56,7 @@ end
     spec2d = ct.ArraySpec{2}(16, true, (0, 0), (16, 8))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             ct.store(a, (1, 1), ct.load(a, (1, 1), (16, 16)))
             return
         end
@@ -75,7 +75,7 @@ end
     spec1d = ct.ArraySpec{1}(128, false, (4,), (16,))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return
@@ -96,7 +96,7 @@ end
     spec1d = ct.ArraySpec{1}(128, true, (0,), (16,))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[1:64]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return
@@ -115,7 +115,7 @@ end
     spec1d = ct.ArraySpec{1}(128, false, (4,), (16,))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[1:64]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return
@@ -132,7 +132,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true, (0,), (0,))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return
@@ -147,7 +147,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32}) do a, n
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, n
             ct.store(a, n, ct.load(a, n, (16,)))
             return
         end
@@ -169,8 +169,8 @@ end
     spec1d = ct.ArraySpec{1}(128, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                         ct.TileArray{Float32,1,spec1d}}) do a, b
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                         ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
             indices = ct.arange(16)
             tile = ct.gather(a, indices)
             ct.scatter(b, indices, tile)
@@ -198,7 +198,7 @@ end
     spec1d = ct.ArraySpec{1}(128, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             tile = ct.load(a, 1, (16,))
             indices = ct.arange(16)
             tile2 = ct.gather(a, indices)
@@ -216,7 +216,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             n = ct.bid(1) * Int32(128)
             n = ct.assume_divisible_by(n, 128)
             @check "muli"
@@ -228,7 +228,7 @@ end
 
     # Non-positive divisor is rejected
     @test_throws "assume: DivBy requires a positive divisor, got 0" begin
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             n = ct.assume_divisible_by(ct.bid(1), 0)
             ct.store(a, n, ct.load(a, n, (64,)))
             return
@@ -237,7 +237,7 @@ end
 
 
     @test_throws "contradicts a known constant" begin
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             n = ct.assume_divisible_by(Int32(5), 4)
             ct.store(a, n, ct.load(a, n, (64,)))
             return
@@ -246,7 +246,7 @@ end
 
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             n = ct.assume_divisible_by(Int32(8), 4)
             @check_not "assume div_by<4>"
             ct.store(a, n, ct.load(a, n, (64,)))

--- a/test/codegen/bounds.jl
+++ b/test/codegen/bounds.jl
@@ -18,7 +18,7 @@
     spec = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
             ct.store(a, 1, ct.load(a, 1, (16,)))
             return
         end
@@ -33,7 +33,7 @@ end
     spec = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return

--- a/test/codegen/boundscheck_integration.jl
+++ b/test/codegen/boundscheck_integration.jl
@@ -1,7 +1,7 @@
 import IRStructurizer
 
 const bounds_spec = ct.ArraySpec{1}(128, true)
-const BoundsArray = ct.TileArray{Float32, 1, bounds_spec}
+const BoundsArray = ct.TileArray{Float32, 1, Int32, bounds_spec}
 
 function bounds_context(a::BoundsArray, b::BoundsArray)
     check_bounds = Base.@_boundscheck
@@ -95,7 +95,7 @@ else
         @test test_bytecode(bounds_loop, loop_types) ==
               test_bytecode(bounds_loop_literal, loop_types)
 
-        range_types = Tuple{ct.TileArray{Int32, 1, ct.ArraySpec{1}(1, true)}, Int32, Int32}
+        range_types = Tuple{ct.TileArray{Int32, 1, Int32, ct.ArraySpec{1}(1, true)}, Int32, Int32}
         checked_kernel = function(out, n, i)
             value = (Int32(1):n)[i]
             ct.store(out, 1, ct.Tile(value))

--- a/test/codegen/boundscheck_views.jl
+++ b/test/codegen/boundscheck_views.jl
@@ -2,9 +2,9 @@
 # `@inbounds` must not discard a partial tile's padding or store clipping.
 
 const view_spec = ct.ArraySpec{1}(64, true)
-const ViewArray = ct.TileArray{Float32, 1, view_spec}
+const ViewArray = ct.TileArray{Float32, 1, Int32, view_spec}
 const view2_spec = ct.ArraySpec{2}(64, true)
-const ViewArray2 = ct.TileArray{Float32, 2, view2_spec}
+const ViewArray2 = ct.TileArray{Float32, 2, Int32, view2_spec}
 
 direct_plain(a) = (ct.store(a, ct.bid(1),
                             ct.load(a, ct.bid(1), (16,); padding_mode=ct.PaddingMode.Zero)); return)

--- a/test/codegen/coverage.jl
+++ b/test/codegen/coverage.jl
@@ -13,8 +13,8 @@
     end
 
     cov_spec = ct.ArraySpec{1}(16, true)
-    cov_tt = Tuple{ct.TileArray{Float32,1,cov_spec}, ct.TileArray{Float32,1,cov_spec},
-                ct.TileArray{Float32,1,cov_spec}}
+    cov_tt = Tuple{ct.TileArray{Float32,1,Int32,cov_spec}, ct.TileArray{Float32,1,Int32,cov_spec},
+                ct.TileArray{Float32,1,Int32,cov_spec}}
 
     # Whether any line in `lo:hi` of `file` has a nonzero execution count in an lcov
     # tracefile.

--- a/test/codegen/cse.jl
+++ b/test/codegen/cse.jl
@@ -11,7 +11,7 @@
     spec1d = ct.ArraySpec{1}(16, true, (0,), (16,))
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             t1 = ct.load(a, 1, (16,))
             t2 = ct.load(a, 1, (16,))
             ct.store(a, 1, t1 + t2)
@@ -26,8 +26,8 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                         ct.TileArray{Float32,1,spec1d}}) do a, b
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                         ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
             ct.store(b, 1, ct.load(a, 1, (16,)))
             return
         end
@@ -44,7 +44,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do out
+        code_tiled(Tuple{ct.TileArray{Int64,1,Int32,spec1d}}) do out
             a = ct.arange(16; dtype = Int64)
             b = ct.arange(16)  # default dtype = Int32
             # `a .- b` requires extending b to Int64 — no type collision
@@ -66,7 +66,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Bool}) do a, c
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Bool}) do a, c
             t1 = ct.load(a, 1, (16,))     # entry: emits the canonical mtv
             if c
                 Base.donotdelete(t1)
@@ -87,7 +87,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Bool}) do a, c
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Bool}) do a, c
             if c
                 ct.store(a, 1, ct.load(a, 1, (16,)))
                 ct.store(a, 1, ct.load(a, 1, (16,)))
@@ -106,7 +106,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Bool}) do a, c
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Bool}) do a, c
             if c
                 ct.store(a, 1, ct.load(a, 1, (16,)))
             else
@@ -128,7 +128,7 @@ end
     spec1d = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             t1 = ct.load(a, 1, (16,))
             t2 = ct.load(a, 1, (16,))
             ct.store(a, 1, t1 + t2)

--- a/test/codegen/fpmode.jl
+++ b/test/codegen/fpmode.jl
@@ -6,7 +6,7 @@ spec2d = ct.ArraySpec{2}(16, true)
 @testset "default (no @fpmode)" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             @check "addf"
@@ -22,7 +22,7 @@ end
 @testset "rounding_mode only" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             ct.@fpmode rounding_mode=ct.Rounding.Zero begin
@@ -40,7 +40,7 @@ end
 @testset "flush_to_zero only" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             ct.@fpmode flush_to_zero=true begin
@@ -58,7 +58,7 @@ end
 @testset "rounding_mode + flush_to_zero" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             ct.@fpmode rounding_mode=ct.Rounding.Zero flush_to_zero=true begin
@@ -76,7 +76,7 @@ end
 @testset "scope: ops outside @fpmode are unaffected" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             # before: default
@@ -103,7 +103,7 @@ end
 @testset "nesting with inheritance" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (16,))
             ct.@fpmode rounding_mode=ct.Rounding.Zero flush_to_zero=true begin
@@ -134,7 +134,7 @@ end
 @testset "subprogram propagation (reduction)" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             t = ct.load(a, pid, (4, 16))
             ct.@fpmode flush_to_zero=true begin

--- a/test/codegen/gather_scatter_view.jl
+++ b/test/codegen/gather_scatter_view.jl
@@ -3,7 +3,7 @@
 # index encoding, and conservative token behavior on their own.
 
 spec2d = ct.ArraySpec{2}(16, true)
-AT2d = ct.TileArray{Float32,2,spec2d}
+AT2d = ct.TileArray{Float32,2,Int32,spec2d}
 
 @testset "GatherScatterView — row-major dimension conversion" begin
     @test @filecheck begin

--- a/test/codegen/int64_indexing.jl
+++ b/test/codegen/int64_indexing.jl
@@ -1,0 +1,86 @@
+spec1d = ct.ArraySpec{1}(16, true)
+spec2d = ct.ArraySpec{2}(16, true)
+Array1D32 = ct.TileArray{Float32, 1, Int32, spec1d}
+Array1D64 = ct.TileArray{Float32, 1, Int64, spec1d}
+Array2D64 = ct.TileArray{Float32, 2, Int64, spec2d}
+
+@testset "Int64 indexing — partition views" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "make_tensor_view"
+        @check "tile<i64> -> tensor_view"
+        @check "exti {{.*}} signed : tile<i32> -> tile<i64>"
+        @check "load_view_tko"
+        @check "tile<i64> -> tile<16xf32>"
+        code_tiled(Tuple{Array1D64}; bytecode_version=v"13.3") do a
+            index = ct.bid(1)
+            tile = ct.load(a, index, (16,))
+            ct.store(a, index, tile)
+            return
+        end
+    end
+
+    @test_throws "Int64-indexed TileArray requires Tile IR bytecode v13.3+" code_tiled(
+        Tuple{Array1D64}; bytecode_version=v"13.2") do a
+        ct.store(a, 1, ct.load(a, 1, (16,)))
+        return
+    end
+end
+
+@testset "Int64 indexing — mixed array widths" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "make_tensor_view"
+        @check "tile<i32> -> tensor_view"
+        @check "make_tensor_view"
+        @check "tile<i64> -> tensor_view"
+        code_tiled(Tuple{Array1D32, Array1D64}; bytecode_version=v"13.3") do a32, a64
+            ct.store(a32, 1, ct.load(a32, 1, (16,)))
+            ct.store(a64, 1, ct.load(a64, 1, (16,)))
+            return
+        end
+    end
+end
+
+@testset "Int64 indexing — strided and gather/scatter views" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "make_strided_view"
+        @check "load_view_tko"
+        @check "tile<i64> -> tile<4x4xf32>"
+        @check "make_gather_scatter_view"
+        @check "tile<i64>, tile<4xi64> -> tile<4x4xf32>"
+        code_tiled(Tuple{Array2D64}; bytecode_version=v"13.3") do a
+            tiles = eachtile(a, (4, 4); step=(2, 3))
+            tile = ct.load(tiles, (ct.bid(1), ct.bid(2)))
+            ct.store(tiles, (ct.bid(1), ct.bid(2)), tile)
+
+            rows = ct.arange(4)
+            sparse = @view a[rows, Int32(1):Int32(4)]
+            gathered = ct.load(sparse, (4, 4))
+            ct.store(sparse, gathered)
+            return
+        end
+    end
+end
+
+@testset "Int64 indexing — pointer and atomic paths" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "offset {{.*}} tile<4x4xi64> -> tile<4x4xptr<f32>>"
+        @check "cmpi less_than {{.*}} unsigned : tile<4x4xi64>"
+        @check "atomic_rmw_tko"
+        @check "atomic_red_view_tko"
+        @check "tile<i64> -> token"
+        code_tiled(Tuple{Array2D64}; bytecode_version=v"13.3") do a
+            indices = ct.arange(4)
+            rows = reshape(indices, (4, 1))
+            cols = reshape(indices, (1, 4))
+            tile = ct.gather(a, (rows, cols))
+            ct.scatter(a, (rows, cols), tile)
+            ct.atomic_add(a, (rows, cols), tile)
+            ct.atomic_store_add(a, (ct.bid(1), ct.bid(2)), tile)
+            return
+        end
+    end
+end

--- a/test/codegen/int64_indexing.jl
+++ b/test/codegen/int64_indexing.jl
@@ -79,7 +79,7 @@ end
             tile = ct.gather(a, (rows, cols))
             ct.scatter(a, (rows, cols), tile)
             ct.atomic_add(a, (rows, cols), tile)
-            ct.atomic_store_add(a, (ct.bid(1), ct.bid(2)), tile)
+            ct.atomic_store_add(a, (ct.bid(1), 1), tile)
             return
         end
     end

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -9,7 +9,7 @@
     @testset "Float32" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 ct.store(b, pid, tile)
@@ -21,7 +21,7 @@
     @testset "Float64" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float64,1,spec}, ct.TileArray{Float64,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec}, ct.TileArray{Float64,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "addf"
@@ -35,7 +35,7 @@
     @testset "Float16" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float16,1,spec}, ct.TileArray{Float16,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float16,1,Int32,spec}, ct.TileArray{Float16,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "addf"
@@ -49,7 +49,7 @@
     @testset "Int32" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}, ct.TileArray{Int32,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}, ct.TileArray{Int32,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "addi"
@@ -70,7 +70,7 @@ end
         spec = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, ct.Constant{Int,16}}) do a, b, c, tile
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, ct.Constant{Int,16}}) do a, b, c, tile
                 @check "get_tile_block_id"
                 bid = ct.bid(1)
                 @check "load_view_tko"
@@ -91,7 +91,7 @@ end
         spec = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Float32,2,spec}, ct.Constant{Int,32}, ct.Constant{Int,32}}) do x, y, tm, tn
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Float32,2,Int32,spec}, ct.Constant{Int,32}, ct.Constant{Int,32}}) do x, y, tm, tn
                 @check "get_tile_block_id"
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
@@ -111,7 +111,7 @@ end
         spec = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Float32,2,spec}, ct.TileArray{Float32,2,spec}, ct.Constant{Int,32}, ct.Constant{Int,32}, ct.Constant{Int,16}}) do A, B, C, tm, tn, tk
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Float32,2,Int32,spec}, ct.Constant{Int,32}, ct.Constant{Int,32}, ct.Constant{Int,16}}) do A, B, C, tm, tn, tk
                 bid = ct.bid(1)
                 num_k = ct.num_tiles(A, 2, (tm, tk))
                 acc = zeros(Float32, (tm, tn))
@@ -138,8 +138,8 @@ end
         spec1d = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Float32,2,spec},
-                           ct.TileArray{Float32,1,spec1d}, ct.Constant{Int,16}}) do X, Y, Sum, TILE_N
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Float32,2,Int32,spec},
+                           ct.TileArray{Float32,1,Int32,spec1d}, ct.Constant{Int,16}}) do X, Y, Sum, TILE_N
                 bid_m = ct.bid(1)
                 num_tiles = ct.num_tiles(X, 2, (1, TILE_N))
 
@@ -173,8 +173,8 @@ end
         spec2d = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d},
-                           ct.TileArray{Int32,1,spec}, Int32, ct.Constant{Int,16}}) do DW, Partial, Locks, group_bid, TILE_N
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d},
+                           ct.TileArray{Int32,1,Int32,spec}, Int32, ct.Constant{Int,16}}) do DW, Partial, Locks, group_bid, TILE_N
                 bid = ct.bid(1)
                 num_tiles = ct.num_tiles(DW, 2, (1, TILE_N))
 
@@ -223,7 +223,7 @@ end
             # With row-major Tile IR, indices are reversed: Julia (row, col) → TileIR [col, row]
             @check "[[IDX:%.+]] = subi %loopIdx"
             @check "store_view_tko{{.*}}[[[IDX]], %{{[^,]+}}]"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Int32,1,spec1d},
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Int32,1,Int32,spec1d},
                            Int32, ct.Constant{Int,4}, ct.Constant{Int,4}}) do DB, Locks, num_iters, GROUP_SIZE_M, TILE_N
                 bid_m = ct.bid(1)
                 # group_bid_m: 1-indexed group ID
@@ -260,7 +260,7 @@ end
             # offset would use %loopIdx instead of group_bid_m.
             @check_not "offset {{.*}}%loopIdx"
             @check "atomic_cas_tko"
-            ct.code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Int32,1,spec1d},
+            ct.code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Int32,1,Int32,spec1d},
                                Int32, ct.Constant{Int,4}, ct.Constant{Int,4}}) do DB, Locks, num_iters, GROUP_SIZE_M, TILE_N
                 bid_m = ct.bid(1)
                 # group_bid_m: 1-indexed group ID
@@ -292,7 +292,7 @@ end
             @check_label "entry"
             @check "loop iter_values"
             @check "loop iter_values"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}, ct.TileArray{Int32,1,spec1d}}) do Locks1, Locks2
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}}) do Locks1, Locks2
                 idx = ct.bid(1)
 
                 # Outer spinloop
@@ -317,7 +317,7 @@ end
             @check_label "entry"
             @check "for %loopIdx in"
             @check "loop iter_values"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}, Int32}) do Locks, num_iters
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}, Int32}) do Locks, num_iters
                 idx = ct.bid(1)
 
                 for j in Int32(1):num_iters
@@ -352,8 +352,8 @@ end
             # The two reduces must use different result indices (not the same one twice)
             @check "reduce [[R1:%.+]]#1"
             @check "reduce [[R2:%.+]]#0"
-            code_tiled(Tuple{ct.TileArray{Float32, 2, spec2d}, ct.TileArray{Float32, 2, spec2d},
-                           ct.TileArray{Float32, 1, spec1d}, ct.TileArray{Float32, 1, spec1d},
+            code_tiled(Tuple{ct.TileArray{Float32, 2, Int32, spec2d}, ct.TileArray{Float32, 2, Int32, spec2d},
+                           ct.TileArray{Float32, 1, Int32, spec1d}, ct.TileArray{Float32, 1, Int32, spec1d},
                            ct.Constant{Int, TILE_M}, ct.Constant{Int, TILE_N}}) do DW, DB, FINAL_DW, FINAL_DB, _TILE_M, _TILE_N
                 bid_n = ct.bid(1)
                 num_tiles = ct.num_tiles(DW, 2, (_TILE_N, _TILE_M))
@@ -390,7 +390,7 @@ end
         spec = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec},
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec},
                            ct.Constant{Int,16}}) do out, inp, TILE_N
                 bid = ct.bid(1)
                 num_tiles = ct.num_tiles(inp, 1, (TILE_N,))
@@ -448,7 +448,7 @@ end
             return
         end
         @test ct.code_structured(k_closure_capture,
-                                 Tuple{ct.TileArray{UInt16, 1, spec}, Int};
+                                 Tuple{ct.TileArray{UInt16, 1, Int32, spec}, Int};
                                  optimize=false) isa Vector
     end
 
@@ -467,8 +467,8 @@ end
             @check "load_view_tko"
             @check "mulf"
             @check "store_view_tko"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d},
-                           ct.TileArray{Float32,2,spec2d}, ct.Constant{Int,1024}}) do X, W, Y, TILE_N
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d},
+                           ct.TileArray{Float32,2,Int32,spec2d}, ct.Constant{Int,1024}}) do X, W, Y, TILE_N
                 bid_m = ct.bid(1)
                 num_tiles = ct.num_tiles(X, 1, (TILE_N, 1))
                 # Hoisted: W load before loop
@@ -493,7 +493,7 @@ end
         @testset "1D gather" begin
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                     pid = ct.bid(1)
                     # Create index tile (simple: just use arange)
                     @check "iota"
@@ -511,7 +511,7 @@ end
         @testset "1D scatter" begin
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                     pid = ct.bid(1)
                     # Load tile
                     tile = ct.load(a, pid, (16,))
@@ -530,7 +530,7 @@ end
         @testset "1D gather with Int indices" begin
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                     pid = ct.bid(1)
                     # Use Int (Int64) to test type conversion
                     @check "iota"
@@ -549,7 +549,7 @@ end
         @testset "1D scatter with Int indices" begin
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     # Use Int (Int64) to test type conversion
@@ -573,8 +573,8 @@ end
             spec2d_c = ct.ArraySpec{2}(16, true)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d_c},
-                                 ct.TileArray{Float32,1,spec_out}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d_c},
+                                 ct.TileArray{Float32,1,Int32,spec_out}}) do a, b
                     pid = ct.bid(1)
                     i0 = ct.arange(16)
                     i1 = ct.arange(16)
@@ -591,8 +591,8 @@ end
             spec2d_nc = ct.ArraySpec{2}(16, false)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d_nc},
-                                 ct.TileArray{Float32,1,spec_out}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d_nc},
+                                 ct.TileArray{Float32,1,Int32,spec_out}}) do a, b
                     pid = ct.bid(1)
                     i0 = ct.arange(16)
                     i1 = ct.arange(16)
@@ -615,7 +615,7 @@ end
         @testset "binary op type mismatch errors in Julia" begin
             # addi with mismatched types (Int32 + Int64) should fail if the
             # result is used. Dead code is removed by DCE before codegen.
-            @test_throws ct.CodegenErrors code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+            @test_throws ct.CodegenErrors code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                 pid = ct.bid(1)  # Int32
                 # Force type mismatch by calling addi with different types
                 result = ct.Intrinsics.addi(pid, Int64(1))
@@ -636,7 +636,7 @@ end
         end
 
         @testset "independent errors all reported, in program order" begin
-            err = trycompile(Tuple{ct.TileArray{Float32,1,spec}, Int, Int}) do a, n, m
+            err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int, Int}) do a, n, m
                 pid = ct.bid(1)
                 ct.store(a; index=pid, tile=ct.fill(1f0, (n,)))
                 ct.store(a; index=pid, tile=ct.fill(2f0, (m,)))
@@ -652,7 +652,7 @@ end
         @testset "cascading errors suppressed" begin
             # Failures on values derived from an already-failed statement are
             # cascades; only the root cause is reported.
-            err = trycompile(Tuple{ct.TileArray{Float32,1,spec}, Int}) do a, n
+            err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int}) do a, n
                 pid = ct.bid(1)
                 t = ct.fill(1f0, (n,))
                 ct.store(a; index=pid, tile=t + t)
@@ -671,7 +671,7 @@ end
                 ct.store(a; index=pid, tile=ct.fill(2f0, (n,)))
                 nothing
             end
-            err = trycompile(Tuple{ct.TileArray{Float32,1,spec}, Int}) do a, n
+            err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int}) do a, n
                 fill_twice(a, ct.bid(1), n)
                 return
             end
@@ -731,7 +731,7 @@ end
         @testset "mismatched tile shapes with + produces MethodError" begin
             spec2d = ct.ArraySpec{2}(16, true)
             @test_throws "Unsupported function call during Tile IR compilation" begin
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile_a = ct.load(a, pid, (4, 8))
                     tile_b = ct.load(a, pid, (8, 4))
@@ -745,7 +745,7 @@ end
         @testset "no matching method produces MethodError" begin
             only_ints(x::Int) = x
             @test_throws "Unsupported function call during Tile IR compilation" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     tile = ct.load(a, ct.bid(1), (16,))
                     only_ints(tile)
                     return
@@ -760,7 +760,7 @@ end
             # `Base.devnull` is `const`, so it's usable as the IO arg
             # without pulling in a non-`const` global like `stdout`.
             @test_throws "Unsupported function call during Tile IR compilation" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     tile = ct.load(a, ct.bid(1), (16,))
                     write(devnull, tile)
                     return
@@ -773,7 +773,7 @@ end
             # bindings — `emit_value!(::GlobalRef)` errors strictly
             # when the binding isn't statically known.
             @test_throws "non-`const` global" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     tile = ct.load(a, ct.bid(1), (16,))
                     write(stdout, tile)
                     return
@@ -791,7 +791,7 @@ end
 
         @testset "non-power-of-2 load shape rejected" begin
             @test_throws "load: tile dimension 1 must be a power of 2, got 3" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     ct.load(a, ct.bid(1), (3,))
                 end
             end
@@ -815,7 +815,7 @@ end
 
         @testset "non-power-of-2 reshape target rejected" begin
             @test_throws "reshape: tile dimension 1 must be a power of 2, got 3" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     tile = ct.load(a, ct.bid(1), (16,))
                     reshape(tile, (3,))
                 end
@@ -824,7 +824,7 @@ end
 
         @testset "zero dimension rejected" begin
             @test_throws "load: tile dimension 1 must be positive, got 0" begin
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     ct.load(a, ct.bid(1), (0,))
                 end
             end
@@ -841,16 +841,16 @@ end
         @testset "valid power-of-2 shapes accepted" begin
             # These should not throw - test a few key sizes
             code_tiled(devnull, a -> (ct.store(a, ct.bid(1), ct.load(a, ct.bid(1), (16,))); return),
-                       Tuple{ct.TileArray{Float32,1,spec}})
+                       Tuple{ct.TileArray{Float32,1,Int32,spec}})
             code_tiled(devnull, a -> (ct.store(a, ct.bid(1), ct.load(a, ct.bid(1), (32,))); return),
-                       Tuple{ct.TileArray{Float32,1,spec}})
+                       Tuple{ct.TileArray{Float32,1,Int32,spec}})
             code_tiled(devnull, a -> (ct.store(a, ct.bid(1), ct.load(a, ct.bid(1), (128,))); return),
-                       Tuple{ct.TileArray{Float32,1,spec}})
+                       Tuple{ct.TileArray{Float32,1,Int32,spec}})
         end
 
         @testset "extract index out of bounds rejected" begin
             @test_throws "extract: slice index 3 out of bounds in dimension 2" begin
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     tile = ct.load(a, (ct.bid(1), 1), (4, 8))
                     ct.extract(tile, (2, 3), (2, 4))
                 end
@@ -859,7 +859,7 @@ end
 
         @testset "extract shape not dividing input rejected" begin
             @test_throws "extract: input shape (4, 8) is not divisible by extract shape (4, 16)" begin
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     tile = ct.load(a, (ct.bid(1), 1), (4, 8))
                     ct.extract(tile, (1, 1), (4, 16))
                 end
@@ -868,7 +868,7 @@ end
 
         @testset "multi-dim: all dimensions must be pow2" begin
             @test_throws "load: tile dimension 2 must be a power of 2, got 3" begin
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     ct.load(a, (ct.bid(1), 1), (4, 3))
                 end
             end
@@ -892,7 +892,7 @@ end
                 # Verify no subi appears between load and store - constant 1-1 should fold to 0
                 @check_not "subi"
                 @check "store_view_tko"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     idx = Int32(1)
                     tile = ct.load(a, idx, (16,))
                     ct.store(a, idx, tile)
@@ -907,7 +907,7 @@ end
                 @check_not "addf"
                 @check "constant <f32: 5"
                 @check "mulf"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     scale = 2.0f0 + 3.0f0
@@ -922,7 +922,7 @@ end
                 @check_label "entry"
                 @check_not "subi"
                 @check "load_view"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     idx = Int32(5) - Int32(2)
                     tile = ct.load(a, idx, (16,))
                     Base.donotdelete(tile)
@@ -936,7 +936,7 @@ end
                 @check_label "entry"
                 @check "constant <f32: 6.000000e+00> : tile<16xf32>"
                 @check "mulf"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     scale = 2.0f0 * 3.0f0
@@ -968,7 +968,7 @@ const _CODEGEN_TEST_FLOAT64 = 3.14159
         # causing MulFOp to receive `nothing` instead of a bytecode Value.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "constant <f32"
@@ -982,7 +982,7 @@ const _CODEGEN_TEST_FLOAT64 = 3.14159
     @testset "external Float64 constant in arithmetic" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float64,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "constant <f64"
@@ -998,7 +998,7 @@ const _CODEGEN_TEST_FLOAT64 = 3.14159
         # Using a local variable forces Julia to emit an assignment from the GlobalRef.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 local_const = _CODEGEN_TEST_FLOAT32
@@ -1015,7 +1015,7 @@ const _CODEGEN_TEST_FLOAT64 = 3.14159
         # because encode_MulFOp! received Nothing from the ghost-wrapped GlobalRef.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Float32}) do a, scale
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, scale
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "constant <f32"
@@ -1035,7 +1035,7 @@ const _CODEGEN_TEST_FLOAT64 = 3.14159
         # operand (LHS) to cover both operand positions.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Float32}) do a, offset
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, offset
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "constant <f32"
@@ -1061,7 +1061,7 @@ end
     @testset "num_ctas only" begin
         @test @filecheck begin
             @check "optimization_hints=<default = {num_cta_in_cga = 4}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=4) do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas=4) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t)
@@ -1073,7 +1073,7 @@ end
     @testset "occupancy only" begin
         @test @filecheck begin
             @check "optimization_hints=<default = {occupancy = 8}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=8) do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", occupancy=8) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t)
@@ -1085,7 +1085,7 @@ end
     @testset "both hints" begin
         @test @filecheck begin
             @check "optimization_hints=<default = {num_cta_in_cga = 2, occupancy = 4}"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0", num_ctas=2, occupancy=4) do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0", num_ctas=2, occupancy=4) do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t)
@@ -1099,7 +1099,7 @@ end
         # (matching Python cuTile, which always emits the target architecture).
         @test @filecheck begin
             @check "optimization_hints=<default = {}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t)
@@ -1113,7 +1113,7 @@ end
         # instead of "default".
         @test @filecheck begin
             @check "optimization_hints=<sm_120 = {num_cta_in_cga = 4}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0",
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0",
                           num_ctas=4, bytecode_version=v"13.2") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
@@ -1125,7 +1125,7 @@ end
         @test @filecheck begin
             @check "load_view_tko"
             @check "optimization_hints = <sm_120 = {latency = 5}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0",
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0",
                           bytecode_version=v"13.2") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=5)
@@ -1138,28 +1138,28 @@ end
     @testset "num_ctas validation" begin
         # Too small
         @test_throws "num_ctas must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=0)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas=0)
         end
 
         # Too large
         @test_throws "num_ctas must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=17)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas=17)
         end
 
         # Not power of 2
         @test_throws "num_ctas must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=3)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas=3)
         end
 
         @test_throws "num_ctas must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas=5)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas=5)
         end
 
         # Valid values should succeed
         for num_ctas in [1, 2, 4, 8, 16]
             @test @filecheck begin
                 @check "num_cta_in_cga = $(num_ctas)"
-                ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", num_ctas)
+                ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", num_ctas)
             end
         end
     end
@@ -1167,23 +1167,23 @@ end
     @testset "occupancy validation" begin
         # Too small
         @test_throws "occupancy must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=0)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", occupancy=0)
         end
 
         # Too large
         @test_throws "occupancy must be" begin
-            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=33)
+            code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", occupancy=33)
         end
 
         # Valid boundaries
         @test @filecheck begin
             @check "occupancy = 1"
-            ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=1)
+            ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", occupancy=1)
         end
 
         @test @filecheck begin
             @check "occupancy = 32"
-            ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"10.0", occupancy=32)
+            ct.code_tiled((a) -> nothing, Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"10.0", occupancy=32)
         end
     end
 
@@ -1197,7 +1197,7 @@ end
             return nothing
         end
 
-        argtypes = Tuple{ct.TileArray{Float32, 1, spec1d}}
+        argtypes = Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}
 
         # Matching arch: both ByTarget hints resolve
         @test @filecheck begin
@@ -1278,7 +1278,7 @@ end
         @test @filecheck begin
             @check "load_view_tko"
             @check "optimization_hints = <default = {latency = 5}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=5)
                 ct.store(a, pid, t)
@@ -1291,7 +1291,7 @@ end
         @test @filecheck begin
             @check "load_view_tko"
             @check "optimization_hints = <default = {allow_tma = false}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); allow_tma=false)
                 ct.store(a, pid, t)
@@ -1304,7 +1304,7 @@ end
         @test @filecheck begin
             @check "load_view_tko"
             @check "optimization_hints = <default = {allow_tma = false, latency = 7}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=7, allow_tma=false)
                 ct.store(a, pid, t)
@@ -1317,7 +1317,7 @@ end
         @test @filecheck begin
             @check "store_view_tko"
             @check "optimization_hints = <default = {latency = 3}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t; latency=3)
@@ -1330,7 +1330,7 @@ end
         @test @filecheck begin
             @check "store_view_tko"
             @check "optimization_hints = <default = {allow_tma = false}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t; allow_tma=false)
@@ -1343,7 +1343,7 @@ end
         @test @filecheck begin
             @check "store_view_tko"
             @check "optimization_hints = <default = {allow_tma = false, latency = 2}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,))
                 ct.store(a, pid, t; allow_tma=false, latency=2)
@@ -1354,7 +1354,7 @@ end
 
     @testset "latency validation" begin
         @test_throws "latency must be between 1 and 10" begin
-            code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 ct.load(a, pid, (16,); latency=11)
             end
@@ -1362,7 +1362,7 @@ end
 
         @test @filecheck begin
             @check "optimization_hints = <default = {latency = 8}>"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a
                 pid = ct.bid(1)
                 t = ct.load(a, pid, (16,); latency=8)
                 ct.store(a, pid, t)
@@ -1382,9 +1382,9 @@ end
             # Third load with no hints
             @check "load_view_tko"
             @check_not "optimization_hints"
-            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d},
-                               ct.TileArray{Float32, 1, spec1d},
-                               ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a, b, c
+            ct.code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d},
+                               ct.TileArray{Float32, 1, Int32, spec1d},
+                               ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a, b, c
                 pid = ct.bid(1)
                 t1 = ct.load(a, pid, (16,); latency=5)
                 t2 = ct.load(b, pid, (16,); allow_tma=false)
@@ -1401,7 +1401,7 @@ end
         @test @filecheck begin
             @check "load_ptr_tko"
             @check "optimization_hints = <default = {latency = 3}>"
-            code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}, ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a, b
+            code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}, ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a, b
                 pid = ct.bid(1)
                 indices = ct.arange(16)
                 tile = ct.gather(a, indices; latency=3)
@@ -1415,7 +1415,7 @@ end
         @test @filecheck begin
             @check "store_ptr_tko"
             @check "optimization_hints = <default = {latency = 5}>"
-            code_tiled(Tuple{ct.TileArray{Float32, 1, spec1d}, ct.TileArray{Float32, 1, spec1d}}; sm_arch=v"12.0") do a, b
+            code_tiled(Tuple{ct.TileArray{Float32, 1, Int32, spec1d}, ct.TileArray{Float32, 1, Int32, spec1d}}; sm_arch=v"12.0") do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 indices = ct.arange(16)
@@ -1438,7 +1438,7 @@ end
             @check_label "entry"
             @check "load_view_tko"
             @check "store_view_tko"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Nothing}) do a, b, _
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, Nothing}) do a, b, _
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 ct.store(b, pid, tile)
@@ -1452,7 +1452,7 @@ end
             @check_label "entry"
             @check "load_view_tko"
             @check "store_view_tko"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Val{16}}) do a, b, _
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, Val{16}}) do a, b, _
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 ct.store(b, pid, tile)
@@ -1476,7 +1476,7 @@ end
                 ct.store(a, pid, result)
                 return
             end
-            code_tiled(_ghost_op_kernel, Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, typeof(+)})
+            code_tiled(_ghost_op_kernel, Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, typeof(+)})
         end
     end
 end
@@ -1502,7 +1502,7 @@ end
             @check "addf"
             @check "store_view_tko"
             code_tiled(_type_param_kernel,
-                       Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec},
+                       Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec},
                              ct.Constant{Int,16}, Type{Float32}})
         end
     end
@@ -1519,7 +1519,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             @check "loop"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Int32}) do data, out, n_iters
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, Int32}) do data, out, n_iters
                 pid = ct.bid(1)
                 acc = zeros(Float32, (16,))
                 for i in Int32(1):n_iters
@@ -1536,7 +1536,7 @@ end
             @check_label "entry"
             @check "loop"
             @check "addf"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, Int32}) do data, out, n_iters
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, Int32}) do data, out, n_iters
                 pid = ct.bid(1)
                 acc = zeros(Float32, (16,))
                 for i in Int32(1):n_iters

--- a/test/codegen/kernel_state.jl
+++ b/test/codegen/kernel_state.jl
@@ -16,7 +16,7 @@
             @check "(%arg0: tile<ptr<i32>>"
             @check "%arg3: tile<i32>"
             @check "reshape %arg3"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 s = ct.Intrinsics.kernel_state()
                 a[pid] = s.seed

--- a/test/codegen/no_wrap.jl
+++ b/test/codegen/no_wrap.jl
@@ -15,7 +15,7 @@
     spec = ct.ArraySpec{1}(16, false)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
             sub = @view a[1:64]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return
@@ -30,7 +30,7 @@ end
     spec = ct.ArraySpec{1}(16, true)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             ct.store(sub, 1, ct.load(sub, 1, (16,)))
             return

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -18,7 +18,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         spec = ct.ArraySpec{1}(16, true)
         # Reject float offsets at the intrinsic boundary so direct callers
         # don't slip past the integer-only requirement.
-        @test_throws "integer" code_tiled(Tuple{ct.TileArray{Float32,1,spec}}) do a
+        @test_throws "integer" code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}}) do a
             base_ptr = ct.Tile(a.ptr)
             float_offs = Float32.(ct.Intrinsics.iota((16,), Int32))
             Base.donotdelete(ct.Intrinsics.offset(base_ptr, float_offs))
@@ -33,7 +33,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         ]
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{T,1,spec}}) do a
+                code_tiled(Tuple{ct.TileArray{T,1,Int32,spec}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     @check "scan"
@@ -47,7 +47,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 2D scan along different axes
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "scan"
@@ -61,7 +61,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Reverse scan
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "scan"
@@ -73,7 +73,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # cumsum convenience
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "scan"
@@ -85,7 +85,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # cumprod
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "scan"
@@ -98,7 +98,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Non-commutative combiner pins down the (acc, elem) convention.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "scan"
@@ -116,7 +116,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
             @check_not "permute"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "reshape"
@@ -130,7 +130,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
             @check_not "permute"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (64,))
                 @check "reshape"
@@ -144,7 +144,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
             @check_not "permute"
-            code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (2, 4, 8))
                 @check "reshape"
@@ -159,7 +159,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             @check_label "entry"
             @check_not "permute"
             @check_not "reshape"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (32,))
                 reshaped = reshape(tile, (32,))
@@ -172,7 +172,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
             @check_not "permute"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "reshape"
@@ -186,7 +186,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "dropdims" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, (pid, 1), (1, 8))
                 @check "reshape"
@@ -198,7 +198,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, (1, pid), (8, 1))
                 @check "reshape"
@@ -210,7 +210,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 tile = ct.load(a, (1, 1), (1, 1))
                 @check "reshape"
                 Base.donotdelete(dropdims(tile; dims=(2, 1)))
@@ -219,7 +219,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "dropped dims must be unique" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             tile = ct.load(a, (1, 1), (1, 1))
             Base.donotdelete(dropdims(tile; dims=(1, 1)))
             return
@@ -228,19 +228,19 @@ spec4d = ct.ArraySpec{4}(16, true)
 
     @testset "permutedims" begin
         @test_throws "axis order must be a permutation" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             Base.donotdelete(permutedims(a, Val((1, 1))))
             return
         end
 
         @test_throws "axis order must be a permutation" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             Base.donotdelete(ct.load(a, (1, 1), (4, 8); order=(1, 1)))
             return
         end
 
         @test_throws "axis order must be a permutation" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             tile = ct.load(a, (1, 1), (4, 8))
             Base.donotdelete(permutedims(tile, (1, 1)))
             return
@@ -249,7 +249,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 2D permutedims with explicit perm (same as transpose)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "permute"
@@ -262,7 +262,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 3D permutedims
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,3,spec3d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,3,Int32,spec3d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (2, 4, 8))
                 @check "permute"
@@ -276,7 +276,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 3D identity permutedims
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,3,spec3d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,3,Int32,spec3d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (2, 4, 8))
                 @check "permute"
@@ -290,7 +290,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 2D permutedims with no-arg (defaults to transpose)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "permute"
@@ -303,7 +303,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # 1D permutedims (reshape to row)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (32,))
                 @check "reshape"
@@ -316,7 +316,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
     @testset "extract" begin
         @test_throws "requires Tile IR v13.4+" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.3") do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.3") do a
             tile = ct.load(a, (1, 1), (4, 8))
             value = ct.extract(tile, (1, 1), (2, 4))
             Base.donotdelete(ct.insert(tile, (2, 2), value))
@@ -326,7 +326,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Extract slice from 2D tile
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 8))
                 @check "extract"
@@ -340,7 +340,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         if ct.bytecode_version() >= v"13.4"
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 8))
                     @check "extract"
@@ -355,7 +355,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Scalar tile getindex
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tile = ct.load(a, 1, (8,))
                 @check "extract"
                 # extract produces tile<1xf32>, reshape to scalar tile<f32>
@@ -369,7 +369,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Scalar tile setindex (functional)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tile = ct.load(a, 1, (8,))
                 @check "iota"
                 @check "select"
@@ -382,7 +382,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Extract slice from 3D tile (FFT real/imag pattern)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,3,spec3d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,3,Int32,spec3d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (2, 4, 2))  # (batch, N, real/imag)
                 @check "extract"
@@ -396,13 +396,13 @@ spec4d = ct.ArraySpec{4}(16, true)
 
     @testset "unchecked view access requires v13.4" begin
         @test_throws "check_bounds=false requires Tile IR v13.4+" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}}; bytecode_version=v"13.3") do a
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}}; bytecode_version=v"13.3") do a
             tile = ct.load(a, 1, (16,); check_bounds=false)
             ct.store(a, 1, tile)
             return
         end
         @test_throws "check_bounds=false requires Tile IR v13.4+" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}}; bytecode_version=v"13.3") do a
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}}; bytecode_version=v"13.3") do a
             tile = ct.load(a, 1, (16,))
             ct.store(a, 1, tile; check_bounds=false)
             return
@@ -411,7 +411,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         if ct.bytecode_version() >= v"13.4"
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                     pid = ct.bid(1)
                     @check "load_view{{.*}}inbounds = [true]"
                     tile = ct.load(a, pid, (16,); check_bounds=false)
@@ -424,7 +424,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 @check "load_view"
                 @check_not "inbounds"
@@ -438,7 +438,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "cat" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile1 = ct.load(a, pid, (4, 4))
                 tile2 = ct.load(b, pid, (4, 4))
@@ -451,7 +451,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile1 = ct.load(a, pid, (4, 8))
                 tile2 = ct.load(b, pid, (4, 8))
@@ -463,8 +463,8 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         # Exercise validation at the intrinsic boundary.
-        @test_throws "ranks differ" code_tiled(Tuple{ct.TileArray{Float32,2,spec2d},
-                                                     ct.TileArray{Float32,1,spec1d}}) do a, b
+        @test_throws "ranks differ" code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d},
+                                                     ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
             pid = ct.bid(1)
             tile1 = ct.load(a, pid, (4, 8))
             tile2 = ct.load(b, pid, (16,))
@@ -473,7 +473,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "element types differ" code_tiled(
-                Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Int32,2,spec2d}}) do a, b
+                Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Int32,2,Int32,spec2d}}) do a, b
             pid = ct.bid(1)
             tile1 = ct.load(a, pid, (4, 8))
             tile2 = ct.load(b, pid, (4, 8))
@@ -483,7 +483,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         # Differ on the non-cat axis to trigger the shape-mismatch check.
         @test_throws "non-cat dimension" code_tiled(
-                Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+                Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
             pid = ct.bid(1)
             tile1 = ct.load(a, pid, (4, 8))
             tile2 = ct.load(b, pid, (8, 8))  # 8 vs 4 on Julia axis 0
@@ -495,7 +495,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "broadcast" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (1, 16))
                 @check "broadcast"
@@ -521,7 +521,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # must vanish before codegen and the pow reduce to a multiply.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "mulf"
@@ -534,7 +534,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "cmpf" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b, c
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(b, pid, (16,))
@@ -550,7 +550,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "cmpi" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}, ct.TileArray{Int32,1,spec1d}, ct.TileArray{Int32,1,spec1d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}}) do a, b, c
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(b, pid, (16,))
@@ -569,7 +569,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         for T in (Float16, ct.BFloat16, Float32, Float64)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{T,1,spec1d}}) do a
+                code_tiled(Tuple{ct.TileArray{T,1,Int32,spec1d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     @check "cmpf not_equal unordered"
@@ -583,7 +583,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "mixed-type integer comparison" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do out
+            code_tiled(Tuple{ct.TileArray{Int64,1,Int32,spec1d}}) do out
                 a = ct.arange(16; dtype=Int64)
                 b = ct.arange(16)
                 # Should promote Int32 to Int64 and compare
@@ -606,7 +606,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # equivalent of cuTile Python ebaa570's tuple compare support).
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32}) do a, n
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, n
                 x = (ct.bid(1), Int32(2))
                 y = (n, Int32(2))
                 @check "cmpi"
@@ -629,7 +629,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test promote_type(UInt16, UInt64) === UInt64
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt64,1,spec1d}}) do out
+            code_tiled(Tuple{ct.TileArray{UInt64,1,Int32,spec1d}}) do out
                 a = ct.arange(16; dtype=UInt16)
                 b = ct.arange(16; dtype=UInt64)
                 @check "exti"
@@ -644,7 +644,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "constant" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 @check "constant"
                 tile = zeros(Float32, (16,))
@@ -657,7 +657,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "constant with runtime value" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32}) do a, val
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, val
                 pid = ct.bid(1)
                 @check "itof"
                 @check "reshape"
@@ -672,7 +672,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "get_num_tile_blocks" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 @check "get_num_tile_blocks"
                 nb = ct.num_blocks(1)
                 Base.donotdelete(nb)
@@ -684,7 +684,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "get_tile_block_id" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 @check "get_tile_block_id"
                 pid = ct.bid(1)
                 Base.donotdelete(pid)
@@ -696,7 +696,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "iota" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 @check "iota"
                 tile = ct.arange(16)
@@ -706,12 +706,12 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         # iota is restricted to 1-D integer tiles; reject the rest cleanly.
-        @test_throws "1-dimensional" code_tiled(Tuple{ct.TileArray{Int32,2,spec2d}}) do a
+        @test_throws "1-dimensional" code_tiled(Tuple{ct.TileArray{Int32,2,Int32,spec2d}}) do a
             Base.donotdelete(ct.Intrinsics.iota((4, 4), Int32))
             return
         end
 
-        @test_throws "integer" code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        @test_throws "integer" code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             Base.donotdelete(ct.Intrinsics.iota((16,), Float32))
             return
         end
@@ -720,7 +720,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "arange start and step" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do out
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do out
                 @check "iota"
                 @check "muli"
                 @check "addi"
@@ -733,7 +733,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "mmaf" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b, c
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 tile_a = ct.load(a, bidx, (32, 16))
@@ -751,9 +751,9 @@ spec4d = ct.ArraySpec{4}(16, true)
         # i8 × i8 → i32 with signedness derived from the Julia element type.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int8,2,spec2d},
-                             ct.TileArray{Int8,2,spec2d},
-                             ct.TileArray{Int32,2,spec2d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Int8,2,Int32,spec2d},
+                             ct.TileArray{Int8,2,Int32,spec2d},
+                             ct.TileArray{Int32,2,Int32,spec2d}}) do a, b, c
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 tile_a = ct.load(a, bidx, (32, 16))
@@ -770,9 +770,9 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Mixed signedness: UInt8 × Int8 → Int32 should emit `unsigned signed`.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt8,2,spec2d},
-                             ct.TileArray{Int8,2,spec2d},
-                             ct.TileArray{Int32,2,spec2d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{UInt8,2,Int32,spec2d},
+                             ct.TileArray{Int8,2,Int32,spec2d},
+                             ct.TileArray{Int32,2,Int32,spec2d}}) do a, b, c
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 tile_a = ct.load(a, bidx, (32, 16))
@@ -795,9 +795,9 @@ spec4d = ct.ArraySpec{4}(16, true)
         # downcast back to BFloat16. Result element type is BFloat16.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{ct.BFloat16,2,spec2d},
-                             ct.TileArray{ct.BFloat16,2,spec2d},
-                             ct.TileArray{ct.BFloat16,2,spec2d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{ct.BFloat16,2,Int32,spec2d},
+                             ct.TileArray{ct.BFloat16,2,Int32,spec2d},
+                             ct.TileArray{ct.BFloat16,2,Int32,spec2d}}) do a, b, c
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 tile_a = ct.load(a, bidx, (32, 16))
@@ -818,9 +818,9 @@ spec4d = ct.ArraySpec{4}(16, true)
         # with the tileiras-allowed-acc message rather than producing a
         # mmaf op tileiras would later reject.
         @test_throws "tileiras requires acc" code_tiled(
-            Tuple{ct.TileArray{ct.BFloat16,2,spec2d},
-                  ct.TileArray{ct.BFloat16,2,spec2d},
-                  ct.TileArray{ct.BFloat16,2,spec2d}}) do a, b, c
+            Tuple{ct.TileArray{ct.BFloat16,2,Int32,spec2d},
+                  ct.TileArray{ct.BFloat16,2,Int32,spec2d},
+                  ct.TileArray{ct.BFloat16,2,Int32,spec2d}}) do a, b, c
             bidx = ct.bid(1)
             bidy = ct.bid(2)
             tile_a = ct.load(a, bidx, (32, 16))
@@ -834,7 +834,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "vec-mat outer product" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b, c
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (16,))
                 tile_b = ct.load(b, bidx, (1, 16))
@@ -851,7 +851,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "mat-vec" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b, c
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (32, 16))
                 tile_b = ct.load(b, bidx, (16,))
@@ -868,7 +868,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "batched matmul with trailing batch dims" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,3,spec3d}, ct.TileArray{Float32,3,spec3d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,3,Int32,spec3d}, ct.TileArray{Float32,3,Int32,spec3d}}) do a, b, c
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (32, 16, 1))
                 tile_b = ct.load(b, bidx, (16, 32, 4))
@@ -884,7 +884,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
     @testset "vec-vec throws error" begin
         err = try
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (16,))
                 tile_b = ct.load(b, bidx, (16,))
@@ -903,7 +903,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "4D batched matmul (2 batch dims)" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,4,spec4d}, ct.TileArray{Float32,4,spec4d}, ct.TileArray{Float32,4,spec4d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,4,Int32,spec4d}, ct.TileArray{Float32,4,Int32,spec4d}, ct.TileArray{Float32,4,Int32,spec4d}}) do a, b, c
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (16, 8, 2, 4))
                 tile_b = ct.load(b, bidx, (8, 16, 2, 4))
@@ -918,7 +918,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "permute" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 tile = ct.load(a, (bidx, bidy), (32, 64))
@@ -933,7 +933,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "reduce" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -946,7 +946,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -960,7 +960,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # minimum
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -974,7 +974,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # prod
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -993,7 +993,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         ]
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{T,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{T,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "reduce"
@@ -1007,7 +1007,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Generic reduce with explicit function
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -1020,7 +1020,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # Reduce with custom combiner (lambda)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -1034,7 +1034,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # capturing the block-arg names and asserting subf's operand order.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "reduce"
@@ -1049,7 +1049,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             @check_label "entry"
             @check "reduce {{.*}} dim=1"
             @check "reduce {{.*}} dim=0"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 Base.donotdelete(sum(tile; dims=(2, 1, 2)))
@@ -1060,7 +1060,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
             @check_count 4 "reduce"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 Base.donotdelete(sum(tile; dims=1:2))
@@ -1071,7 +1071,7 @@ spec4d = ct.ArraySpec{4}(16, true)
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check_not "reduce"
@@ -1083,7 +1083,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "region dimension(s) must be ≥ 1, got 0" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             tile = ct.load(a, pid, (4, 16))
             Base.donotdelete(sum(tile; dims=0))
@@ -1091,7 +1091,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "region dimension(s) must be ≥ 1, got 0" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             tile = ct.load(a, pid, (4, 16))
             Base.donotdelete(sum(tile; dims=(0,)))
@@ -1099,7 +1099,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "reduced dimension(s) must be integers" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             tile = ct.load(a, pid, (4, 16))
             Base.donotdelete(sum(tile; dims=(1.0,)))
@@ -1107,7 +1107,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "region dimension(s) must be ≥ 1, got 0" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             tile = ct.load(a, pid, (4, 16))
             Base.donotdelete(ct.Intrinsics.reduce((tile,), -1, +, (0.0f0,)))
@@ -1115,7 +1115,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         end
 
         @test_throws "reduce() dimension must be in 1:2; got 3" code_tiled(
-            Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             pid = ct.bid(1)
             tile = ct.load(a, pid, (4, 16))
             Base.donotdelete(ct.Intrinsics.reduce((tile,), 2, +, (0.0f0,)))
@@ -1125,7 +1125,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # any
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 mask = tile .> 0.0f0
@@ -1139,7 +1139,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # all
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 mask = tile .> 0.0f0
@@ -1153,7 +1153,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # count
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "exti"
@@ -1169,7 +1169,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             # Float32: sum → 0.0, maximum → -Inf (0xFF800000), minimum → +Inf (0x7F800000)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[0.000000e+00 : f32]"
@@ -1179,7 +1179,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[0xFF800000 : f32]"
@@ -1189,7 +1189,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[0x7F800000 : f32]"
@@ -1201,7 +1201,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             # Float16: maximum → -Inf (0xFC00), minimum → +Inf (0x7C00)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float16,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float16,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[0xFC00 : f16]"
@@ -1211,7 +1211,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             end
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float16,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Float16,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[0x7C00 : f16]"
@@ -1223,7 +1223,7 @@ spec4d = ct.ArraySpec{4}(16, true)
             # Int32: maximum → typemin (zigzag of -2147483648)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Int32,2,spec2d}}) do a
+                code_tiled(Tuple{ct.TileArray{Int32,2,Int32,spec2d}}) do a
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (4, 16))
                     @check "identities=[-2147483648"
@@ -1236,7 +1236,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # argmax
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "iota"
@@ -1251,7 +1251,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # argmin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "iota"
@@ -1268,7 +1268,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # map(abs, tile) should emit AbsFOp with correct shaped type
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "absf"
@@ -1280,7 +1280,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # map(x -> x * x, tile) should emit MulFOp
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "mulf"
@@ -1292,7 +1292,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # mapreduce(abs, +, tile) should emit AbsFOp then ReduceOp
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "absf"
@@ -1306,7 +1306,7 @@ spec4d = ct.ArraySpec{4}(16, true)
         # mapreduce(x -> x * x, +, tile) should emit MulFOp then ReduceOp
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (4, 16))
                 @check "mulf"
@@ -1321,7 +1321,7 @@ spec4d = ct.ArraySpec{4}(16, true)
     @testset "select" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b, c
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(b, pid, (16,))
@@ -1341,7 +1341,7 @@ end
         a -> ct.load(a, ct.bid(1), (0,)),
     )
         @test_throws "tile dimension 1 must be positive" code_tiled(
-            f, Tuple{ct.TileArray{Float32,1,spec1d}})
+            f, Tuple{ct.TileArray{Float32,1,Int32,spec1d}})
     end
 end
 
@@ -1373,7 +1373,7 @@ end
         # Int32 -> UInt32 (same Tile IR type I32): no bitcast op emitted
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}, ct.TileArray{UInt32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}, ct.TileArray{UInt32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check_not "bitcast"
@@ -1385,7 +1385,7 @@ end
         # Float32 -> Int32 (different Tile IR types): bitcast op emitted
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Int32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "bitcast"
@@ -1397,7 +1397,7 @@ end
         # Int32 -> Float32 (different Tile IR types): bitcast op emitted
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "bitcast"
@@ -1412,7 +1412,7 @@ end
         # reinterpret is a plain bitcast — no pack/unpack, shape preserved.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float16,1,spec1d}, ct.TileArray{Int16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float16,1,Int32,spec1d}, ct.TileArray{Int16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "bitcast"
@@ -1426,7 +1426,7 @@ end
         # folded away.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt8,1,spec1d}, ct.TileArray{UInt16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt8,1,Int32,spec1d}, ct.TileArray{UInt16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "unpack"
@@ -1438,7 +1438,7 @@ end
         # Narrow UInt16 -> UInt8 (1D): lowers to a single pack.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt16,1,spec1d}, ct.TileArray{UInt8,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt16,1,Int32,spec1d}, ct.TileArray{UInt8,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (8,))
                 @check "pack"
@@ -1451,7 +1451,7 @@ end
         # (`literal` since the `+` in the message is a regex metachar to FileCheck.)
         @test @filecheck throws=ct.CodegenErrors begin
             @check literal=true "v13.3+"
-            code_tiled(Tuple{ct.TileArray{UInt8,1,spec1d}, ct.TileArray{UInt16,1,spec1d}};
+            code_tiled(Tuple{ct.TileArray{UInt8,1,Int32,spec1d}, ct.TileArray{UInt16,1,Int32,spec1d}};
                        bytecode_version=v"13.2") do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
@@ -1463,7 +1463,7 @@ end
         # Rank-1 scaled: one UInt8 (8 bits) can't fill a UInt16; caught by unpack.
         @test @filecheck throws=ct.CodegenErrors begin
             @check "do not evenly divide"
-            code_tiled(Tuple{ct.TileArray{UInt8,1,spec1d}, ct.TileArray{UInt16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt8,1,Int32,spec1d}, ct.TileArray{UInt16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 ct.store(b, pid, reinterpret(UInt16, ct.load(a, pid, (1,))))
                 return
@@ -1473,7 +1473,7 @@ end
         # reshape-widen: leading dim must equal the ratio (2); 1 fails the final reshape.
         @test @filecheck throws=ct.CodegenErrors begin
             @check "same number of elements"
-            code_tiled(Tuple{ct.TileArray{UInt8,2,spec2d}, ct.TileArray{UInt16,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt8,2,Int32,spec2d}, ct.TileArray{UInt16,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 ct.store(b, pid, reinterpret(reshape, UInt16, ct.load(a, pid, (1, 4))))
                 return
@@ -1493,7 +1493,7 @@ end
         # Float32 -> Float16
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1506,7 +1506,7 @@ end
         # Float32 -> TFloat32
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1519,7 +1519,7 @@ end
         # Float32 -> BFloat16
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1532,7 +1532,7 @@ end
         # Broadcasting syntax: Float16.(tile)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1544,7 +1544,7 @@ end
         # Broadcasting syntax: BFloat16.(tile)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1557,7 +1557,7 @@ end
         # Broadcasting syntax: TFloat32.(tile)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1572,7 +1572,7 @@ end
         # convert.(Float16, tile) — Type arg via Ref{Type{Float16}}
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float16,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1584,7 +1584,7 @@ end
         # convert.(Float32, float16_tile) — upcast via Type arg
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float16,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float16,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftof"
@@ -1596,7 +1596,7 @@ end
         # unsafe_trunc.(Int32, float32_tile) — ftoi via Type arg
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Int32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "ftoi"
@@ -1615,7 +1615,7 @@ end
     @testset "@assert with message" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 @check "cmpi"
                 ct.@assert bid > Int32(0) "bid must be positive"
@@ -1631,7 +1631,7 @@ end
     @testset "@assert without message" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 @check "cmpi"
                 ct.@assert bid > Int32(0)
@@ -1649,7 +1649,7 @@ end
         # Empty if branches must emit YieldOp to satisfy MLIR block terminator requirements
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int,1,spec1d}, ct.TileArray{Int,1,spec1d}}) do counter, lock
+            code_tiled(Tuple{ct.TileArray{Int,1,Int32,spec1d}, ct.TileArray{Int,1,Int32,spec1d}}) do counter, lock
                 result = ct.atomic_cas(lock, 1, 0, 1)
                 @check "if"
                 if result == 0
@@ -1665,7 +1665,7 @@ end
     @testset "for" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Int32}) do a, b, n
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, b, n
                 pid = ct.bid(1)
                 acc = zeros(Float32, (16,))
                 @check "for"
@@ -1682,7 +1682,7 @@ end
     @testset "for with step (StepRange)" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Int32}) do a, b, n
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, b, n
                 pid = ct.bid(1)
                 acc = zeros(Float32, (16,))
                 @check "for"
@@ -1699,7 +1699,7 @@ end
     @testset "for with decrement (StepRange)" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Int32}) do a, b, n
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Int32}) do a, b, n
                 pid = ct.bid(1)
                 acc = zeros(Float32, (16,))
                 # Decrementing StepRange compiles to a generic loop (not ForOp)
@@ -1717,7 +1717,7 @@ end
     @testset "loop" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do locks, data
+            code_tiled(Tuple{ct.TileArray{Int,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do locks, data
                 bid = ct.bid(1)
                 @check "loop"
                 # Spinloop - unbounded iteration
@@ -1736,7 +1736,7 @@ end
     @testset "return" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 @check "return"
                 return
             end
@@ -1756,7 +1756,7 @@ end
         # 1D
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 @check "load_view_tko"
                 tile = ct.load(a, pid, (16,))
@@ -1769,7 +1769,7 @@ end
         # 2D
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 @check "load_view_tko"
@@ -1784,7 +1784,7 @@ end
     @testset "make_token" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 # DCE removes unused make_token in empty kernels
                 @check_not "make_token"
                 return
@@ -1800,7 +1800,7 @@ end
     @testset "unary float math" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "absf"
@@ -1844,7 +1844,7 @@ end
         # On v13.2+ the active @fpmode rounding_mode is forwarded to TanHOp.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}};
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}};
                        bytecode_version=v"13.2") do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
@@ -1861,7 +1861,7 @@ end
     @testset "fma" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c, d
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b, c, d
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(b, pid, (16,))
@@ -1878,7 +1878,7 @@ end
         # Binary map → addf
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(a, pid, (16,))
@@ -1892,7 +1892,7 @@ end
         # Broadcasting via .+ → broadcast + addf
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 pid = ct.bid(1)
                 row = ct.load(a, pid, (1, 16))
                 col = ct.load(a, pid, (32, 1))
@@ -1907,7 +1907,7 @@ end
         # Ternary map → fma
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(a, pid, (16,))
@@ -1922,7 +1922,7 @@ end
         # map(max, ...) → maxf
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(a, pid, (16,))
@@ -1938,7 +1938,7 @@ end
         # a .+ b .* c → fma (fused by fma_fusion_pass!)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(a, pid, (16,))
@@ -1953,7 +1953,7 @@ end
         # a .- b .* c → fma(negf(b), c, a)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(a, pid, (16,))
@@ -1970,7 +1970,7 @@ end
     @testset "remf" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b, c
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b, c
                 pid = ct.bid(1)
                 tile_a = ct.load(a, pid, (16,))
                 tile_b = ct.load(b, pid, (16,))
@@ -1985,7 +1985,7 @@ end
     @testset "binary float math" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(b, pid, (16,))
@@ -2006,7 +2006,7 @@ end
         # `fld(x, y)` on floats lowers to floor(divf).
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(b, pid, (16,))
@@ -2023,7 +2023,7 @@ end
         # scalars broadcast as shaped splat ConstantOps, not BroadcastOps.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "constant <f32: 1.000000e+00> : tile<16xf32>"
@@ -2058,8 +2058,8 @@ end
         # atan2 is available from Tile IR v13.2.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                             ct.TileArray{Float32,1,spec1d}};
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                             ct.TileArray{Float32,1,Int32,spec1d}};
                        bytecode_version=v"13.2") do y, x
                 pid = ct.bid(1)
                 ty = ct.load(y, pid, (16,))
@@ -2071,8 +2071,8 @@ end
         end
 
         # Older toolchains must reject the op cleanly.
-        @test_throws "v13.2" code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                                              ct.TileArray{Float32,1,spec1d}};
+        @test_throws "v13.2" code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                                              ct.TileArray{Float32,1,Int32,spec1d}};
                                         bytecode_version=v"13.1") do y, x
             pid = ct.bid(1)
             ty = ct.load(y, pid, (16,))
@@ -2085,7 +2085,7 @@ end
     @testset "power operations" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "pow"
@@ -2097,7 +2097,7 @@ end
         # scalar exponent (pow(x, 2) is strength-reduced to mulf(x, x))
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "mulf"
@@ -2110,7 +2110,7 @@ end
         # pow2 strength reduction works for Float64 too
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float64,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "mulf"
@@ -2122,8 +2122,8 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                             ct.TileArray{Int32,1,spec1d}}) do a, e
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                             ct.TileArray{Int32,1,Int32,spec1d}}) do a, e
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 exponent = ct.load(e, pid, (16,))
@@ -2140,8 +2140,8 @@ end
         if ct.bytecode_version() >= v"13.4"
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                                 ct.TileArray{Int32,1,spec1d}}) do a, e
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                                 ct.TileArray{Int32,1,Int32,spec1d}}) do a, e
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     exponent = ct.load(e, pid, (16,))
@@ -2153,7 +2153,7 @@ end
         end
 
         @test_throws "cuda_tile.fpowi requires Tile IR v13.4+" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Int32,1,spec1d}};
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}};
             bytecode_version=v"13.3") do a, e
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
@@ -2165,8 +2165,8 @@ end
         if ct.bytecode_version() >= v"13.4"
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                                 ct.TileArray{UInt16,1,spec1d}}) do a, e
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                                 ct.TileArray{UInt16,1,Int32,spec1d}}) do a, e
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     exponent = ct.load(e, pid, (16,))
@@ -2180,7 +2180,7 @@ end
 
         for T in (Int64, UInt32, UInt64)
             @test_throws "does not support $T exponents" code_tiled(
-                Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{T,1,spec1d}}) do a, e
+                Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{T,1,Int32,spec1d}}) do a, e
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 exponent = ct.load(e, pid, (16,))
@@ -2195,7 +2195,7 @@ end
         # Note: We pass scalar args to avoid constant folding at compile time
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Float32}) do a, b, x
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, b, x
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "sin"
@@ -2210,7 +2210,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Float32}) do a, b, x
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, b, x
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "exp"
@@ -2224,7 +2224,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Float32}) do a, b, x
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, b, x
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "sqrt"
@@ -2238,7 +2238,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}, Float32}) do a, b, x
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, b, x
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "rsqrt"
@@ -2261,7 +2261,7 @@ end
     @testset "unary" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec_i32}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec_i32}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "absi"
@@ -2277,8 +2277,8 @@ end
         spec_u32 = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec_u32},
-                             ct.TileArray{UInt32,1,spec_u32}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec_u32},
+                             ct.TileArray{UInt32,1,Int32,spec_u32}}) do a, b
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(b, pid, (16,))
@@ -2290,7 +2290,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec_i32}, ct.TileArray{Int32,1,spec_i32}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec_i32}, ct.TileArray{Int32,1,Int32,spec_i32}}) do a, b
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(b, pid, (16,))
@@ -2307,7 +2307,7 @@ end
     # rather than silently emitting an unsigned multiply.
     @testset "mul_hi rejects signed integers" begin
         @test_throws "signed" code_tiled(
-                Tuple{ct.TileArray{Int32,1,spec_i32}, ct.TileArray{Int32,1,spec_i32}}) do a, b
+                Tuple{ct.TileArray{Int32,1,Int32,spec_i32}, ct.TileArray{Int32,1,Int32,spec_i32}}) do a, b
             pid = ct.bid(1)
             ta = ct.load(a, pid, (16,))
             tb = ct.load(b, pid, (16,))
@@ -2329,7 +2329,7 @@ end
     @testset "andi, ori, xori" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec_i32}, ct.TileArray{Int32,1,spec_i32}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec_i32}, ct.TileArray{Int32,1,Int32,spec_i32}}) do a, b
                 pid = ct.bid(1)
                 ta = ct.load(a, pid, (16,))
                 tb = ct.load(b, pid, (16,))
@@ -2347,7 +2347,7 @@ end
     @testset "shli, shri" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec_i32}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec_i32}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "shli"
@@ -2361,7 +2361,7 @@ end
     @testset "bitwise NOT (~)" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec_i32}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec_i32}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 @check "xori"
@@ -2380,7 +2380,7 @@ end
         spec = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do locks
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do locks
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_cas_tko"
@@ -2396,7 +2396,7 @@ end
         # xchg
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do locks
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do locks
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2410,7 +2410,7 @@ end
         spec_f32 = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec_f32}}) do counters
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec_f32}}) do counters
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2422,7 +2422,7 @@ end
         # max
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2434,7 +2434,7 @@ end
         # min
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2446,7 +2446,7 @@ end
         # or
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2458,7 +2458,7 @@ end
         # and
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2470,7 +2470,7 @@ end
         # xor
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 bid = ct.bid(1)
                 @check "offset"
                 @check "atomic_rmw_tko"
@@ -2484,7 +2484,7 @@ end
         spec = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 @check "iota"
                 indices = ct.arange(16; dtype=Int)
                 @check "offset"
@@ -2499,7 +2499,7 @@ end
         spec3d = ct.ArraySpec{3}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,3,spec3d}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,3,Int32,spec3d}}) do arr
                 @check "iota"
                 i = ct.arange(4; dtype=Int)
                 j = ct.arange(4; dtype=Int)
@@ -2517,7 +2517,7 @@ end
         # xchg
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 @check "iota"
                 indices = ct.arange(16; dtype=Int)
                 @check "offset"
@@ -2530,7 +2530,7 @@ end
         # add (integer)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
                 @check "iota"
                 indices = ct.arange(16; dtype=Int)
                 @check "offset"
@@ -2544,7 +2544,7 @@ end
         spec_f32 = ct.ArraySpec{1}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec_f32}}) do arr
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec_f32}}) do arr
                 @check "iota"
                 indices = ct.arange(16; dtype=Int)
                 @check "offset"
@@ -2558,7 +2558,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             code_tiled(
-                    Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                    Tuple{ct.TileArray{ct.BFloat16,1,Int32,spec_bf16}};
                     sm_arch=v"9.0",
                     bytecode_version=v"13.3") do arr
                 indices = ct.arange(16; dtype=Int)
@@ -2568,7 +2568,7 @@ end
             end
         end
         @test_throws "requires Hopper (sm_90) or newer, got sm_80" code_tiled(
-                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                Tuple{ct.TileArray{ct.BFloat16,1,Int32,spec_bf16}};
                 sm_arch=v"8.0",
                 bytecode_version=v"13.3") do arr
             indices = ct.arange(16; dtype=Int)
@@ -2576,7 +2576,7 @@ end
             return
         end
         @test_throws "BFloat16 requires Tile IR bytecode ≥ 13.3" code_tiled(
-                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                Tuple{ct.TileArray{ct.BFloat16,1,Int32,spec_bf16}};
                 sm_arch=v"9.0",
                 bytecode_version=v"13.2") do arr
             indices = ct.arange(16; dtype=Int)
@@ -2589,7 +2589,7 @@ end
         spec2d = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 tiles = ct.eachtile(a, (16, 16))
                 val = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
                 @check "make_partition_view"
@@ -2601,7 +2601,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 val = ct.broadcast_to(ct.Tile(Int32(1)), (16,))
                 @check "atomic_red_view_tko relaxed device{{.*}}, add,"
@@ -2612,7 +2612,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tiles = ct.eachtile(a, (16,); step=(8,))
                 val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
                 @check "make_strided_view"
@@ -2625,7 +2625,7 @@ end
         # Atomic views ignore TiledView padding.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tiles = ct.eachtile(a, (16,); padding_mode=ct.PaddingMode.Zero)
                 val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
                 @check "make_partition_view"
@@ -2637,7 +2637,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tiles = ct.eachtile(
                     a, (16,); step=(8,), padding_mode=ct.PaddingMode.Zero)
                 val = ct.broadcast_to(ct.Tile(1.0f0), (16,))
@@ -2650,7 +2650,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 val = ct.broadcast_to(ct.Tile(UInt32(1)), (16,))
                 @check "atomic_red_view_tko relaxed device{{.*}}umax"
@@ -2661,7 +2661,7 @@ end
 
         spec_bf16 = ct.ArraySpec{1}(16, true)
         @test_throws "requires Hopper (sm_90) or newer, got sm_80" code_tiled(
-                Tuple{ct.TileArray{ct.BFloat16,1,spec_bf16}};
+                Tuple{ct.TileArray{ct.BFloat16,1,Int32,spec_bf16}};
                 sm_arch=v"8.0",
                 bytecode_version=v"13.3") do a
             val = ct.broadcast_to(ct.Tile(ct.BFloat16(1)), (16,))
@@ -2671,7 +2671,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 tile = ct.load(a, bid, (16,))
                 @check "store_view_tko{{.*}}token = [[TOK:%[^ ]+]]"
@@ -2682,14 +2682,14 @@ end
             end
         end
 
-        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do a
+        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,Int32,spec1d}}) do a
             bid = ct.bid(1)
             val = ct.broadcast_to(ct.Tile(Int32(1)), (16,))  # Int32 into Int64
             ct.atomic_store_or(a, bid, val)
             return
         end
 
-        @test_throws "expected" code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        @test_throws "expected" code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             tiles = ct.eachtile(a, (16, 16))
             val = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
             ct.atomic_store_add(tiles, (1, 1, 1), val)  # 3 indices for a 2D view
@@ -2702,7 +2702,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 tiles = ct.eachtile(a, (16, 16))
                 v = ct.broadcast_to(ct.Tile(1.0f0), (16, 16))
                 @check "atomic_red_view_tko relaxed device{{.*}}addf"
@@ -2714,7 +2714,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             @check_not "atomic_red_view_tko"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 @check "atomic_rmw_tko acq_rel"
                 ct.@atomic :acquire_release a[bid] += Int32(1)
@@ -2724,7 +2724,7 @@ end
 
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 @check "atomic_rmw_tko"
                 pair = ct.@atomic a[bid] + Int32(3)
@@ -2750,7 +2750,7 @@ end
         for T in (UInt32, UInt64)
             @test @filecheck begin
                 @check_label "entry"
-                code_tiled(Tuple{ct.TileArray{T,1,spec1d}}) do arr
+                code_tiled(Tuple{ct.TileArray{T,1,Int32,spec1d}}) do arr
                     bid = ct.bid(1)
                     @check "atomic_rmw_tko{{.*}}umax"
                     ct.atomic_max(arr, bid, zero(eltype(arr)))
@@ -2763,7 +2763,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             @check_not "umax"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do arr
                 bid = ct.bid(1)
                 @check "atomic_rmw_tko{{.*}}max"
                 ct.atomic_max(arr, bid, Int32(0))
@@ -2773,14 +2773,14 @@ end
     end
 
     @testset "reject bitwise atomic dtype mismatch" begin
-        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr
+        @test_throws "exactly match" code_tiled(Tuple{ct.TileArray{Int64,1,Int32,spec1d}}) do arr
             bid = ct.bid(1)
             ct.atomic_or(arr, bid, Int32(1))  # Int32 update into Int64 array
             return
         end
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int64,1,spec1d}}) do arr
+            code_tiled(Tuple{ct.TileArray{Int64,1,Int32,spec1d}}) do arr
                 bid = ct.bid(1)
                 @check "atomic_rmw_tko"
                 ct.atomic_add(arr, bid, Int32(1))
@@ -2792,13 +2792,13 @@ end
     # `weak` ordering is not supported on atomics; reject at the boundary.
     @testset "reject MemoryOrder.Weak" begin
         spec = ct.ArraySpec{1}(16, true)
-        @test_throws "Weak" code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do locks
+        @test_throws "Weak" code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do locks
             bid = ct.bid(1)
             ct.atomic_cas(locks, bid, Int32(0), Int32(1);
                           memory_order=ct.MemoryOrder.Weak)
             return
         end
-        @test_throws "Weak" code_tiled(Tuple{ct.TileArray{Int32,1,spec}}) do arr
+        @test_throws "Weak" code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec}}) do arr
             bid = ct.bid(1)
             ct.atomic_xchg(arr, bid, Int32(0); memory_order=ct.MemoryOrder.Weak)
             return
@@ -2818,7 +2818,7 @@ end
         # 1D
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 @check "load_view_tko"
                 tile = ct.load(a, pid, (16,))
@@ -2832,7 +2832,7 @@ end
         spec2d = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 @check "load_view_tko"
@@ -2848,7 +2848,7 @@ end
         spec4d = ct.ArraySpec{4}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,4,spec4d}, ct.TileArray{Float32,4,spec4d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,4,Int32,spec4d}, ct.TileArray{Float32,4,Int32,spec4d}}) do a, b
                 bidx = ct.bid(1)
                 bidy = ct.bid(2)
                 bidz = ct.bid(3)
@@ -2863,7 +2863,7 @@ end
         # with padding_mode
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}) do a, b
                 pid = ct.bid(1)
                 @check "load_view_tko"
                 tile = ct.load(a, pid, (16,); padding_mode=ct.PaddingMode.Zero)
@@ -2875,7 +2875,7 @@ end
         # with order (dim_map)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 @check "dim_map=[1, 0]"
                 @check "load_view_tko"
@@ -2891,7 +2891,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             @check_not "dim_map"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 tile = ct.load(a, (pid, 1), (4, 8))
                 ct.store(b, (pid, 1), tile)
@@ -2904,7 +2904,7 @@ end
         # 1D shape on 2D array: should pad shape to (16, 1) internally
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
                 @check "load_view_tko"
                 tile = ct.load(a, (pid, 1), (16,))
@@ -2918,7 +2918,7 @@ end
     @testset "TileArray scalar getindex" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do lengths, out
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do lengths, out
                 bid = ct.bid(1)
                 @check "make_partition_view"
                 @check "load_view_tko"
@@ -2934,7 +2934,7 @@ end
         spec = ct.ArraySpec{2}(16, true)
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec}, ct.TileArray{Float32,2,spec}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec}, ct.TileArray{Float32,2,Int32,spec}}) do a, b
                 @check "make_tensor_view"
                 @check "make_partition_view"
                 @check "get_index_space_shape"
@@ -2959,7 +2959,7 @@ end
     @testset "print constant string" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 @check "print_tko"
                 @check "hello\n"
@@ -2974,7 +2974,7 @@ end
     @testset "print with float tile" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 tile = ct.load(a, bid, (16,))
                 @check "print_tko"
@@ -3001,7 +3001,7 @@ end
     @testset "println with tile" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 tile = ct.load(a, bid, (16,))
                 @check "print_tko"
@@ -3016,7 +3016,7 @@ end
     @testset "print integer tile" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Int32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
                 bid = ct.bid(1)
                 tile = ct.load(a, bid, (16,))
                 @check "print_tko"
@@ -3033,7 +3033,7 @@ end
         # in the format string, mirroring cuTile Python's print behaviour.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
                 tile = ct.load(a, (1, 1), (4, 16))
                 @check "print_tko"
                 @check "shape=(4, 16)"
@@ -3045,7 +3045,7 @@ end
         # 1-element tuples render `(x,)` not `(x)` (matches Julia/Python).
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 tile = ct.load(a, 1, (16,))
                 @check "print_tko"
                 @check "shape=(16,)"
@@ -3078,7 +3078,7 @@ end
     @testset "print multiple tiles" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Int32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Int32,1,Int32,spec1d}}) do a, b
                 bid = ct.bid(1)
                 ta = ct.load(a, bid, (16,))
                 tb = ct.load(b, bid, (16,))
@@ -3095,8 +3095,8 @@ end
     @testset "prints are globally ordered" begin
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                             ct.TileArray{Float32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                             ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
                 ta = ct.load(a, 1, (16,))
                 tb = ct.load(b, 1, (16,))
                 @check "[[FIRST:%[^ ]+]] = print_tko"
@@ -3115,7 +3115,7 @@ end
         @test @filecheck begin
             @check_label "entry"
             @check_count 1 "make_token"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}};
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}};
                        bytecode_version=v"13.1") do a
                 bid = ct.bid(1)
                 tile = ct.load(a, bid, (16,))
@@ -3132,7 +3132,7 @@ end
 @testset "array construction" begin
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float64,1,spec1d}, Float64}) do a, x
+        code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d}, Float64}) do a, x
             @check "cat {{.*}}-> tile<4xf64>"
             ct.store(a, ct.bid(1), [x, 2, 3, 4])
             return
@@ -3144,7 +3144,7 @@ end
     # reversed shape).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             @check "constant <f32: [{{\\[}}1.000000e+00, 3.000000e+00, 5.000000e+00, 7.000000e+00], [2.000000e+00, 4.000000e+00, 6.000000e+00, 8.000000e+00]]> : tile<2x4xf32>"
             ct.store(a, ct.bid(1), Float32[1 2; 3 4; 5 6; 7 8])
             return
@@ -3203,7 +3203,7 @@ end
 
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Float32}) do a, x
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Float32}) do a, x
             @check "cat {{.*}}-> tile<4xf32>"
             t = ct.load(a, ct.bid(1), (2,))
             ct.store(a, ct.bid(1), cat(t, x, x; dims=1))
@@ -3213,8 +3213,8 @@ end
 
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d},
-                         ct.TileArray{Float32,3,spec3d}}) do a, b
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d},
+                         ct.TileArray{Float32,3,Int32,spec3d}}) do a, b
             t = ct.load(a, ct.bid(1), (2, 2))
             @check "cat {{.*}}-> tile<2x4x2xf32>"
             ct.store(b, ct.bid(1), [t t;;; t t])
@@ -3224,7 +3224,7 @@ end
 
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             t = ct.load(a, ct.bid(1), (2, 2))
             @check "cat {{.*}}-> tile<4x4xf32>"
             Base.donotdelete(cat(t, t; dims=(1, 2)))
@@ -3254,7 +3254,7 @@ end
     end
 
     @test_throws "positive integers" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
         t = ct.load(a, ct.bid(1), (2,))
         Base.donotdelete(cat(t, t; dims=0))
         return
@@ -3274,7 +3274,7 @@ end
     @test @filecheck begin
         @check_label "entry"
         @check_not "cat "
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             t = ct.load(a, ct.bid(1), (2, 2))
             Base.donotdelete(hvncat(0, t))
             return
@@ -3282,13 +3282,13 @@ end
     end
 
     @test_throws "cannot infer an element type" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
         Base.donotdelete([])
         return
     end
 
     @test_throws "concatenation syntax" code_tiled(
-            Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
         t = ct.load(a, ct.bid(1), (4,))
         Base.donotdelete([t, t])
         return
@@ -3312,7 +3312,7 @@ end
     @test @filecheck begin
         @check_label "entry"
         @check_not "cat "
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             t = ct.load(a, ct.bid(1), (4,))
             ct.store(a, ct.bid(1), vcat(Float32[], t, Float32[]))
             return
@@ -3323,8 +3323,8 @@ end
         @check_label "entry"
         @check "ftof {{.*}}tile<4xf32> -> tile<4xf64>"
         @check_not "cat "
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d},
-                         ct.TileArray{Float64,1,spec1d}}) do input, output
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                         ct.TileArray{Float64,1,Int32,spec1d}}) do input, output
             t = ct.load(input, ct.bid(1), (4,))
             ct.store(output, ct.bid(1), vcat(Float64[], t))
             return
@@ -3334,7 +3334,7 @@ end
     @test @filecheck begin
         @check_label "entry"
         @check_not "cat "
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             t = ct.load(a, ct.bid(1), (4,))
             ct.store(a, ct.bid(1), Float32[Float64[]; t])
             return

--- a/test/codegen/reflection.jl
+++ b/test/codegen/reflection.jl
@@ -1,5 +1,5 @@
 spec = ct.ArraySpec{1}(16, true)
-TT3 = Tuple{ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}, ct.TileArray{Float32,1,spec}}
+TT3 = Tuple{ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}, ct.TileArray{Float32,1,Int32,spec}}
 
 function reflect_vadd(a, b, c)
     pid = ct.bid(1)
@@ -74,8 +74,8 @@ end
 
 @testset "Constant args" begin
     const_spec = ct.ArraySpec{1}(128, true, (0,), (32,))
-    ConstTT = Tuple{ct.TileArray{Float32,1,const_spec}, ct.TileArray{Float32,1,const_spec},
-                    ct.TileArray{Float32,1,const_spec}, ct.Constant{Int64, 16}}
+    ConstTT = Tuple{ct.TileArray{Float32,1,Int32,const_spec}, ct.TileArray{Float32,1,Int32,const_spec},
+                    ct.TileArray{Float32,1,Int32,const_spec}, ct.Constant{Int64, 16}}
 
     function reflect_const_vadd(a, b, c, tile_size::Int)
         pid = ct.bid(1)
@@ -119,8 +119,8 @@ end
             return
         end
 
-        ConstTypeTT = Tuple{ct.TileArray{Float32,1,const_spec}, ct.TileArray{Float32,1,const_spec},
-                            ct.TileArray{Float32,1,const_spec}, ct.Constant{Int64, 16},
+        ConstTypeTT = Tuple{ct.TileArray{Float32,1,Int32,const_spec}, ct.TileArray{Float32,1,Int32,const_spec},
+                            ct.TileArray{Float32,1,Int32,const_spec}, ct.Constant{Int64, 16},
                             Type{Float32}}
 
         @test @filecheck begin

--- a/test/codegen/rng_intrinsics.jl
+++ b/test/codegen/rng_intrinsics.jl
@@ -14,7 +14,7 @@
             # rng_counter() twice with an rng_advance(16) between → one addi
             # with constant 16. Const-folding collapses 0 + 16 = 16, so the
             # output store sees a constant-16 tile.
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 v = ct.Intrinsics.rng_counter(0)
                 ct.Intrinsics.rng_advance(0, 16)
@@ -34,7 +34,7 @@
         # `addi %iterArg, 1` and continuing with the bumped value.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}, Int32}) do a, n
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}, Int32}) do a, n
                 pid = ct.bid(1)
                 for i in Int32(1):n
                     ct.Intrinsics.rng_advance(0, 1)
@@ -55,7 +55,7 @@
         # well-defined counter value.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}, Int32}) do a, cond
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}, Int32}) do a, cond
                 pid = ct.bid(1)
                 if cond > Int32(0)
                     ct.Intrinsics.rng_advance(0, 1)
@@ -77,7 +77,7 @@
         # a single-slot implementation would merge to 48.
         @test @filecheck begin
             @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{UInt32,1,spec1d}, ct.TileArray{UInt32,1,spec1d}}) do a, b
+            code_tiled(Tuple{ct.TileArray{UInt32,1,Int32,spec1d}, ct.TileArray{UInt32,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
                 ct.Intrinsics.rng_advance(1, 16)
                 ct.Intrinsics.rng_advance(2, 32)
@@ -99,7 +99,7 @@
             @check_label "entry"
             @check_not "rng_counter"
             @check_not "rng_advance"
-            code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
                 pid = ct.bid(1)
                 tile = ct.load(a, pid, (16,))
                 ct.store(a, pid, tile)

--- a/test/codegen/slice.jl
+++ b/test/codegen/slice.jl
@@ -16,7 +16,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # stride and base pointer are runtime kernel parameters.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[3:10]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -34,7 +34,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # `subi(stop, start)` for the new axis size.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -54,7 +54,7 @@ end
     spec2d_nc = ct.ArraySpec{2}(16, false)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d_nc}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d_nc}, Int32, Int32}) do a, i, j
             sub = @view a[i:j, :]
             t = ct.load(sub, (1, 1), (4, 4))
             ct.store(sub, (1, 1), t)
@@ -69,7 +69,7 @@ end
     # Slice along axis 2; axis 1 is full (`:`).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, Int32, Int32}) do a, i, j
             sub = @view a[:, i:j]
             t = ct.load(sub, (1, 1), (4, 4))
             ct.store(sub, (1, 1), t)
@@ -86,7 +86,7 @@ end
     # Both axes sliced. Emits two offsets (one per axis).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d},
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d},
                          Int32, Int32, Int32, Int32}) do a, i, j, k, l
             sub = @view a[i:j, k:l]
             t = ct.load(sub, (1, 1), (4, 4))
@@ -104,7 +104,7 @@ end
     # the tile-origin StridedView path.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[2:3:20]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -120,7 +120,7 @@ end
     # A runtime-positive step remains dynamic in the TensorView stride.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, Int32, Int32, Int32}) do a, i, s, j
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, Int32, Int32, Int32}) do a, i, s, j
             sub = @view a[i:s:j, :]
             t = ct.load(sub, (1, 1), (4, 4))
             ct.store(sub, (1, 1), t)
@@ -136,7 +136,7 @@ end
     # the AssertOp is elided by the assert intrinsic's Const(true) fast path.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[3:10]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -150,7 +150,7 @@ end
     # `last(r) >= first(r) - 1`, so any such assert would always pass.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, Int32, Int32}) do a, i, j
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, Int32, Int32}) do a, i, j
             sub = @view a[i:j]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -168,7 +168,7 @@ end
     # `emit_intrinsic!(::typeof(Intrinsics.assert), ...)`.)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[0:10]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)
@@ -183,7 +183,7 @@ end
     # IR or silently materializing a reversal.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             sub = @view a[10:-1:1]
             t = ct.load(sub, 1, (4,))
             ct.store(sub, 1, t)

--- a/test/codegen/token_order.jl
+++ b/test/codegen/token_order.jl
@@ -11,8 +11,8 @@ spec1d = ct.ArraySpec{1}(16, true, (0,), (16,))
 # Same layout facts, but distinct indices may map to the same memory
 # (e.g. a zero stride) — parallel stores must be disabled.
 spec1d_aliasing = ct.ArraySpec{1}(16, true, (0,), (16,), true)
-AT = ct.TileArray{Float32, 1, spec1d}
-AT_aliasing = ct.TileArray{Float32, 1, spec1d_aliasing}
+AT = ct.TileArray{Float32, 1, Int32, spec1d}
+AT_aliasing = ct.TileArray{Float32, 1, Int32, spec1d_aliasing}
 
 @testset "token_order — identity IV store is loop-parallel" begin
     # `store(b, i, _)` lowers the index as `subi(iv, 1)` — injective, so the

--- a/test/codegen/views.jl
+++ b/test/codegen/views.jl
@@ -6,6 +6,11 @@
 spec1d = ct.ArraySpec{1}(16, true)
 spec2d = ct.ArraySpec{2}(16, true)
 
+@testset "make_tensor_view — imprecise type argument" begin
+    @test ct.tfunc(nothing, ct.Intrinsics.make_tensor_view,
+                   DataType, Any, Any, Any) === nothing
+end
+
 @testset "permutedims — 2D (2, 1)" begin
     # Source: contiguous (strides=[?,1]). After permutedims with (2,1),
     # contiguity flag drops (new stride[1] is the old stride[2], not 1) —

--- a/test/codegen/views.jl
+++ b/test/codegen/views.jl
@@ -7,6 +7,8 @@ spec1d = ct.ArraySpec{1}(16, true)
 spec2d = ct.ArraySpec{2}(16, true)
 
 @testset "make_tensor_view — imprecise type argument" begin
+    # The public codegen path normally keeps this argument precise in the test
+    # harness; call the inference hook directly to cover the cold-process case.
     @test ct.tfunc(nothing, ct.Intrinsics.make_tensor_view,
                    DataType, Any, Any, Any) === nothing
 end

--- a/test/codegen/views.jl
+++ b/test/codegen/views.jl
@@ -12,7 +12,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # the new tensor_view is fully dynamic.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             b = permutedims(a, (2, 1))
             t = ct.load(b, (1, 1), (4, 4))
             ct.store(a, (1, 1), t)
@@ -29,7 +29,7 @@ end
     # transpose(arr) === permutedims(arr, (2, 1)).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}) do a
             b = transpose(a)
             t = ct.load(b, (1, 1), (4, 4))
             ct.store(a, (1, 1), t)
@@ -46,7 +46,7 @@ end
     # folds to `true` and is elided.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
             b = reshape(a, (4, 4))
             t = ct.load(b, (1, 1), (4, 4))
             ct.store(a, 1, ct.reshape(t, (16,)))
@@ -67,7 +67,7 @@ end
     spec_noncontig = ct.ArraySpec{2}(0, false)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec_noncontig}}) do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec_noncontig}}) do a
             b = reshape(a, (16,))
             t = ct.load(b, 1, (16,))
             ct.store(a, (1, 1), ct.reshape(t, (4, 4)))
@@ -84,7 +84,7 @@ end
         @check_label "entry"
         @check "make_partition_view"
         @check_not "make_strided_view"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}};
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
                    bytecode_version=v"13.2") do a, b
             src = eachtile(a, (8,))
             dst = eachtile(b, (8,); step=(8,))
@@ -101,7 +101,7 @@ end
         @check "tile=(4x8), traversal_strides=[2,3]"
         @check "load_view_tko"
         @check "store_view_tko"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float32,2,spec2d}};
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float32,2,Int32,spec2d}};
                    bytecode_version=v"13.3") do a, b
             src = eachtile(a, (8, 4); step=(3, 2), padding_mode=ct.PaddingMode.Zero)
             dst = eachtile(b, (8, 4); step=(3, 2))
@@ -112,7 +112,7 @@ end
     end
 
     @test_throws "v13.3+" code_tiled(
-        Tuple{ct.TileArray{Float32,1,spec1d}}; bytecode_version=v"13.2") do a
+        Tuple{ct.TileArray{Float32,1,Int32,spec1d}}; bytecode_version=v"13.2") do a
             tiles = eachtile(a, (8,); step=(4,))
             ct.store(tiles, 1, ct.load(tiles, 1))
             return
@@ -130,7 +130,7 @@ end
         @check "get_index_space_shape"
         @check "load_view_tko"
         @check "store_view_tko"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}}; bytecode_version=v"13.3") do a
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}; bytecode_version=v"13.3") do a
             tiles = eachtile(a, (8,); step=(4,))
             n = size(tiles, 1)
             ct.store(a, 1, ct.load(tiles, n))
@@ -148,7 +148,7 @@ end
         @check "make_partition_view"
         @check "dim_map=[1, 0]"
         @check "load_view_tko"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.3") do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.3") do a
             tiles = eachtile(a, (4, 8); order=(2, 1))
             ct.store(a, (1, 1), ct.load(tiles, (1, 1)))
             return
@@ -161,7 +161,7 @@ end
         @check "make_strided_view"
         @check "dim_map=[1, 0]"
         @check "load_view_tko"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.3") do a
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.3") do a
             tiles = eachtile(a, (4, 8); step=(2, 8), order=(2, 1))
             ct.store(a, (1, 1), ct.load(tiles, (1, 1)))
             return

--- a/test/device/core.jl
+++ b/test/device/core.jl
@@ -562,7 +562,7 @@ end
 @testset "struct destructuring" begin
     @testset "TileArray + scalar field" begin
         struct ArrayWithScale{T, N, S}
-            arr::ct.TileArray{T, N, S}
+            arr::ct.TileArray{T, N, Int32, S}
             scale::Float32
         end
 
@@ -581,8 +581,8 @@ end
 
     @testset "two TileArrays in one struct" begin
         struct TwoArrays{T, N, S1, S2}
-            a::ct.TileArray{T, N, S1}
-            b::ct.TileArray{T, N, S2}
+            a::ct.TileArray{T, N, Int32, S1}
+            b::ct.TileArray{T, N, Int32, S2}
         end
 
         function add_two_kernel(dest::ct.TileArray{Float32,1}, pair::TwoArrays{Float32,1}, ts)
@@ -602,7 +602,7 @@ end
 
     @testset "nested struct (struct inside struct)" begin
         struct InnerLayer{T, N, S}
-            arr::ct.TileArray{T, N, S}
+            arr::ct.TileArray{T, N, Int32, S}
             bias::Float32
         end
         struct OuterLayer{T, N, S}
@@ -643,8 +643,8 @@ end
     @testset "heterogeneous tuple in struct" begin
         struct HetTupleWrapper{A, B}; a::A; b::B; end
 
-        function het_tuple_kernel(dest::ct.TileArray{Float32,1,S},
-                                  w::HetTupleWrapper{ct.TileArray{Float32,1,S2}, Int32},
+        function het_tuple_kernel(dest::ct.TileArray{Float32,1,Int32,S},
+                                  w::HetTupleWrapper{ct.TileArray{Float32,1,Int32,S2}, Int32},
                                   ts) where {S, S2}
             bid = ct.bid(1)
             tile = ct.load(w.a, bid, (ts[1],))

--- a/test/device/int64_indexing.jl
+++ b/test/device/int64_indexing.jl
@@ -18,8 +18,14 @@ Base.getindex(::WideDeviceVector, ::Int) = error("not implemented")
     wide = WideDeviceVector(src, Int64(typemax(Int32)) + 1)
     dst = CUDA.zeros(Float32, 16)
 
-    @test ct.indextype(ct.cuTileconvert(wide)) === Int64
-    @test ct.indextype(ct.cuTileconvert(dst)) === Int32
+    @test ct.indextype(ct.TileArray(wide)) === Int64
     @cuda backend=cuTile blocks=1 copy_wide_prefix(wide, dst)
+    @test Array(dst) == Array(src)
+
+    fill!(dst, 0)
+    src64 = ct.TileArray(src; index=Int64)
+    dst64 = ct.TileArray(dst; index=Int64)
+    @test ct.indextype(src64) === ct.indextype(dst64) === Int64
+    @cuda backend=cuTile blocks=1 copy_wide_prefix(src64, dst64)
     @test Array(dst) == Array(src)
 end

--- a/test/device/int64_indexing.jl
+++ b/test/device/int64_indexing.jl
@@ -1,0 +1,25 @@
+struct WideDeviceVector{T, A<:CuArray{T, 1}} <: AbstractVector{T}
+    parent::A
+    len::Int64
+end
+Base.size(a::WideDeviceVector) = (a.len,)
+Base.strides(::WideDeviceVector) = (Int64(1),)
+Base.pointer(a::WideDeviceVector) = pointer(a.parent)
+Base.getindex(::WideDeviceVector, ::Int) = error("not implemented")
+
+@testset "Int64 indexing" begin
+    function copy_wide_prefix(src::ct.TileArray{Float32, 1},
+                              dst::ct.TileArray{Float32, 1})
+        ct.store(dst, 1, ct.load(src, 1, (16,)))
+        return
+    end
+
+    src = CUDA.rand(Float32, 16)
+    wide = WideDeviceVector(src, Int64(typemax(Int32)) + 1)
+    dst = CUDA.zeros(Float32, 16)
+
+    @test ct.indextype(ct.cuTileconvert(wide)) === Int64
+    @test ct.indextype(ct.cuTileconvert(dst)) === Int32
+    @cuda backend=cuTile blocks=1 copy_wide_prefix(wide, dst)
+    @test Array(dst) == Array(src)
+end

--- a/test/device/tile.jl
+++ b/test/device/tile.jl
@@ -1206,8 +1206,8 @@ end
 
     @testset "batched mat-vec (3D × 1D) errors" begin
         @test_throws cuTile.CodegenErrors begin
-            ct.code_tiled(Tuple{ct.TileArray{Float32,3,ct.ArraySpec{3}(16,true)},
-                                ct.TileArray{Float32,1,ct.ArraySpec{1}(16,true)}}) do a, b
+            ct.code_tiled(Tuple{ct.TileArray{Float32,3,Int32,ct.ArraySpec{3}(16,true)},
+                                ct.TileArray{Float32,1,Int32,ct.ArraySpec{1}(16,true)}}) do a, b
                 bidx = ct.bid(1)
                 tile_a = ct.load(a, bidx, (16, 8, 4))
                 tile_b = ct.load(b, bidx, (8,))

--- a/test/extensions/DLFP8Types.jl
+++ b/test/extensions/DLFP8Types.jl
@@ -9,7 +9,7 @@ spec2d = ct.ArraySpec{2}(16, true)
 # Float32 -> Float8_E4M3FN
 @test @filecheck begin
     @check_label "entry"
-    code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+    code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
         pid = ct.bid(1)
         tile = ct.load(a, pid, (16,))
         @check "ftof"
@@ -22,7 +22,7 @@ end
 # Float32 -> Float8_E5M2
 @test @filecheck begin
     @check_label "entry"
-    code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+    code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
         pid = ct.bid(1)
         tile = ct.load(a, pid, (16,))
         @check "ftof"
@@ -35,8 +35,8 @@ end
 # Non-scaled f8 matmul lowers to `mmaf` (f8 operands, f32 accumulator).
 @test @filecheck begin
     @check_label "entry"
-    code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                     ct.TileArray{Float32,2,spec2d}}) do a, b, c
+    code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                     ct.TileArray{Float32,2,Int32,spec2d}}) do a, b, c
         ta = ct.load(a, (1, 1), (16, 16))
         tb = ct.load(b, (1, 1), (16, 16))
         @check "mmaf"
@@ -48,8 +48,8 @@ end
 # `fast_acc=true` is an FP8-only hint; it still lowers to `mmaf` (13.3+).
 @test @filecheck begin
     @check_label "entry"
-    code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                     ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.3") do a, b, c
+    code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                     ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.3") do a, b, c
         ta = ct.load(a, (1, 1), (16, 16))
         tb = ct.load(b, (1, 1), (16, 16))
         @check "mmaf"

--- a/test/extensions/Microfloats/codegen.jl
+++ b/test/extensions/Microfloats/codegen.jl
@@ -9,7 +9,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # Float32 -> Float8_E4M3FN (always available; 13.1+)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
             @check "ftof"
@@ -22,7 +22,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # Float32 -> Float8_E5M2 (always available; 13.1+)
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}}) do a, b
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
             @check "ftof"
@@ -35,7 +35,7 @@ spec2d = ct.ArraySpec{2}(16, true)
     # Float32 -> Float8_E8M0FNU works on bytecode 13.2+
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}};
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
                    bytecode_version=v"13.2") do a, b
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
@@ -55,7 +55,7 @@ spec2d = ct.ArraySpec{2}(16, true)
             return
         end
         @test_throws "v13.2+" code_tiled(devnull, kernel,
-            Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}};
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
             bytecode_version=v"13.1")
     end
 
@@ -68,7 +68,7 @@ spec2d = ct.ArraySpec{2}(16, true)
             return
         end
         @test_throws "v13.3+" code_tiled(devnull, kernel,
-            Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{Float32,1,spec1d}};
+            Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
             bytecode_version=v"13.2")
     end
 end
@@ -79,7 +79,7 @@ end
     # lowering to `cuda_tile.unpack` (13.3+).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{UInt8,1,spec1d}, ct.TileArray{Float32,1,spec1d}};
+        code_tiled(Tuple{ct.TileArray{UInt8,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
                    bytecode_version=v"13.3") do a, b
             pid = ct.bid(1)
             bytes = ct.load(a, pid, (8,))            # Tile{UInt8,(8,)}
@@ -93,7 +93,7 @@ end
     # And the reverse packs FP4 back into bytes via `cuda_tile.pack` (13.3+).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,1,spec1d}, ct.TileArray{UInt8,1,spec1d}};
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{UInt8,1,Int32,spec1d}};
                    bytecode_version=v"13.3") do a, b
             pid = ct.bid(1)
             vals = ct.load(a, pid, (16,))
@@ -109,8 +109,8 @@ end
     # f8e4m3fn operands with an f32 accumulator lower to `mmaf` (13.1+).
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                         ct.TileArray{Float32,2,spec2d}}) do a, b, c
+        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                         ct.TileArray{Float32,2,Int32,spec2d}}) do a, b, c
             ta = ct.load(a, (1, 1), (16, 16))
             tb = ct.load(b, (1, 1), (16, 16))
             @check "mmaf"
@@ -122,8 +122,8 @@ end
     # f8e5m2 operands with an f16 accumulator also lower to `mmaf`.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float8_E5M2,2,spec2d}, ct.TileArray{Float8_E5M2,2,spec2d},
-                         ct.TileArray{Float16,2,spec2d}}) do a, b, c
+        code_tiled(Tuple{ct.TileArray{Float8_E5M2,2,Int32,spec2d}, ct.TileArray{Float8_E5M2,2,Int32,spec2d},
+                         ct.TileArray{Float16,2,Int32,spec2d}}) do a, b, c
             ta = ct.load(a, (1, 1), (16, 16))
             tb = ct.load(b, (1, 1), (16, 16))
             @check "mmaf"
@@ -135,8 +135,8 @@ end
     # A disallowed accumulator dtype for f8 (only f16/f32 are valid) is rejected
     # with a clear error rather than producing an mmaf op tileiras would reject.
     @test_throws "tileiras requires acc" code_tiled(
-        Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-              ct.TileArray{Float64,2,spec2d}}) do a, b, c
+        Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+              ct.TileArray{Float64,2,Int32,spec2d}}) do a, b, c
         ta = ct.load(a, (1, 1), (16, 16))
         tb = ct.load(b, (1, 1), (16, 16))
         acc = zeros(Float64, (16, 16))
@@ -150,8 +150,8 @@ end
     # the op as a flag); requires bytecode 13.3.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                         ct.TileArray{Float32,2,spec2d}};
+        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                         ct.TileArray{Float32,2,Int32,spec2d}};
                    bytecode_version=v"13.3") do a, b, c
             ta = ct.load(a, (1, 1), (16, 16))
             tb = ct.load(b, (1, 1), (16, 16))
@@ -163,8 +163,8 @@ end
 
     # `fast_acc` is an FP8-only hint: requesting it for f16 inputs is rejected.
     @test_throws "only supported for fp8" code_tiled(
-        Tuple{ct.TileArray{Float16,2,spec2d}, ct.TileArray{Float16,2,spec2d},
-              ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.3") do a, b, c
+        Tuple{ct.TileArray{Float16,2,Int32,spec2d}, ct.TileArray{Float16,2,Int32,spec2d},
+              ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.3") do a, b, c
         ta = ct.load(a, (1, 1), (16, 16))
         tb = ct.load(b, (1, 1), (16, 16))
         ct.store(c, (1, 1), muladd(ta, tb, zeros(Float32, (16, 16)); fast_acc=true))
@@ -179,8 +179,8 @@ end
             return
         end
         @test_throws "13.3" code_tiled(devnull, kernel,
-            Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                  ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.2")
+            Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                  ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.2")
     end
 end
 
@@ -189,9 +189,9 @@ end
     # accumulate into f32. Block size B = K ÷ K_s = 64 ÷ 2 = 32.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E8M0FNU,2,spec2d},
-                         ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E8M0FNU,2,spec2d},
-                         ct.TileArray{Float32,2,spec2d}};
+        code_tiled(Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E8M0FNU,2,Int32,spec2d},
+                         ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E8M0FNU,2,Int32,spec2d},
+                         ct.TileArray{Float32,2,Int32,spec2d}};
                    bytecode_version=v"13.3") do x, x_scale, y, y_scale, z
             xt  = ct.load(x,       (1, 1), (16, 64))
             xst = ct.load(x_scale, (1, 1), (16, 2))
@@ -208,9 +208,9 @@ end
     # unpacked FP4 tiles; `mmaf_scaled` accepts them too.
     @test @filecheck begin
         @check_label "entry"
-        code_tiled(Tuple{ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                         ct.TileArray{Float32,2,spec2d}, ct.TileArray{Float8_E4M3FN,2,spec2d},
-                         ct.TileArray{Float32,2,spec2d}};
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                         ct.TileArray{Float32,2,Int32,spec2d}, ct.TileArray{Float8_E4M3FN,2,Int32,spec2d},
+                         ct.TileArray{Float32,2,Int32,spec2d}};
                    bytecode_version=v"13.3") do x, x_scale, y, y_scale, z
             xt  = convert(ct.Tile{Float4_E2M1FN}, ct.load(x, (1, 1), (16, 64)))
             xst = ct.load(x_scale, (1, 1), (16, 4))
@@ -233,9 +233,9 @@ end
             return
         end
         @test_throws "13.3" code_tiled(devnull, kernel,
-            Tuple{ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E8M0FNU,2,spec2d},
-                  ct.TileArray{Float8_E4M3FN,2,spec2d}, ct.TileArray{Float8_E8M0FNU,2,spec2d},
-                  ct.TileArray{Float32,2,spec2d}}; bytecode_version=v"13.2")
+            Tuple{ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E8M0FNU,2,Int32,spec2d},
+                  ct.TileArray{Float8_E4M3FN,2,Int32,spec2d}, ct.TileArray{Float8_E8M0FNU,2,Int32,spec2d},
+                  ct.TileArray{Float32,2,Int32,spec2d}}; bytecode_version=v"13.2")
     end
 end
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -90,16 +90,8 @@ end
     @test ct.indextype(small_tile) === Int32
     @test ct.indextype(wide_tile) === Int64
     @test ct.indextype(forced_wide_tile) === Int64
-    @test eltype(small_tile.sizes) === Int32
-    @test eltype(wide_tile.strides) === Int64
     @test_throws InexactError ct.TileArray(wide; index=Int32)
     @test_throws ArgumentError ct.TileArray(small; index=UInt32)
-
-    indices = (Int16(2), Int64(3))
-    @test ct.zero_based_indices(Int32, indices) === (Int64(1), Int64(2))
-    @test ct.zero_based_indices(Int64, indices) === (Int64(1), Int64(2))
-    @test_throws MethodError ct.zero_based_indices(Int32, (2.0,))
-    @test_throws MethodError ct.zero_based_indices(Int64, (2.0,))
 end
 
 @testset "PartitionView" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,3 +1,13 @@
+struct TestDeviceArray{T, N} <: AbstractArray{T, N}
+    ptr::CUDA.CuPtr{T}
+    dims::NTuple{N, Int64}
+    steps::NTuple{N, Int64}
+end
+Base.size(a::TestDeviceArray) = a.dims
+Base.strides(a::TestDeviceArray) = a.steps
+Base.pointer(a::TestDeviceArray) = a.ptr
+Base.getindex(::TestDeviceArray, ::Vararg{Int}) = error("not implemented")
+
 @testset "Constant" begin
     # Auto-typed convenience constructor
     @test cuTile.Constant(Int32(5)) === cuTile.Constant{Int32, Int32(5)}()
@@ -57,16 +67,33 @@ end
 
     # array_spec tests
     spec = ct.ArraySpec{2}(128, true)
-    TA = ct.TileArray{Float32, 2, spec}
+    TA = ct.TileArray{Float32, 2, Int32, spec}
     @test ct.array_spec(TA) === spec
+    @test ct.indextype(TA) === Int32
     @test ct.array_spec(ct.TileArray{Float32, 2}) === nothing
 
     spec1 = ct.ArraySpec{2}(128, true, (1, 4), (16, 8))
-    T = ct.TileArray{Float32, 2, spec1}
+    T = ct.TileArray{Float32, 2, Int32, spec1}
     @test ct.array_spec(ct.sliced_arraytype(T)).contiguous
     @test !ct.array_spec(ct.sliced_arraytype(T; stepped_axis=1)).contiguous
     @test ct.array_spec(ct.sliced_arraytype(T; stepped_axis=2)).contiguous
     @test ct.array_spec(ct.sliced_arraytype(T; stepped_axis=1)).stride_div_by == (1, 4)
+
+    ptr = CUDA.CuPtr{Float32}(0)
+    small = TestDeviceArray(ptr, (Int64(16), Int64(8)), (Int64(1), Int64(16)))
+    wide = TestDeviceArray(ptr, (Int64(16), Int64(8)),
+                           (Int64(1), Int64(typemax(Int32)) + 1))
+
+    small_tile = ct.TileArray(small)
+    wide_tile = ct.TileArray(wide)
+    forced_wide_tile = ct.TileArray(small; index=Int64)
+    @test ct.indextype(small_tile) === Int32
+    @test ct.indextype(wide_tile) === Int64
+    @test ct.indextype(forced_wide_tile) === Int64
+    @test eltype(small_tile.sizes) === Int32
+    @test eltype(wide_tile.strides) === Int64
+    @test_throws InexactError ct.TileArray(wide; index=Int32)
+    @test_throws ArgumentError ct.TileArray(small; index=UInt32)
 end
 
 @testset "PartitionView" begin
@@ -119,6 +146,12 @@ end
     @test size(permuted) == (Int32(4), Int32(8))  # cld(10, 3), cld(16, 2)
     @test_throws "must be a permutation" eachtile(a, (8, 4); order=(1, 1))
     @test_throws "must be a permutation" eachtile(a, (8, 4); order=(1,))
+
+    a64 = ct.TileArray(Ptr{Float32}(0), (Int64(16), Int64(10)),
+                       (Int64(1), Int64(16)))
+    tiles64 = eachtile(a64, (8, 4); step=(3, 2))
+    @test size(tiles64) == (Int64(6), Int64(5))
+    @test size(tiles64, 3) === Int64(1)
 end
 
 @testset "GatherScatterTileView" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -94,6 +94,12 @@ end
     @test eltype(wide_tile.strides) === Int64
     @test_throws InexactError ct.TileArray(wide; index=Int32)
     @test_throws ArgumentError ct.TileArray(small; index=UInt32)
+
+    indices = (Int16(2), Int64(3))
+    @test ct.zero_based_indices(Int32, indices) === (Int64(1), Int64(2))
+    @test ct.zero_based_indices(Int64, indices) === (Int64(1), Int64(2))
+    @test_throws MethodError ct.zero_based_indices(Int32, (2.0,))
+    @test_throws MethodError ct.zero_based_indices(Int64, (2.0,))
 end
 
 @testset "PartitionView" begin


### PR DESCRIPTION
cuTile.jl currently represents array sizes and strides as Int32. That keeps index arithmetic cheap for normal arrays, but it also means arrays whose dimensions, strides, or offsets exceed the Int32 range cannot be represented correctly.

CUDA Tile 13.3 added support for Int64-indexed tensor views, which Python cuTile exposes through `IndexedWithInt64`. This PR adds the corresponding support to cuTile.jl.

`TileArray` now carries its index width as part of its type. Arrays continue to use Int32 by default, but switch to Int64 automatically when one of their sizes or strides does not fit. Int64 can also be requested explicitly:

```julia
TileArray(array; index=Int64)
```

The selected width is preserved through derived arrays and views, and is used consistently by partition and strided views, gather/scatter operations, bounds checks, pointer arithmetic, and atomics.

Int64-indexed arrays require Tile IR bytecode 13.3 or newer. The existing Int32 path remains unchanged.