### PR TITLE
Add explicit rounding modes for float conversions

### DIFF
--- a/docs/src/man/comparison.md
+++ b/docs/src/man/comparison.md
@@ -289,6 +289,7 @@ requested padding and partial stores clip to the array. In both, an explicit
 | `expand_dims` | `reshape` |
 | `permute` | `permutedims` |
 | `astype` | `convert(ct.Tile{T}, x)` |
+| `astype(x, T, rounding_mode=RM)` | `T.(x, RoundDown)` |
 | `bitcast`, `pack_to_bytes`, `unpack_from_bytes` | `reinterpret` |
 
 Julia's `reinterpret` covers all three of Python's reinterpretation functions,
@@ -377,7 +378,9 @@ code-generation construct when compile-time unrolling is actually required.
 
 Enum members follow Julia's capitalization: `PaddingMode.NEG_ZERO` is
 `ct.PaddingMode.NegZero`, `MemoryOrder.ACQ_REL` is `ct.MemoryOrder.AcqRel`, and
-`RoundingMode.RN`/`RZ`/`RM`/`RP` are
-`ct.Rounding.NearestEven`/`Zero`/`NegInf`/`PosInf`. Julia exposes no equivalent
-of `RoundingMode.FULL` or `.RZI`, nor of `MemoryScope.NONE`, while weak ordering
-is expressed through `memory_order` instead.
+For arithmetic, `RoundingMode.RN`/`RZ`/`RM`/`RP` are
+`ct.Rounding.NearestEven`/`Zero`/`NegInf`/`PosInf`. Per-conversion rounding uses
+Base's `RoundNearest`/`RoundToZero`/`RoundDown`/`RoundUp`; Python's
+`RoundingMode.RA` is `RoundNearestTiesAway`. Julia exposes no arithmetic
+equivalent of `RoundingMode.FULL` or `.RZI`, nor of `MemoryScope.NONE`, while
+weak ordering is expressed through `memory_order` instead.

--- a/docs/src/man/compatibility.md
+++ b/docs/src/man/compatibility.md
@@ -68,6 +68,7 @@ Everything not listed here works at v13.1.
 | `eachtile` with `step != shape` | Equal shape and step work at v13.1 |
 | `num_worker_warps` compiler option | |
 | Whole-tile `reinterpret` | Between element types of differing width |
+| Conversion to `Float8_E8M0FNU` | `RoundToZero` or `RoundUp`; some source types require v13.4 |
 
 ### Requires v13.4
 
@@ -76,6 +77,7 @@ Everything not listed here works at v13.1.
 | `ct.insert` | Replace a non-overlapping sub-tile |
 | `check_bounds=false` | On `ct.load` and `ct.store` only; on `ct.gather`/`ct.scatter` it merely skips the bounds mask |
 | `ct.Intrinsics.powi` | Integer exponents through `cuda_tile.fpowi` |
+| Directed float conversion rounding | `RoundToZero`, `RoundDown`, `RoundUp`, or `RoundNearestTiesAway`; supported pairs vary |
 
 
 ## Features by architecture

--- a/docs/src/man/element_types.md
+++ b/docs/src/man/element_types.md
@@ -46,6 +46,7 @@ tutorial](../tutorials/matmul.md) works through that in context.
 |-----------|-------------|
 | `convert(Tile{T}, tile)` | Convert element type of a whole tile |
 | `T(x)`, `T.(tile)` | Scalar conversion, broadcast element-wise over a tile |
+| `T(x, mode)`, `T.(tile, mode)` | Float-to-float conversion with explicit rounding |
 | `reinterpret` | Reinterpret bits rather than convert values |
 
 Converting a `Float32` tile to `TFloat32` is the usual way to opt into tensor-core
