### PR TITLE
Add tileiras remarks to Tile IR reflection

### DIFF
--- a/docs/src/man/debugging.md
+++ b/docs/src/man/debugging.md
@@ -36,6 +36,18 @@ Spelling out those types is only worth it when you have no GPU, since
 `code_tiled` does not need CUDA.jl. Otherwise let the launch site derive them
 for you with `ct.@device_code_tiled`, described next.
 
+With a CUDA 13.4 or newer `tileiras`, pass `remarks=true` to compile the Tile IR
+and print optimization diagnostics after it:
+
+```julia
+ct.code_tiled(vadd, argtypes; remarks=true, sm_arch=v"10.0")
+```
+
+The remarks report successful and failed optimizations, including tensor-core
+selection and memory alignment issues. `sm_arch` may be omitted when a CUDA
+device is available. Remarks are generated afresh for reflection and are not
+read from or written to the compilation cache.
+
 
 ## Intercepting a launch
 
@@ -52,6 +64,13 @@ cuda_tile.module @kernels {
     return
   }
 }
+```
+
+Pass `remarks=true` to include `tileiras` optimization remarks for every
+intercepted kernel:
+
+```julia
+ct.@device_code_tiled remarks=true @cuda backend=cuTile blocks=grid kernel(args...)
 ```
 
 Three are available, corresponding to successive stages of the pipeline:

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -108,11 +108,16 @@ constant_eltype(::Type{Constant{T,V}}) where {T,V} = T
 constant_value(::Type{Constant{T,V}}) where {T,V} = V
 
 """
-    code_tiled([io::IO], f, argtypes; sm_arch, opt_level, num_ctas, occupancy, num_worker_warps)
+    code_tiled([io::IO], f, argtypes; sm_arch, opt_level, num_ctas, occupancy,
+               num_worker_warps, remarks=false)
 
 Print the CUDA Tile IR for a Julia function as a textual MLIR representation.
 Analogous to `code_llvm`/`code_native`. Calls the driver directly without
 caching in CuTileResults, so reflection never pollutes the compilation cache.
+
+Set `remarks=true` to also run `tileiras` and print its optimization remarks.
+This requires Tile IR 13.4 or newer. When no GPU is available, pass `sm_arch`
+explicitly.
 """
 function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
                     sm_arch::Union{VersionNumber, Nothing}=nothing,
@@ -122,6 +127,7 @@ function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
                     num_worker_warps::Union{Int, Nothing}=nothing,
                     bytecode_version::VersionNumber=cuTile.bytecode_version(),
                     debuginfo::Bool=false,
+                    remarks::Bool=false,
                     world::UInt=Base.get_world_counter())
     stripped, const_argtypes = process_const_argtypes(f, argtypes)
     mi = lookup_method_instance(f, stripped; world)
@@ -135,6 +141,30 @@ function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
                          name=sanitize_name(string(mi.def.name)),
                          opts, cache, const_argtypes)
     print(io, disassemble_tileir(bytecode; debuginfo))
+    if remarks
+        tileiras_supports_remarks() || throw(ArgumentError(
+            "tileiras optimization remarks require tileiras 13.4 or newer"))
+        target = if sm_arch === nothing
+            try
+                default_sm_arch()
+            catch
+                throw(ArgumentError(
+                    "sm_arch must be specified when requesting remarks without a CUDA device"))
+            end
+        else
+            sm_arch
+        end
+        resolved_opt_level = something(resolve_hint(opt_level, kernel_meta,
+                                                    :opt_level, target), 3)
+        _, text = run_tileiras(bytecode, target, resolved_opt_level; remarks=true)
+        if !isempty(text)
+            println(io)
+            println(io, "// tileiras optimization remarks")
+            for line in eachline(IOBuffer(text); keep=true)
+                print(io, "// ", line)
+            end
+        end
+    end
 end
 code_tiled(@nospecialize(f), @nospecialize(argtypes); kwargs...) =
     code_tiled(stdout, f, argtypes; kwargs...)
@@ -182,9 +212,10 @@ function emit_hooked_compilation(inner_hook, ex...)
 end
 
 """
-    @device_code_tiled [io=stdout] expression
+    @device_code_tiled [io=stdout] [remarks=false] expression
 
 Print the Tile IR (MLIR) for all kernels compiled while evaluating the expression.
+With `remarks=true`, also print `tileiras` optimization remarks for each kernel.
 
 # Example
 ```julia

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -193,6 +193,81 @@ function run_and_collect(cmd)
     return proc, log
 end
 