@@ -55,6 +56,35 @@ acceleration for a matmul:
 a = ct.load(A; index=(bid_m, k), shape=(tm, tk))
 a_tf32 = convert(ct.Tile{ct.TFloat32}, a)
 ```
+
+Float conversions use round-to-nearest, ties-to-even by default. Pass a Base
+rounding mode to choose a mode for one conversion:
+
+```julia
+down = Float32.(a, RoundDown)
+up = map(x -> Float32(x, RoundUp), a)
+```
+
+| Mode | Meaning |
+|------|---------|
+| `RoundNearest` | Nearest, ties to even |
+| `RoundToZero` | Toward zero |
+| `RoundDown` | Toward negative infinity |
+| `RoundUp` | Toward positive infinity |
+| `RoundNearestTiesAway` | Nearest, ties away from zero |
+
+Explicit rounding applies only to float-to-float conversions. The supported
+source/target pairs follow Tile IR: round-to-nearest supports every float target
+except `Float8_E8M0FNU`; the directed modes are limited to particular targets,
+and most require bytecode v13.4. Unsupported pairs report their available modes
+at compilation. `RoundNearestTiesUp` and `RoundFromZero` have no Tile IR
+equivalent.
+
+`Float8_E8M0FNU` is the exception: its ordinary conversion defaults to
+`RoundToZero`. Conversions to it with `RoundToZero` or `RoundUp` work from
+bytecode v13.3 for `Float32`, `TFloat32`, `Float16`, `BFloat16`,
+`Float8_E8M0FNU`, and `Float4_E2M1FN`; `Float64`, `Float8_E5M2`, and
+`Float8_E4M3FN` sources require v13.4.
 
 `reinterpret` covers same-width bit reinterpretation directly. When the element
 width changes, it preserves the total bit count by scaling the first tile

--- a/ext/DLFP8TypesExt.jl
+++ b/ext/DLFP8TypesExt.jl
@@ -12,6 +12,9 @@ function ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E5M2})
     return ct.F8E5M2(table)
 end
 
+ct.float_dtype_tag(::Type{Float8_E4M3FN}) = ct.SimpleType.F8E4M3FN
+ct.float_dtype_tag(::Type{Float8_E5M2}) = ct.SimpleType.F8E5M2
+
 # Non-scaled `mma`/`matmul` (`cuda_tile.mmaf`) accepts f8e4m3fn and f8e5m2
 # operands with an f16 or f32 accumulator (f16 first/preferred), mirroring
 # cuda-tile's mmaf type table and cutile-python's `_mma_supported_dtypes`.
@@ -30,16 +33,20 @@ for F8 in FP8Types
     # Standard float → FP8
     for F in StandardFloats
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $F8(x::$F) = ct.Intrinsics.ftof(x, $F8)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $F8(x::$F, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $F8, r)
     end
     # FP8 → standard float
     for F in StandardFloats
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $F(x::$F8) = ct.Intrinsics.ftof(x, $F)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $F(x::$F8, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $F, r)
     end
     # FP8 → FP8
     for F8b in FP8Types
         F8 === F8b && continue
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $F8(x::$F8b) = ct.Intrinsics.ftof(x, $F8)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $F8(x::$F8b, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $F8, r)
     end
+    @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $F8(x::$F8, ::Base.Rounding.RoundingMode) = x
 end
 
 end

--- a/ext/DLFP8TypesExt.jl
+++ b/ext/DLFP8TypesExt.jl
@@ -12,9 +12,6 @@ function ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E5M2})
     return ct.F8E5M2(table)
 end
 
-ct.float_dtype_tag(::Type{Float8_E4M3FN}) = ct.SimpleType.F8E4M3FN
-ct.float_dtype_tag(::Type{Float8_E5M2}) = ct.SimpleType.F8E5M2
-
 # Non-scaled `mma`/`matmul` (`cuda_tile.mmaf`) accepts f8e4m3fn and f8e5m2
 # operands with an f16 or f32 accumulator (f16 first/preferred), mirroring
 # cuda-tile's mmaf type table and cutile-python's `_mma_supported_dtypes`.

--- a/ext/MicrofloatsExt.jl
+++ b/ext/MicrofloatsExt.jl
@@ -15,6 +15,11 @@ ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E5M2})   = ct.F8E5M2(
 ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E8M0FNU}) = ct.F8E8M0FNU(table)
 ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float4_E2M1FN})  = ct.F4E2M1FN(table)
 
+ct.float_dtype_tag(::Type{Float8_E4M3FN}) = ct.SimpleType.F8E4M3FN
+ct.float_dtype_tag(::Type{Float8_E5M2}) = ct.SimpleType.F8E5M2
+ct.float_dtype_tag(::Type{Float8_E8M0FNU}) = ct.SimpleType.F8E8M0FNU
+ct.float_dtype_tag(::Type{Float4_E2M1FN}) = ct.SimpleType.F4E2M1FN
+
 # Microfloats are byte-storage primitives, so cuTile's default
 # `bitwidth` (8 * sizeof) over-counts the sub-byte formats.
 ct.bitwidth(::Type{T}) where {T<:Microfloats.Microfloat} = Microfloats.bitwidth(T)
@@ -44,16 +49,20 @@ for MF in MicrofloatTypes
     # standard float → microfloat
     for F in StandardFloats
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $MF(x::$F) = ct.Intrinsics.ftof(x, $MF)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $MF(x::$F, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $MF, r)
     end
     # microfloat → standard float
     for F in StandardFloats
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $F(x::$MF) = ct.Intrinsics.ftof(x, $F)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $F(x::$MF, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $F, r)
     end
     # microfloat → microfloat
     for MFb in MicrofloatTypes
         MF === MFb && continue
         @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable Base.@assume_effects :foldable $MF(x::$MFb) = ct.Intrinsics.ftof(x, $MF)
+        @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $MF(x::$MFb, r::Base.Rounding.RoundingMode) = ct.Intrinsics.ftof(x, $MF, r)
     end
+    @eval Base.Experimental.@consistent_overlay ct.cuTileMethodTable $MF(x::$MF, ::Base.Rounding.RoundingMode) = x
 end
 
 end

--- a/ext/MicrofloatsExt.jl
+++ b/ext/MicrofloatsExt.jl
@@ -15,11 +15,6 @@ ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E5M2})   = ct.F8E5M2(
 ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float8_E8M0FNU}) = ct.F8E8M0FNU(table)
 ct.julia_to_tile_dtype!(table::ct.TypeTable, ::Type{Float4_E2M1FN})  = ct.F4E2M1FN(table)
 
-ct.float_dtype_tag(::Type{Float8_E4M3FN}) = ct.SimpleType.F8E4M3FN
-ct.float_dtype_tag(::Type{Float8_E5M2}) = ct.SimpleType.F8E5M2
-ct.float_dtype_tag(::Type{Float8_E8M0FNU}) = ct.SimpleType.F8E8M0FNU
-ct.float_dtype_tag(::Type{Float4_E2M1FN}) = ct.SimpleType.F4E2M1FN
-
 # Microfloats are byte-storage primitives, so cuTile's default
 # `bitwidth` (8 * sizeof) over-counts the sub-byte formats.
 ct.bitwidth(::Type{T}) where {T<:Microfloats.Microfloat} = Microfloats.bitwidth(T)

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -119,6 +119,7 @@ end
     Approx = 4
     Full = 5
     NearestIntToZero = 6
+    NearestAway = 7
 end
 
 @enumx IntegerOverflow begin

--- a/src/bytecode/types.jl
+++ b/src/bytecode/types.jl
@@ -129,6 +129,34 @@ function items(table::TypeTable)
     return pairs
 end
 
+function type_encoding(table::TypeTable, id::TypeId)
+    for (encoding, type_id) in table.types
+        type_id == id && return encoding
+    end
+    throw(ArgumentError("unknown type id $(id.id)"))
+end
+
+function simple_type_tag(table::TypeTable, id::TypeId)
+    encoding = type_encoding(table, id)
+    length(encoding) == 1 || throw(ArgumentError("type id $(id.id) is not a simple type"))
+    return only(encoding)
+end
+
+function tile_eltype_id(table::TypeTable, id::TypeId)
+    encoding = type_encoding(table, id)
+    first(encoding) == CompositeType.Tile ||
+        throw(ArgumentError("type id $(id.id) is not a tile type"))
+
+    value = 0
+    shift = 0
+    for byte in @view encoding[2:end]
+        value |= Int(byte & 0x7f) << shift
+        byte & 0x80 == 0 && return TypeId(value)
+        shift += 7
+    end
+    throw(ArgumentError("invalid tile element type id"))
+end
+
 # Type constructors
 
 function simple_type!(table::TypeTable, tag::UInt8)

--- a/src/compiler/intrinsics/conversions.jl
+++ b/src/compiler/intrinsics/conversions.jl
@@ -199,55 +199,33 @@ ftof_rounding_mode(::Type) = RoundingMode.NearestEven
 @inline lookup_ftof_rounding_mode(@nospecialize(T::Type)) =
     Base.invokelatest(ftof_rounding_mode, T)::RoundingMode.T
 
-float_dtype_tag(::Type{Float16}) = SimpleType.F16
-float_dtype_tag(::Type{BFloat16}) = SimpleType.BF16
-float_dtype_tag(::Type{Float32}) = SimpleType.F32
-float_dtype_tag(::Type{TFloat32}) = SimpleType.TF32
-float_dtype_tag(::Type{Float64}) = SimpleType.F64
+const E8M0_LATE_SOURCES = (SimpleType.F64, SimpleType.F8E5M2, SimpleType.F8E4M3FN)
+const F16_DIRECTED_SOURCES = (
+    SimpleType.F16, SimpleType.BF16, SimpleType.F8E5M2,
+    SimpleType.F8E4M3FN, SimpleType.F4E2M1FN,
+)
 
-@inline lookup_float_dtype_tag(@nospecialize(T::Type)) =
-    Base.invokelatest(float_dtype_tag, T)::UInt8
-
-const FTOF_ROUNDING_REGISTRY = let
-    all = (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.F16,
-           SimpleType.BF16, SimpleType.F8E5M2, SimpleType.F8E8M0FNU,
-           SimpleType.F8E4M3FN, SimpleType.F4E2M1FN)
-    registry = Dict{Tuple{UInt8,UInt8,RoundingMode.T},VersionNumber}()
-    add(from, to, mode, version) = foreach(f -> registry[(f, to, mode)] = version, from)
-
-    for to in (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.BF16,
-               SimpleType.F16, SimpleType.F8E4M3FN, SimpleType.F8E5M2, SimpleType.F4E2M1FN)
-        add(all, to, RoundingMode.NearestEven, v"13.0")
+function ftof_rounding_min_version(from::UInt8, to::UInt8, mode::RoundingMode.T)
+    if mode == RoundingMode.NearestEven
+        return to == SimpleType.F8E8M0FNU ? nothing : v"13.0"
+    elseif mode == RoundingMode.Zero
+        to in (SimpleType.F64, SimpleType.F32, SimpleType.TF32,
+               SimpleType.F16, SimpleType.BF16) && return v"13.4"
+        to == SimpleType.F8E8M0FNU &&
+            return (from in E8M0_LATE_SOURCES ? v"13.4" : v"13.3")
+    elseif mode in (RoundingMode.NegativeInf, RoundingMode.PositiveInf)
+        to == SimpleType.F64 && return v"13.4"
+        to == SimpleType.F32 && from != SimpleType.F8E8M0FNU && return v"13.4"
+        to == SimpleType.F16 && from in F16_DIRECTED_SOURCES && return v"13.4"
+        mode == RoundingMode.PositiveInf && to == SimpleType.F8E8M0FNU &&
+            return (from in E8M0_LATE_SOURCES ? v"13.4" : v"13.3")
+    elseif mode == RoundingMode.NearestAway
+        to == SimpleType.F64 && return v"13.4"
+        to in (SimpleType.F32, SimpleType.TF32) &&
+            from ∉ (SimpleType.F64, SimpleType.F8E8M0FNU) && return v"13.4"
+        to == SimpleType.F16 && from in F16_DIRECTED_SOURCES && return v"13.4"
     end
-    for to in (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.F16, SimpleType.BF16)
-        add(all, to, RoundingMode.Zero, v"13.4")
-    end
-
-    e8m0_early = filter(t -> t ∉ (SimpleType.F64, SimpleType.F8E5M2, SimpleType.F8E4M3FN), all)
-    e8m0_late = (SimpleType.F64, SimpleType.F8E5M2, SimpleType.F8E4M3FN)
-    for mode in (RoundingMode.Zero, RoundingMode.PositiveInf)
-        add(e8m0_early, SimpleType.F8E8M0FNU, mode, v"13.3")
-        add(e8m0_late, SimpleType.F8E8M0FNU, mode, v"13.4")
-    end
-
-    add(all, SimpleType.F64, RoundingMode.NegativeInf, v"13.4")
-    add(all, SimpleType.F64, RoundingMode.PositiveInf, v"13.4")
-    no_e8m0 = filter(!=(SimpleType.F8E8M0FNU), all)
-    for mode in (RoundingMode.NegativeInf, RoundingMode.PositiveInf)
-        add(no_e8m0, SimpleType.F32, mode, v"13.4")
-        add(filter(t -> t ∉ (SimpleType.F64, SimpleType.F32, SimpleType.TF32,
-                             SimpleType.F8E8M0FNU), all),
-            SimpleType.F16, mode, v"13.4")
-    end
-
-    add(all, SimpleType.F64, RoundingMode.NearestAway, v"13.4")
-    ra_f32 = filter(t -> t ∉ (SimpleType.F64, SimpleType.F8E8M0FNU), all)
-    add(ra_f32, SimpleType.F32, RoundingMode.NearestAway, v"13.4")
-    add(ra_f32, SimpleType.TF32, RoundingMode.NearestAway, v"13.4")
-    add(filter(t -> t ∉ (SimpleType.F64, SimpleType.F32, SimpleType.TF32,
-                         SimpleType.F8E8M0FNU), all),
-        SimpleType.F16, RoundingMode.NearestAway, v"13.4")
-    registry
+    return nothing
 end
 
 bytecode_rounding_mode(::Base.Rounding.RoundingMode{:Nearest}) = RoundingMode.NearestEven
@@ -257,22 +235,6 @@ bytecode_rounding_mode(::Base.Rounding.RoundingMode{:Up}) = RoundingMode.Positiv
 bytecode_rounding_mode(::Base.Rounding.RoundingMode{:NearestTiesAway}) = RoundingMode.NearestAway
 bytecode_rounding_mode(mode::Base.Rounding.RoundingMode) =
     throw(IRError("rounding mode $mode is not supported for float conversion"))
-
-function tile_eltype_tag(table::TypeTable, id::TypeId)
-    tile = only(encoded for (encoded, type_id) in table.types if type_id == id)
-    tile[1] == CompositeType.Tile || throw(IRError("ftof: expected a tile type"))
-    dtype_id = Int(tile[2] & 0x7f)
-    shift = 7
-    i = 3
-    while tile[i - 1] & 0x80 != 0
-        dtype_id |= Int(tile[i] & 0x7f) << shift
-        shift += 7
-        i += 1
-    end
-    dtype = only(encoded for (encoded, type_id) in table.types if type_id.id == dtype_id)
-    length(dtype) == 1 || throw(IRError("ftof: expected a simple element type"))
-    return only(dtype)
-end
 
 const FLOAT_DTYPE_NAMES = Dict(
     SimpleType.F16 => "Float16", SimpleType.BF16 => "BFloat16",
@@ -287,13 +249,13 @@ function validate_ftof_rounding(from_tag::UInt8, to_tag::UInt8, mode::RoundingMo
                                 version::VersionNumber)
     from = float_dtype_name(from_tag)
     to = float_dtype_name(to_tag)
-    min_version = get(FTOF_ROUNDING_REGISTRY, (from_tag, to_tag, mode), nothing)
+    min_version = ftof_rounding_min_version(from_tag, to_tag, mode)
     if min_version === nothing
         supported = RoundingMode.T[
             candidate for candidate in (RoundingMode.NearestEven, RoundingMode.Zero,
                                          RoundingMode.NegativeInf, RoundingMode.PositiveInf,
                                          RoundingMode.NearestAway)
-            if haskey(FTOF_ROUNDING_REGISTRY, (from_tag, to_tag, candidate))
+            if ftof_rounding_min_version(from_tag, to_tag, candidate) !== nothing
         ]
         isempty(supported) && throw(IRError("float conversion from $from to $to is not supported"))
         throw(IRError("rounding mode $mode is not supported for conversion from $from to $to; supported modes are $(Tuple(supported))"))
@@ -338,8 +300,9 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.ftof), args)
     else
         lookup_ftof_rounding_mode(target_type)
     end
-    validate_ftof_rounding(tile_eltype_tag(tt, source.type_id),
-                           lookup_float_dtype_tag(target_type), rounding_mode, tt.version)
+    source_tag = simple_type_tag(tt, tile_eltype_id(tt, source.type_id))
+    target_tag = simple_type_tag(tt, dtype)
+    validate_ftof_rounding(source_tag, target_tag, rounding_mode, tt.version)
     result_v = encode_FToFOp!(cb, result_type_id, source.v; rounding_mode)
     src_type = CC.widenconst(source.jltype)
     result_jltype = similar_type(src_type, target_type)

--- a/src/compiler/intrinsics/conversions.jl
+++ b/src/compiler/intrinsics/conversions.jl
@@ -199,18 +199,123 @@ ftof_rounding_mode(::Type) = RoundingMode.NearestEven
 @inline lookup_ftof_rounding_mode(@nospecialize(T::Type)) =
     Base.invokelatest(ftof_rounding_mode, T)::RoundingMode.T
 
+float_dtype_tag(::Type{Float16}) = SimpleType.F16
+float_dtype_tag(::Type{BFloat16}) = SimpleType.BF16
+float_dtype_tag(::Type{Float32}) = SimpleType.F32
+float_dtype_tag(::Type{TFloat32}) = SimpleType.TF32
+float_dtype_tag(::Type{Float64}) = SimpleType.F64
+
+@inline lookup_float_dtype_tag(@nospecialize(T::Type)) =
+    Base.invokelatest(float_dtype_tag, T)::UInt8
+
+const FTOF_ROUNDING_REGISTRY = let
+    all = (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.F16,
+           SimpleType.BF16, SimpleType.F8E5M2, SimpleType.F8E8M0FNU,
+           SimpleType.F8E4M3FN, SimpleType.F4E2M1FN)
+    registry = Dict{Tuple{UInt8,UInt8,RoundingMode.T},VersionNumber}()
+    add(from, to, mode, version) = foreach(f -> registry[(f, to, mode)] = version, from)
+
+    for to in (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.BF16,
+               SimpleType.F16, SimpleType.F8E4M3FN, SimpleType.F8E5M2, SimpleType.F4E2M1FN)
+        add(all, to, RoundingMode.NearestEven, v"13.0")
+    end
+    for to in (SimpleType.F64, SimpleType.F32, SimpleType.TF32, SimpleType.F16, SimpleType.BF16)
+        add(all, to, RoundingMode.Zero, v"13.4")
+    end
+
+    e8m0_early = filter(t -> t ∉ (SimpleType.F64, SimpleType.F8E5M2, SimpleType.F8E4M3FN), all)
+    e8m0_late = (SimpleType.F64, SimpleType.F8E5M2, SimpleType.F8E4M3FN)
+    for mode in (RoundingMode.Zero, RoundingMode.PositiveInf)
+        add(e8m0_early, SimpleType.F8E8M0FNU, mode, v"13.3")
+        add(e8m0_late, SimpleType.F8E8M0FNU, mode, v"13.4")
+    end
+
+    add(all, SimpleType.F64, RoundingMode.NegativeInf, v"13.4")
+    add(all, SimpleType.F64, RoundingMode.PositiveInf, v"13.4")
+    no_e8m0 = filter(!=(SimpleType.F8E8M0FNU), all)
+    for mode in (RoundingMode.NegativeInf, RoundingMode.PositiveInf)
+        add(no_e8m0, SimpleType.F32, mode, v"13.4")
+        add(filter(t -> t ∉ (SimpleType.F64, SimpleType.F32, SimpleType.TF32,
+                             SimpleType.F8E8M0FNU), all),
+            SimpleType.F16, mode, v"13.4")
+    end
+
+    add(all, SimpleType.F64, RoundingMode.NearestAway, v"13.4")
+    ra_f32 = filter(t -> t ∉ (SimpleType.F64, SimpleType.F8E8M0FNU), all)
+    add(ra_f32, SimpleType.F32, RoundingMode.NearestAway, v"13.4")
+    add(ra_f32, SimpleType.TF32, RoundingMode.NearestAway, v"13.4")
+    add(filter(t -> t ∉ (SimpleType.F64, SimpleType.F32, SimpleType.TF32,
+                         SimpleType.F8E8M0FNU), all),
+        SimpleType.F16, RoundingMode.NearestAway, v"13.4")
+    registry
+end
+
+bytecode_rounding_mode(::Base.Rounding.RoundingMode{:Nearest}) = RoundingMode.NearestEven
+bytecode_rounding_mode(::Base.Rounding.RoundingMode{:ToZero}) = RoundingMode.Zero
+bytecode_rounding_mode(::Base.Rounding.RoundingMode{:Down}) = RoundingMode.NegativeInf
+bytecode_rounding_mode(::Base.Rounding.RoundingMode{:Up}) = RoundingMode.PositiveInf
+bytecode_rounding_mode(::Base.Rounding.RoundingMode{:NearestTiesAway}) = RoundingMode.NearestAway
+bytecode_rounding_mode(mode::Base.Rounding.RoundingMode) =
+    throw(IRError("rounding mode $mode is not supported for float conversion"))
+
+function tile_eltype_tag(table::TypeTable, id::TypeId)
+    tile = only(encoded for (encoded, type_id) in table.types if type_id == id)
+    tile[1] == CompositeType.Tile || throw(IRError("ftof: expected a tile type"))
+    dtype_id = Int(tile[2] & 0x7f)
+    shift = 7
+    i = 3
+    while tile[i - 1] & 0x80 != 0
+        dtype_id |= Int(tile[i] & 0x7f) << shift
+        shift += 7
+        i += 1
+    end
+    dtype = only(encoded for (encoded, type_id) in table.types if type_id.id == dtype_id)
+    length(dtype) == 1 || throw(IRError("ftof: expected a simple element type"))
+    return only(dtype)
+end
+
+const FLOAT_DTYPE_NAMES = Dict(
+    SimpleType.F16 => "Float16", SimpleType.BF16 => "BFloat16",
+    SimpleType.F32 => "Float32", SimpleType.TF32 => "TFloat32",
+    SimpleType.F64 => "Float64", SimpleType.F8E4M3FN => "Float8_E4M3FN",
+    SimpleType.F8E5M2 => "Float8_E5M2", SimpleType.F8E8M0FNU => "Float8_E8M0FNU",
+    SimpleType.F4E2M1FN => "Float4_E2M1FN",
+)
+float_dtype_name(tag::UInt8) = get(FLOAT_DTYPE_NAMES, tag, string(tag))
+
+function validate_ftof_rounding(from_tag::UInt8, to_tag::UInt8, mode::RoundingMode.T,
+                                version::VersionNumber)
+    from = float_dtype_name(from_tag)
+    to = float_dtype_name(to_tag)
+    min_version = get(FTOF_ROUNDING_REGISTRY, (from_tag, to_tag, mode), nothing)
+    if min_version === nothing
+        supported = RoundingMode.T[
+            candidate for candidate in (RoundingMode.NearestEven, RoundingMode.Zero,
+                                         RoundingMode.NegativeInf, RoundingMode.PositiveInf,
+                                         RoundingMode.NearestAway)
+            if haskey(FTOF_ROUNDING_REGISTRY, (from_tag, to_tag, candidate))
+        ]
+        isempty(supported) && throw(IRError("float conversion from $from to $to is not supported"))
+        throw(IRError("rounding mode $mode is not supported for conversion from $from to $to; supported modes are $(Tuple(supported))"))
+    end
+    version >= min_version ||
+        throw(IRError("conversion from $from to $to with rounding mode $mode requires Tile IR bytecode v$min_version+, got v$version"))
+    return
+end
+
 """
-    Intrinsics.ftof(x::Tile{<:AbstractFloat}, ::Type{F2}) -> Tile{F2}     where {F2<:AbstractFloat}
+    Intrinsics.ftof(x::Tile{<:AbstractFloat}, ::Type{F2}, rounding=nothing) -> Tile{F2}
 
 Element-wise floating-point to floating-point conversion; lowers to
 `cuda_tile.ftof`.
 
 Also invocable with a scalar, promoted to a 0-D tile before codegen. `F2`
-must be a compile-time constant. The rounding mode is picked from
-[`ftof_rounding_mode`](@ref); the default is `NearestEven`.
+must be a compile-time constant. `rounding` accepts Base's `RoundNearest`,
+`RoundToZero`, `RoundDown`, `RoundUp`, and `RoundNearestTiesAway`; when omitted,
+the mode is picked from [`ftof_rounding_mode`](@ref).
 """
-@intrinsic ftof(x::F1, ::Type{F2}) where {F1<:AbstractFloat, F2<:AbstractFloat}
-function tfunc(𝕃, ::typeof(Intrinsics.ftof), @nospecialize(x), @nospecialize(target_type))
+@intrinsic ftof(x::F1, ::Type{F2}, rounding=nothing) where {F1<:AbstractFloat, F2<:AbstractFloat}
+function tfunc(𝕃, ::typeof(Intrinsics.ftof), @nospecialize(x), @nospecialize(target_type), @nospecialize(rest...))
     T = instanceof_tfunc(target_type)
     T === nothing && return nothing
     src = CC.widenconst(x)
@@ -226,7 +331,15 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.ftof), args)
     dtype = lookup_dtype!(tt, target_type)
     result_type_id = tile_type!(tt, dtype, source.shape)
 
-    rounding_mode = lookup_ftof_rounding_mode(target_type)
+    rounding_mode = if length(args) == 3
+        mode = @something get_constant(ctx, args[3]) throw(IRError("ftof: requires a compile-time rounding mode"))
+        mode isa Base.Rounding.RoundingMode || throw(IRError("ftof: invalid rounding mode $mode"))
+        bytecode_rounding_mode(mode)
+    else
+        lookup_ftof_rounding_mode(target_type)
+    end
+    validate_ftof_rounding(tile_eltype_tag(tt, source.type_id),
+                           lookup_float_dtype_tag(target_type), rounding_mode, tt.version)
     result_v = encode_FToFOp!(cb, result_type_id, source.v; rounding_mode)
     src_type = CC.widenconst(source.jltype)
     result_jltype = similar_type(src_type, target_type)

--- a/src/language/overlays.jl
+++ b/src/language/overlays.jl
@@ -78,6 +78,15 @@ end
 for T in Floats, S in Floats
     T === S && continue
     @eval @overlay $T(x::$S) = Intrinsics.ftof(x, $T)
+    @eval Base.Experimental.@consistent_overlay cuTileMethodTable $T(x::$S, r::Base.Rounding.RoundingMode) = Intrinsics.ftof(x, $T, r)
+end
+for T in Floats
+    @eval Base.Experimental.@consistent_overlay cuTileMethodTable $T(x::$T, ::Base.Rounding.RoundingMode) = x
+end
+for T in Floats, S in (SignedInts..., UnsignedInts..., Bool)
+    @eval Base.Experimental.@consistent_overlay cuTileMethodTable function $T(x::$S, ::Base.Rounding.RoundingMode)
+        throw(ArgumentError("rounding modes are only supported for float-to-float conversions"))
+    end
 end
 
 # Integer to float

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -529,6 +529,7 @@ spec4d = ct.ArraySpec{4}(16, true)
                 return
             end
         end
+
     end
 
     @testset "cmpf" begin
@@ -1565,6 +1566,75 @@ end
                 ct.store(b, pid, Float32.(ct.TFloat32.(tile)))
                 return
             end
+        end
+
+        for (mode, attr) in ((RoundToZero, "zero"),
+                             (RoundDown, "negative_inf"),
+                             (RoundUp, "positive_inf"))
+            @test @filecheck begin
+                @check_label "entry"
+                code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d},
+                                 ct.TileArray{Float32,1,Int32,spec1d}};
+                           bytecode_version=v"13.4") do a, b
+                    pid = ct.bid(1)
+                    tile = ct.load(a, pid, (16,))
+                    @check "ftof"
+                    @check "rounding<$attr>"
+                    ct.store(b, pid, Float32.(tile, mode))
+                    return
+                end
+            end
+        end
+
+        # Explicit nearest-even and nearest-away through map and scalar conversion.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d},
+                             ct.TileArray{Float32,1,Int32,spec1d}, Float32};
+                       bytecode_version=v"13.4") do a, b, x
+                pid = ct.bid(1)
+                tile = ct.load(a, pid, (16,))
+                @check "ftof"
+                mapped = map(y -> Float32(y, RoundNearest), tile)
+                @check "rounding<nearest_away>"
+                Base.donotdelete(ct.TFloat32(x, RoundNearestTiesAway))
+                ct.store(b, pid, mapped)
+                return
+            end
+        end
+
+        # Same-type conversions are identities, including with an explicit mode.
+        @test @filecheck begin
+            @check_label "entry"
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
+                tile = ct.load(a, ct.bid(1), (16,))
+                Base.donotdelete(Float32.(tile, RoundDown))
+                @check_not "ftof"
+                return
+            end
+        end
+
+        let tt = Tuple{ct.TileArray{Float64,1,Int32,spec1d},
+                       ct.TileArray{Float32,1,Int32,spec1d}},
+            convert_with = mode -> (a, b) -> begin
+                pid = ct.bid(1)
+                ct.store(b, pid, Float32.(ct.load(a, pid, (16,)), mode))
+                return
+            end
+            @test_throws "requires Tile IR bytecode v13.4" code_tiled(
+                devnull, convert_with(RoundDown), tt; bytecode_version=v"13.3")
+            @test_throws "NearestAway is not supported" code_tiled(
+                devnull, convert_with(RoundNearestTiesAway), tt; bytecode_version=v"13.4")
+            @test_throws "NearestTiesUp" code_tiled(
+                devnull, convert_with(RoundNearestTiesUp), tt; bytecode_version=v"13.4")
+        end
+
+        @test_throws "only supported for float-to-float" code_tiled(
+            Tuple{ct.TileArray{Int32,1,Int32,spec1d},
+                  ct.TileArray{Float32,1,Int32,spec1d}}) do a, b
+            pid = ct.bid(1)
+            ct.store(b, pid, Float32.(ct.load(a, pid, (16,)), RoundDown))
+            return
         end
     end
 

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1568,38 +1568,42 @@ end
             end
         end
 
-        for (mode, attr) in ((RoundToZero, "zero"),
-                             (RoundDown, "negative_inf"),
-                             (RoundUp, "positive_inf"))
+        # Directed rounding needs v13.4, which the disassembler only understands
+        # when the local toolkit is new enough.
+        if ct.bytecode_version() >= v"13.4"
+            for (mode, attr) in ((RoundToZero, "zero"),
+                                 (RoundDown, "negative_inf"),
+                                 (RoundUp, "positive_inf"))
+                @test @filecheck begin
+                    @check_label "entry"
+                    code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d},
+                                     ct.TileArray{Float32,1,Int32,spec1d}};
+                               bytecode_version=v"13.4") do a, b
+                        pid = ct.bid(1)
+                        tile = ct.load(a, pid, (16,))
+                        @check "ftof"
+                        @check "rounding<$attr>"
+                        ct.store(b, pid, Float32.(tile, mode))
+                        return
+                    end
+                end
+            end
+
+            # Explicit nearest-even and nearest-away through map and scalar conversion.
             @test @filecheck begin
                 @check_label "entry"
                 code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d},
-                                 ct.TileArray{Float32,1,Int32,spec1d}};
-                           bytecode_version=v"13.4") do a, b
+                                 ct.TileArray{Float32,1,Int32,spec1d}, Float32};
+                           bytecode_version=v"13.4") do a, b, x
                     pid = ct.bid(1)
                     tile = ct.load(a, pid, (16,))
                     @check "ftof"
-                    @check "rounding<$attr>"
-                    ct.store(b, pid, Float32.(tile, mode))
+                    mapped = map(y -> Float32(y, RoundNearest), tile)
+                    @check "rounding<nearest_away>"
+                    Base.donotdelete(ct.TFloat32(x, RoundNearestTiesAway))
+                    ct.store(b, pid, mapped)
                     return
                 end
-            end
-        end
-
-        # Explicit nearest-even and nearest-away through map and scalar conversion.
-        @test @filecheck begin
-            @check_label "entry"
-            code_tiled(Tuple{ct.TileArray{Float64,1,Int32,spec1d},
-                             ct.TileArray{Float32,1,Int32,spec1d}, Float32};
-                       bytecode_version=v"13.4") do a, b, x
-                pid = ct.bid(1)
-                tile = ct.load(a, pid, (16,))
-                @check "ftof"
-                mapped = map(y -> Float32(y, RoundNearest), tile)
-                @check "rounding<nearest_away>"
-                Base.donotdelete(ct.TFloat32(x, RoundNearestTiesAway))
-                ct.store(b, pid, mapped)
-                return
             end
         end
 

--- a/test/device/types.jl
+++ b/test/device/types.jl
@@ -108,19 +108,25 @@ end
     a = CuArray([-value, value])
     b = CUDA.zeros(Float32, 2)
 
-    for (mode, expected) in ((RoundNearest, Float32[-high, high]),
-                             (RoundDown, Float32[-high, low]),
-                             (RoundUp, Float32[-low, high]),
-                             (RoundToZero, Float32[-low, low]))
-        @cuda backend=cuTile round_f64_f32(a, b, ct.Constant(mode))
-        @test Array(b) == expected
+    # Round-to-nearest is the default mode, supported on every bytecode version.
+    @cuda backend=cuTile round_f64_f32(a, b, ct.Constant(RoundNearest))
+    @test Array(b) == Float32[-high, high]
+
+    # The directed modes and ties-away need v13.4.
+    if ct.bytecode_version() >= v"13.4"
+        for (mode, expected) in ((RoundDown, Float32[-high, low]),
+                                 (RoundUp, Float32[-low, high]),
+                                 (RoundToZero, Float32[-low, low]))
+            @cuda backend=cuTile round_f64_f32(a, b, ct.Constant(mode))
+            @test Array(b) == expected
+        end
+
+        tie = Float32(1 + 2.0^-11)
+        @cuda backend=cuTile round_f32_tf32(CuArray([-tie, tie]), b)
+        @test Array(b) == Float32[-(1 + 2.0^-10), 1 + 2.0^-10]
+
+        scalar = CUDA.zeros(Float32, 1)
+        @cuda backend=cuTile round_scalar_f64_f32(value, scalar)
+        @test Array(scalar) == Float32[low]
     end
-
-    tie = Float32(1 + 2.0^-11)
-    @cuda backend=cuTile round_f32_tf32(CuArray([-tie, tie]), b)
-    @test Array(b) == Float32[-(1 + 2.0^-10), 1 + 2.0^-10]
-
-    scalar = CUDA.zeros(Float32, 1)
-    @cuda backend=cuTile round_scalar_f64_f32(value, scalar)
-    @test Array(scalar) == Float32[low]
 end

--- a/test/device/types.jl
+++ b/test/device/types.jl
@@ -82,3 +82,45 @@ end
 
     @test Array(d) ≈ Array(a) .- Array(b)
 end
+
+function round_f64_f32(a::ct.TileArray{Float64,1}, b::ct.TileArray{Float32,1},
+                       mode::Base.Rounding.RoundingMode)
+    tile = ct.load(a, ct.bid(1), (2,))
+    ct.store(b, ct.bid(1), Float32.(tile, mode))
+    return
+end
+
+function round_f32_tf32(a::ct.TileArray{Float32,1}, b::ct.TileArray{Float32,1})
+    tile = ct.load(a, ct.bid(1), (2,))
+    ct.store(b, ct.bid(1), Float32.(ct.TFloat32.(tile, RoundNearestTiesAway)))
+    return
+end
+
+function round_scalar_f64_f32(x::Float64, b::ct.TileArray{Float32,1})
+    ct.store(b, Int32(1), Float32(x, RoundDown))
+    return
+end
+
+@testset "conversion rounding" begin
+    low = 1.0f0
+    high = nextfloat(low)
+    value = Float64(low) + Float64(high - low) * 0.6
+    a = CuArray([-value, value])
+    b = CUDA.zeros(Float32, 2)
+
+    for (mode, expected) in ((RoundNearest, Float32[-high, high]),
+                             (RoundDown, Float32[-high, low]),
+                             (RoundUp, Float32[-low, high]),
+                             (RoundToZero, Float32[-low, low]))
+        @cuda backend=cuTile round_f64_f32(a, b, ct.Constant(mode))
+        @test Array(b) == expected
+    end
+
+    tie = Float32(1 + 2.0^-11)
+    @cuda backend=cuTile round_f32_tf32(CuArray([-tie, tie]), b)
+    @test Array(b) == Float32[-(1 + 2.0^-10), 1 + 2.0^-10]
+
+    scalar = CUDA.zeros(Float32, 1)
+    @cuda backend=cuTile round_scalar_f64_f32(value, scalar)
+    @test Array(scalar) == Float32[low]
+end

--- a/test/extensions/DLFP8Types.jl
+++ b/test/extensions/DLFP8Types.jl
@@ -32,17 +32,19 @@ end
     end
 end
 
-# Float8_E5M2 -> Float32 with explicit rounding
-@test @filecheck begin
-    @check_label "entry"
-    code_tiled(Tuple{ct.TileArray{Float8_E5M2,1,Int32,spec1d},
-                     ct.TileArray{Float32,1,Int32,spec1d}};
-               bytecode_version=v"13.4") do a, b
-        pid = ct.bid(1)
-        tile = ct.load(a, pid, (16,))
-        @check "rounding<negative_inf>"
-        ct.store(b, pid, Float32.(tile, RoundDown))
-        return
+# Float8_E5M2 -> Float32 with explicit rounding (needs v13.4 to disassemble)
+if ct.bytecode_version() >= v"13.4"
+    @test @filecheck begin
+        @check_label "entry"
+        code_tiled(Tuple{ct.TileArray{Float8_E5M2,1,Int32,spec1d},
+                         ct.TileArray{Float32,1,Int32,spec1d}};
+                   bytecode_version=v"13.4") do a, b
+            pid = ct.bid(1)
+            tile = ct.load(a, pid, (16,))
+            @check "rounding<negative_inf>"
+            ct.store(b, pid, Float32.(tile, RoundDown))
+            return
+        end
     end
 end
 

--- a/test/extensions/DLFP8Types.jl
+++ b/test/extensions/DLFP8Types.jl
@@ -32,6 +32,20 @@ end
     end
 end
 
+# Float8_E5M2 -> Float32 with explicit rounding
+@test @filecheck begin
+    @check_label "entry"
+    code_tiled(Tuple{ct.TileArray{Float8_E5M2,1,Int32,spec1d},
+                     ct.TileArray{Float32,1,Int32,spec1d}};
+               bytecode_version=v"13.4") do a, b
+        pid = ct.bid(1)
+        tile = ct.load(a, pid, (16,))
+        @check "rounding<negative_inf>"
+        ct.store(b, pid, Float32.(tile, RoundDown))
+        return
+    end
+end
+
 # Non-scaled f8 matmul lowers to `mmaf` (f8 operands, f32 accumulator).
 @test @filecheck begin
     @check_label "entry"

--- a/test/extensions/Microfloats/codegen.jl
+++ b/test/extensions/Microfloats/codegen.jl
@@ -32,11 +32,11 @@ spec2d = ct.ArraySpec{2}(16, true)
         end
     end
 
-    # Float32 -> Float8_E8M0FNU works on bytecode 13.2+
+    # Float32 -> Float8_E8M0FNU conversion requires bytecode 13.3.
     @test @filecheck begin
         @check_label "entry"
         code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
-                   bytecode_version=v"13.2") do a, b
+                   bytecode_version=v"13.3") do a, b
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
             @check "ftof"
@@ -46,7 +46,22 @@ spec2d = ct.ArraySpec{2}(16, true)
         end
     end
 
-    # Float8_E8M0FNU rejected on bytecode 13.1 with a clear version error
+    # Float32 -> Float8_E8M0FNU supports round-up from bytecode 13.3.
+    @test @filecheck begin
+        @check_label "entry"
+        code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                         ct.TileArray{Float32,1,Int32,spec1d}};
+                   bytecode_version=v"13.3") do a, b
+            pid = ct.bid(1)
+            tile = ct.load(a, pid, (16,))
+            @check "rounding<positive_inf>"
+            converted = Float8_E8M0FNU.(tile, RoundUp)
+            ct.store(b, pid, Float32.(converted))
+            return
+        end
+    end
+
+    # The type exists in 13.2, but the default round-to-zero conversion does not.
     let kernel = (a, b) -> begin
             pid = ct.bid(1)
             tile = ct.load(a, pid, (16,))
@@ -54,9 +69,9 @@ spec2d = ct.ArraySpec{2}(16, true)
             ct.store(b, pid, convert(ct.Tile{Float32}, converted))
             return
         end
-        @test_throws "v13.2+" code_tiled(devnull, kernel,
+        @test_throws "requires Tile IR bytecode v13.3" code_tiled(devnull, kernel,
             Tuple{ct.TileArray{Float32,1,Int32,spec1d}, ct.TileArray{Float32,1,Int32,spec1d}};
-            bytecode_version=v"13.1")
+            bytecode_version=v"13.2")
     end
 
     # Float4_E2M1FN requires bytecode 13.3 — rejected at 13.2 with a clear error


### PR DESCRIPTION
Support per-conversion rounding modes for floating-point conversions using Julia's existing constructor API:

```julia
Float32.(tile, RoundDown)
map(x -> Float32(x, RoundUp), tile)
```

This adds:

- RoundNearest, RoundToZero, RoundDown, and RoundUp
- RoundNearestTiesAway and its Tile IR encoding
- validation of supported source, target, and rounding-mode combinations
- Tile IR bytecode version checks
- support for DLFP8Types and Microfloats
- documentation of the Julia and cuTile Python equivalents

Ordinary `convert(Tile{T}, tile)` behavior is unchanged. Explicit rounding is restricted to float-to-float conversions.

The conversion registry follows cuTile Python's supported combinations. In particular, most directed modes require Tile IR v13.4, while selected `Float8_E8M0FNU` conversions are supported from v13.3.