+function cleanup_tileiras_remarks(remarks::AbstractString)
+    starts = findall(r"(?m)^---(?:[ \t].*)?\r?$", remarks)
+    if length(starts) >= 2
+        prefix = remarks[firstindex(remarks):prevind(remarks, first(starts).start)]
+        documents = String[]
+        seen = Set{String}()
+        for (i, start) in enumerate(starts)
+            stop = i == length(starts) ? lastindex(remarks) :
+                   prevind(remarks, starts[i + 1].start)
+            document = String(SubString(remarks, start.start, stop))
+            if document ∉ seen
+                push!(seen, document)
+                push!(documents, document)
+            end
+        end
+        remarks = prefix * join(documents)
+    end
+
+    lines = readlines(IOBuffer(remarks); keep=true)
+    folded = String[]
+    i = 1
+    while i <= length(lines)
+        line = lines[i]
+        push!(folded, line)
+        if startswith(line, "  - Reason:")
+            i += 1
+            while i <= length(lines) && lines[i] == line
+                i += 1
+            end
+        else
+            i += 1
+        end
+    end
+    return join(folded)
+end
+
+function run_tileiras(bytecode::Vector{UInt8}, sm_arch::VersionNumber,
+                      opt_level::Int; remarks::Bool=false)
+    input_path = tempname() * ".tile"
+    output_path = tempname() * ".cubin"
+    remarks_path = tempname() * ".remarks.yaml"
+    compiled = false
+    try
+        write(input_path, bytecode)
+        args = String[input_path, "-o", output_path,
+                      "--gpu-name", format_sm_arch(sm_arch),
+                      "-O$(opt_level)", "--lineinfo"]
+        if remarks
+            append!(args, ["--remark-format=yaml", "--remarks=all",
+                           "--remarks-output-file=$(remarks_path)"])
+        end
+        proc, log = run_and_collect(tileiras_cmd(args...))
+        if !success(proc)
+            reason = proc.termsignal > 0 ? "tileiras received signal $(proc.termsignal)" :
+                                           "tileiras exited with code $(proc.exitcode)"
+            msg = "Failed to compile Tile IR ($reason)"
+            isempty(log) || (msg *= "\n" * log)
+            msg *= "\nIf you think this is a bug, please file an issue and attach $(input_path)"
+            if parse(Bool, get(ENV, "BUILDKITE", "false"))
+                run(`buildkite-agent artifact upload $(input_path)`)
+            end
+            error(msg)
+        end
+        compiled = true
+        cubin = read(output_path)
+        remark_text = remarks && isfile(remarks_path) ?
+                      cleanup_tileiras_remarks(read(remarks_path, String)) : ""
+        return cubin, remark_text
+    finally
+        compiled && rm(input_path, force=true)
+        rm(output_path, force=true)
+        rm(remarks_path, force=true)
+    end
+end
+
 const toolkit_version_cache =
     Base.Lockable(Base.RefValue{Union{Nothing, Some{Union{Nothing, String}}}}(nothing))
 
@@ -260,6 +335,13 @@ end
 function parse_toolkit_version(log::AbstractString)
     m = match(TILEIRAS_VERSION_REGEX, log)
     m === nothing ? (isempty(log) ? nothing : String(log)) : m.captures[1]
+end
+
+function tileiras_supports_remarks()
+    version = toolkit_version()
+    version === nothing && return false
+    parsed = tryparse(VersionNumber, version)
+    return parsed !== nothing && parsed >= v"13.4"
 end
 
 """
@@ -465,34 +547,7 @@ function emit_binary!(cache::CacheView, mi::Core.MethodInstance,
     end
 
     # Run tileiras to produce CUBIN
-    input_path = tempname() * ".tile"
-    output_path = tempname() * ".cubin"
-    compiled = false
-    try
-        write(input_path, bytecode)
-        cmd = tileiras_cmd(input_path, "-o", output_path,
-                           "--gpu-name", format_sm_arch(sm_arch),
-                           "-O$(opt_level)", "--lineinfo")
-        proc, log = run_and_collect(cmd)
-        if !success(proc)
-            reason = proc.termsignal > 0 ? "tileiras received signal $(proc.termsignal)" :
-                                           "tileiras exited with code $(proc.exitcode)"
-            msg = "Failed to compile Tile IR ($reason)"
-            if !isempty(log)
-                msg *= "\n" * log
-            end
-            msg *= "\nIf you think this is a bug, please file an issue and attach $(input_path)"
-            if parse(Bool, get(ENV, "BUILDKITE", "false"))
-                run(`buildkite-agent artifact upload $(input_path)`)
-            end
-            error(msg)
-        end
-        compiled = true
-        res.cuda_bin = read(output_path)
-    finally
-        compiled && rm(input_path, force=true)
-        rm(output_path, force=true)
-    end
+    res.cuda_bin, _ = run_tileiras(bytecode, sm_arch, opt_level)
 
     if cache_key !== nothing
         try

--- a/test/codegen/reflection.jl
+++ b/test/codegen/reflection.jl
@@ -72,13 +72,6 @@ end
     end
 end
 
-@testset "tileiras remarks cleanup" begin
-    first = "--- !Passed\nName: First\n  - Reason: same\n  - Reason: same\n...\n"
-    second = "--- !Failure\nName: Second\n...\n"
-    @test ct.cleanup_tileiras_remarks(first * second * second) ==
-          "--- !Passed\nName: First\n  - Reason: same\n...\n" * second
-end
-
 if ct.tileiras_supports_remarks()
     @testset "code_tiled remarks" begin
         output = sprint(io -> ct.code_tiled(io, reflect_vadd, TT3;

--- a/test/codegen/reflection.jl
+++ b/test/codegen/reflection.jl
@@ -72,6 +72,23 @@ end
     end
 end
 
+@testset "tileiras remarks cleanup" begin
+    first = "--- !Passed\nName: First\n  - Reason: same\n  - Reason: same\n...\n"
+    second = "--- !Failure\nName: Second\n...\n"
+    @test ct.cleanup_tileiras_remarks(first * second * second) ==
+          "--- !Passed\nName: First\n  - Reason: same\n...\n" * second
+end
+
+if ct.tileiras_supports_remarks()
+    @testset "code_tiled remarks" begin
+        output = sprint(io -> ct.code_tiled(io, reflect_vadd, TT3;
+                                            sm_arch=v"10.0", remarks=true))
+        @test occursin("// tileiras optimization remarks", output)
+        @test occursin("// --- !Passed", output)
+        @test occursin("// Name:", output)
+    end
+end
+
 @testset "Constant args" begin
     const_spec = ct.ArraySpec{1}(128, true, (0,), (32,))
     ConstTT = Tuple{ct.TileArray{Float32,1,Int32,const_spec}, ct.TileArray{Float32,1,Int32,const_spec},


### PR DESCRIPTION
`vadd` demo:

```
julia> @device_code_tiled remarks=true @cuda backend=cuTile blocks=grid vadd(a, b, c, ct.Constant(tile_size))
// vadd(cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, cuTile.Constant{Int64, 16})

entry @vadd(%arg0: tile<ptr<f32>>, %arg1: tile<i32>, %arg2: tile<i32>, %arg3: tile<ptr<f32>>, %arg4: tile<i32>, %arg5: tile<i32>, %arg6: tile<ptr<f32>>, %arg7: tile<i32>, %arg8: tile<i32>, %arg9: tile<i32>) {
  ...
}

// tileiras optimization remarks
// --- !Passed
// Pass:            Memory
// Name:            RemarkMemoryLoadInstructionSelected
// DebugLoc:        { File: '/home/tim/Julia/pkg/cuTile/src/language/operations.jl', Line: 652, Column: 0 }
// Function:        vadd
// Args:
//   - RemarkId:    1
//   - Remark:      Load instruction selected
//   - Instruction: Global-memory load instruction
// ...
// --- !Passed
// Pass:            Memory
// Name:            RemarkMemoryLoadInstructionSelected
// DebugLoc:        { File: '/home/tim/Julia/pkg/cuTile/src/language/operations.jl', Line: 652, Column: 0 }
// Function:        vadd
// Args:
//   - RemarkId:    2
//   - Remark:      Load instruction selected
//   - Instruction: Global-memory load instruction
// ...
```