### PR TITLE
Sync with cuTile Python

### DIFF
--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -9,3 +9,16 @@
 # bytecode version to emit, overriding the auto-probe of `tileiras`'s
 # capabilities. should be a version supported by cuTile.jl.
 #bytecode_version = "13.2"
+
+# maximum time in seconds for a `tileiras` invocation. compilation does not
+# time out by default.
+#compiler_timeout_seconds = 60
+
+# whether to cache compiled kernels on disk. enabled by default.
+#disk_cache = true
+
+# disk cache directory. defaults to cuTile's Scratch.jl-managed directory.
+#cache_dir = "/fast/local/cache"
+
+# maximum disk cache size in bytes. defaults to 1 GiB.
+#cache_size_bytes = 1073741824

--- a/docs/src/man/debugging.md
+++ b/docs/src/man/debugging.md
@@ -56,7 +56,7 @@ the argument types from the actual `CuArray`s:
 
 ```julia-repl
 julia> ct.@device_code_tiled @cuda backend=cuTile blocks=cld(vector_size, tile_size) vadd(a, b, c, ct.Constant(tile_size))
-// vadd(cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}, …)
+// vadd(cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false, (false,)}()}, …)
 
 cuda_tile.module @kernels {
   entry @vadd(%arg0: tile<ptr<f32>>, …) {

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -5,6 +5,20 @@ covers what happens at that point: how arguments cross to the device, which of
 them are compile-time values, what counts as a distinct kernel, and how the
 results are cached.
 
+Persistent compiler settings are package preferences. For example:
+
+```toml
+[cuTile]
+compiler_timeout_seconds = 60
+```
+
+The timeout covers each `tileiras` invocation. On expiry, cuTile terminates the
+compiler and reports a [`TileCompilerTimeoutError`](@ref cuTile.TileCompilerTimeoutError).
+
+```@docs
+cuTile.TileCompilerTimeoutError
+```
+
 Launching requires CUDA.jl to be imported. It supplies the `CuArray` type, the
 compiler artifacts, and the stream the kernel runs on.
 

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -5,11 +5,14 @@ covers what happens at that point: how arguments cross to the device, which of
 them are compile-time values, what counts as a distinct kernel, and how the
 results are cached.
 
-Persistent compiler settings are package preferences. For example:
+Persistent settings are package preferences. For example:
 
 ```toml
 [cuTile]
 compiler_timeout_seconds = 60
+disk_cache = true
+cache_dir = "/fast/local/cache"
+cache_size_bytes = 2147483648
 ```
 
 The timeout covers each `tileiras` invocation. On expiry, cuTile terminates the
@@ -159,12 +162,6 @@ Across sessions, the Tile IR → CUBIN step is cached on disk, so the second run
 of a program skips the `tileiras` invocation entirely. The cache is
 content-addressed on the bytecode plus the toolkit version, architecture and
 optimization level, so a toolchain upgrade simply produces new entries rather
-than stale hits. Two environment variables control it:
-
-| Variable | Effect |
-|----------|--------|
-| `JULIA_CUTILE_CACHE_DIR` | Override the cache directory. `0`, `off`, `none` or empty disables the disk cache. |
-| `JULIA_CUTILE_CACHE_SIZE` | Override the maximum cache size (default 1 GiB). |
-
-These knobs are considered internal, and may disappear when cuTile.jl integrates
-more deeply with Julia's integrated code cache.
+than stale hits. The `disk_cache` preference disables it when set to `false`;
+`cache_dir` overrides its scratch directory, and `cache_size_bytes` overrides
+its default 1 GiB maximum size.

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -119,10 +119,10 @@ one down. But they do mean that arrays which look interchangeable are not:
 
 ```julia-repl
 julia> typeof(ct.TileArray(CUDA.rand(Float32, 1024)))
-cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false}()}
+cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, true, (0,), (16,), false, (false,)}()}
 
 julia> typeof(ct.TileArray(view(CUDA.rand(Float32, 2048), 1:2:2048)))
-cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, false, (0,), (16,), false}()}
+cuTile.TileArray{Float32, 1, Int32, cuTile.ArraySpec{1, 128, false, (0,), (16,), false, (false,)}()}
 ```
 
 The strided view is not contiguous, so it compiles to a second, more

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -13,9 +13,8 @@ entirely.
 - A single LMDB env at `\$(scratchspace)/disk_cache/`. The directory
   contains `data.mdb` + `lock.mdb`; wiping the cache means `rm -rf` of
   that directory or `Scratch.delete_scratch!`.
-- Set `JULIA_CUTILE_CACHE_DIR` to override the cache directory. Values
-  `0`, `off`, `none`, and the empty string disable the disk cache. Set
-  `JULIA_CUTILE_CACHE_SIZE` to override the default 1 GiB LMDB map size.
+- The `disk_cache`, `cache_dir`, and `cache_size_bytes` preferences configure
+  or disable the cache. The default map size is 1 GiB.
 - Keys: `sha256(SCHEMA_VERSION || toolkit_version || sm_arch || opt_level || bytecode)`.
   Any input change produces a fresh key, so old-toolkit entries never
   match on lookup. Bump [`SCHEMA_VERSION`](@ref) to invalidate every
@@ -50,6 +49,7 @@ module DiskCache
 import LMDB
 using SHA: sha256
 using Scratch: @get_scratch!
+using Preferences: @load_preference
 
 # ===========================================================================
 # Value framing and key prefixes
@@ -173,6 +173,28 @@ end
 isopen(cache::Cache) = LMDB.isopen(cache.env)
 
 const DEFAULT_MAPSIZE = Csize_t(1) << 30
+
+function parse_cache_size(setting)
+    setting isa Integer && !(setting isa Bool) && 0 < setting <= typemax(Csize_t) ||
+        throw(ArgumentError("cache_size_bytes must be a positive integer byte count"))
+    return Csize_t(setting)
+end
+
+function parse_cache_dir(setting)
+    setting isa AbstractString && !isempty(setting) ||
+        throw(ArgumentError("cache_dir must be a non-empty path string"))
+    return String(setting)
+end
+
+const cache_enabled = let setting = @load_preference("disk_cache", true)
+    setting isa Bool || throw(ArgumentError("disk_cache must be a boolean"))
+    setting
+end
+const cache_dir_override = let setting = @load_preference("cache_dir", nothing)
+    setting === nothing ? nothing : parse_cache_dir(setting)
+end
+const cache_size = parse_cache_size(
+    @load_preference("cache_size_bytes", Int(DEFAULT_MAPSIZE)))
 
 """
     close(cache::Cache)
@@ -610,34 +632,17 @@ function try_init()
     end
 end
 
-function configured_cache_dir()
-    setting = Base.get(ENV, "JULIA_CUTILE_CACHE_DIR", nothing)
+function configured_cache_dir(enabled=cache_enabled, setting=cache_dir_override)
+    enabled || return nothing
     if setting === nothing
         # @get_scratch! resolves to cuTile's package UUID via moduleroot,
         # so the path is $DEPOT/scratchspaces/<cuTile-UUID>/disk_cache/.
         return @get_scratch!("disk_cache")
     end
-    cache_setting_disabled(setting) && return nothing
-    return abspath(expanduser(setting))
+    return abspath(expanduser(parse_cache_dir(setting)))
 end
 
-function configured_mapsize()
-    setting = Base.get(ENV, "JULIA_CUTILE_CACHE_SIZE", nothing)
-    setting === nothing && return DEFAULT_MAPSIZE
-    return parse_cache_size(setting)
-end
-
-function cache_setting_disabled(setting::AbstractString)
-    lowercase(strip(setting)) in ("", "0", "off", "none")
-end
-
-function parse_cache_size(setting::AbstractString)
-    value = tryparse(UInt64, strip(setting))
-    if value === nothing || value == 0
-        throw(ArgumentError("JULIA_CUTILE_CACHE_SIZE must be a positive integer byte count"))
-    end
-    return value
-end
+configured_mapsize(setting=cache_size) = parse_cache_size(setting)
 
 function wipe_lmdb_files(path::AbstractString)
     rm(joinpath(path, "data.mdb"); force=true)

--- a/src/compiler/analysis/assume.jl
+++ b/src/compiler/analysis/assume.jl
@@ -113,12 +113,11 @@ function arg_chain(::Type{T}, path::Vector{Int}) where {T <: TileArray}
         i = path[2]
         1 <= i <= ndims(T) || return EMPTY_PREDS
         if path[1] == 2  # sizes[i]
+            spec.singleton[i] && return EMPTY_PREDS
             return op_predicates(nothing, nothing, nothing, :size, Int(spec.shape_div_by[i]))
         elseif path[1] == 3  # strides[i]
-            # Contiguous axis: `make_tensor_view` inlines `1` and the
-            # `muli(x, 1)` algebra rule folds it out of scatter/gather
-            # offsets, so this slot never enters the bytecode signature.
-            spec.contiguous && i == 1 && return EMPTY_PREDS
+            # Static contiguous/singleton strides need no runtime assumption.
+            ((spec.contiguous && i == 1) || spec.singleton[i]) && return EMPTY_PREDS
             return op_predicates(nothing, nothing, nothing, :stride, Int(spec.stride_div_by[i]))
         end
     end

--- a/src/compiler/analysis/constant.jl
+++ b/src/compiler/analysis/constant.jl
@@ -122,19 +122,17 @@ function interpret_integer(value::Integer, width::Int, signed::Bool)
     signed && bits >= modulus >> 1 ? bits - modulus : bits
 end
 
-# Project a `TileArrayFieldRef` to a scalar constant when the spec pins
-# the field's value statically. Currently only the contiguous-axis stride
-# (= 1) qualifies; sizes are dynamic (only divisibility / bounds are
-# encoded), and the pointer is opaque to constant analysis. The
-# `contiguous ⟹ stride_div_by[1] ∈ {0, 1}` consistency is enforced by
-# `ArraySpec`'s inner constructor, so no defensive check is needed here.
+# Project fields fixed by the `ArraySpec`: singleton sizes/strides and the
+# contiguous first stride are one.
 function tilearray_field_constant(ref::TileArrayFieldRef)
-    ref.field === :strides || return nothing
-    ref.index == 1 || return nothing
-    ref.spec.contiguous || return nothing
-    # Match the strides field's element type: a contiguous-axis stride
-    # equals `1` in whatever integer width `TileArray.strides` carries.
-    return eltype(fieldtype(ref.T, :strides))(1)
+    ref.index isa Int || return nothing
+    if ref.field === :sizes && ref.spec.singleton[ref.index]
+        return eltype(fieldtype(ref.T, :sizes))(1)
+    elseif ref.field === :strides &&
+           ((ref.index == 1 && ref.spec.contiguous) || ref.spec.singleton[ref.index])
+        return eltype(fieldtype(ref.T, :strides))(1)
+    end
+    return nothing
 end
 
 #=============================================================================

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -516,36 +516,52 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_gather_scatter_vie
 end
 
 """
-    compute_tensor_view_strides(array_spec, ndim) -> Vector{Int64}
+    compute_tensor_view_shape(array_spec, ndim) -> RowMajorShape
+    compute_tensor_view_strides(array_spec, ndim, elem_type) -> Vector{Int64}
 
-Compute the stride values for a TensorView type based on ArraySpec.
-Returns static stride values where known, DYNAMIC_SHAPE where dynamic.
+Compute static TensorView dimensions and strides from an `ArraySpec`.
+Singleton axes use a 16-byte-aligned synthetic stride: their physical stride
+does not contribute to any in-bounds address.
 
 For contiguous column-major arrays (matching Julia's memory layout),
 stride[1] = 1 is statically known. Higher dimensions are typically dynamic.
 """
-function compute_tensor_view_strides(array_spec::Union{ArraySpec, Nothing}, ndim::Int)
+function compute_tensor_view_shape(array_spec::Union{ArraySpec, Nothing}, ndim::Int)
+    shape = fill(DYNAMIC_SHAPE, ndim)
+    if array_spec !== nothing
+        for i in 1:ndim
+            array_spec.singleton[i] && (shape[ndim + 1 - i] = 1)
+        end
+    end
+    return RowMajorShape(shape)
+end
+
+function compute_tensor_view_strides(array_spec::Union{ArraySpec, Nothing}, ndim::Int,
+                                     elem_type::Type)
     strides = fill(DYNAMIC_SHAPE, ndim)
 
-    if array_spec !== nothing && array_spec.contiguous && ndim >= 1
-        # Contiguous column-major array: Julia stride[1]=1 becomes Tile IR stride[ndim]=1
-        strides[ndim] = 1
+    if array_spec !== nothing
+        if array_spec.contiguous && ndim >= 1 && !array_spec.singleton[1]
+            strides[ndim] = 1
+        end
+        for i in 1:ndim
+            array_spec.singleton[i] && (strides[ndim + 1 - i] = 16 ÷ sizeof(elem_type))
+        end
     end
 
     return strides
 end
 
 """
-    filter_dynamic_strides(stride_vals, tv_strides) -> Vector{Value}
+    filter_dynamic_values(values, static) -> Vector{Value}
 
-Filter stride values to only include those corresponding to dynamic dimensions.
-Only pass operands for dimensions where tv_strides[i] == DYNAMIC_SHAPE.
+Drop operands represented statically in a TensorView type.
 """
-function filter_dynamic_strides(stride_vals::Vector{Value}, tv_strides::Vector{Int64})
+function filter_dynamic_values(values::Vector{Value}, static)
     dynamic_vals = Value[]
-    for (i, stride_type_val) in enumerate(tv_strides)
-        if stride_type_val == DYNAMIC_SHAPE && i <= length(stride_vals)
-            push!(dynamic_vals, stride_vals[i])
+    for (i, static_value) in enumerate(static)
+        if static_value == DYNAMIC_SHAPE && i <= length(values)
+            push!(dynamic_vals, values[i])
         end
     end
     return dynamic_vals
@@ -640,10 +656,9 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_tensor_view), args
     ]
     stride_vals = Value[
         let elem_op = tuple_element_source(block, strides_arg, i),
-            # Skip the contiguous axis: its stride is statically `1`
-            # and never enters the bytecode kernel signature
-            # (`filter_dynamic_strides`).
-            chain = (spec !== nothing && spec.contiguous && i == 1) ? EMPTY_PREDS :
+            # Static TensorView strides never enter the bytecode operands.
+            chain = (spec !== nothing &&
+                     ((spec.contiguous && i == 1) || spec.singleton[i])) ? EMPTY_PREDS :
                     op_predicates(ctx.divby_info, ctx.bounds_info,
                                   elem_op, :stride, stride_hint(i))
             wrap_for(ctx, tv.v::Value, tv.type_id::TypeId, chain)
@@ -656,13 +671,15 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_tensor_view), args
     reverse!(size_vals)
     reverse!(stride_vals)
 
-    tv_shape = RowMajorShape(fill(DYNAMIC_SHAPE, ndim))
-    tv_strides = compute_tensor_view_strides(spec, ndim)
+    tv_shape = compute_tensor_view_shape(spec, ndim)
+    tv_strides = compute_tensor_view_strides(spec, ndim, elem_T)
     tv_type = tensor_view_type!(tt, dtype, tv_shape, tv_strides)
 
-    dynamic_stride_vals = filter_dynamic_strides(stride_vals, tv_strides)
+    dynamic_size_vals = filter_dynamic_values(size_vals, tv_shape)
+    dynamic_stride_vals = filter_dynamic_values(stride_vals, tv_strides)
 
-    tensor_view = encode_MakeTensorViewOp!(cb, tv_type, base_ptr, size_vals, dynamic_stride_vals)
+    tensor_view = encode_MakeTensorViewOp!(cb, tv_type, base_ptr,
+                                           dynamic_size_vals, dynamic_stride_vals)
     result_jltype = TensorView{elem_T, ndim}
     return CGVal(tensor_view, tv_type, result_jltype)
 end

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -97,6 +97,21 @@ function default_view_indices(ctx::CGCtx, indices_arg, view_arg, ndim::Int, name
     return pad_indices(ctx, index_vals, ndim, index_type, index_jl_type)
 end
 
+function check_view_memory_order(memory_order, memory_scope, is_load::Bool, name::String)
+    valid = is_load ? (MemoryOrder.Weak, MemoryOrder.Relaxed, MemoryOrder.Acquire) :
+                      (MemoryOrder.Weak, MemoryOrder.Relaxed, MemoryOrder.Release)
+    memory_order in valid || throw(IRError(
+        "$name: invalid memory order $memory_order; expected one of $valid"))
+    if memory_order === MemoryOrder.Weak
+        memory_scope === nothing || throw(IRError(
+            "$name: weak memory ordering cannot specify a memory scope"))
+    else
+        memory_scope isa MemScope.T || throw(IRError(
+            "$name: $memory_order memory ordering requires a memory scope"))
+    end
+    return
+end
+
 function emit_view_load!(ctx::CGCtx, args, name::String; resolve_indices=default_view_indices)
     cb = ctx.cb
     tt = ctx.tt
@@ -104,7 +119,7 @@ function emit_view_load!(ctx::CGCtx, args, name::String; resolve_indices=default
     # Input token appended by token_order_pass!.
     input_token = extract_token_arg!(ctx, args)
 
-    # args: (view, latency, allow_tma, indices, check_bounds)
+    # args: (view, latency, allow_tma, indices, check_bounds, memory_order, memory_scope)
     view_arg = emit_value!(ctx, args[1])
     view_arg === nothing && throw(IRError("$name() requires a view argument"))
     view_arg.v === nothing && throw(IRError("$name() requires a materialized view"))
@@ -126,6 +141,9 @@ function emit_view_load!(ctx::CGCtx, args, name::String; resolve_indices=default
     allow_tma = @something get_constant(ctx, args[3]) throw(IRError("$name(): allow_tma must be a compile-time constant"))
     allow_tma_val = allow_tma isa Bool ? allow_tma : true
     check_bounds = @something get_constant(ctx, args[5]) throw(IRError("$name(): check_bounds must be a compile-time constant"))
+    memory_order = @something get_constant(ctx, args[6]) throw(IRError("$name(): memory_order must be a compile-time constant"))
+    memory_scope = @something get_constant(ctx, args[7]) throw(IRError("$name(): memory_scope must be a compile-time constant"))
+    check_view_memory_order(memory_order, memory_scope, true, name)
 
     # Resolve indices to Julia-order values, then reverse for Tile IR row-major.
     index_vals = resolve_indices(ctx, args[4], view_arg, ndim, name)
@@ -135,7 +153,10 @@ function emit_view_load!(ctx::CGCtx, args, name::String; resolve_indices=default
 
     tile_val, result_token = encode_LoadViewTkoOp!(
         cb, tile_type, token_type, view_arg.v, index_vals;
-        token = input_token, optimization_hints, inbounds=fill(!check_bounds, ndim)
+        token = input_token,
+        memory_ordering=convert_enum(MemoryOrderingSemantics, memory_order),
+        memory_scope=memory_scope === nothing ? nothing : convert_enum(MemoryScope, memory_scope),
+        optimization_hints, inbounds=fill(!check_bounds, ndim)
     )
 
     # Store result token for TokenResultNode
@@ -153,7 +174,7 @@ function emit_view_store!(ctx::CGCtx, args, name::String;
     # Input token appended by token_order_pass!.
     input_token = extract_token_arg!(ctx, args)
 
-    # args: (view, tile, latency, allow_tma, indices, check_bounds)
+    # args: (view, tile, latency, allow_tma, indices, check_bounds, memory_order, memory_scope)
     view_arg = emit_value!(ctx, args[1])
     view_arg === nothing && throw(IRError("$name() requires a view argument"))
     view_arg.v === nothing && throw(IRError("$name() requires a materialized view"))
@@ -191,6 +212,9 @@ function emit_view_store!(ctx::CGCtx, args, name::String;
     allow_tma = @something get_constant(ctx, args[4]) throw(IRError("$name(): allow_tma must be a compile-time constant"))
     allow_tma_val = allow_tma isa Bool ? allow_tma : true
     check_bounds = @something get_constant(ctx, args[6]) throw(IRError("$name(): check_bounds must be a compile-time constant"))
+    memory_order = @something get_constant(ctx, args[7]) throw(IRError("$name(): memory_order must be a compile-time constant"))
+    memory_scope = @something get_constant(ctx, args[8]) throw(IRError("$name(): memory_scope must be a compile-time constant"))
+    check_view_memory_order(memory_order, memory_scope, false, name)
 
     # Resolve indices to Julia-order values, then reverse for Tile IR row-major.
     index_vals = resolve_indices(ctx, args[5], view_arg, actual_ndim, name)
@@ -201,7 +225,10 @@ function emit_view_store!(ctx::CGCtx, args, name::String;
 
     result_token = encode_StoreViewTkoOp!(
         cb, token_type, tile_val, view_arg.v, index_vals;
-        token = input_token, optimization_hints, inbounds=fill(!check_bounds, actual_ndim)
+        token = input_token,
+        memory_ordering=convert_enum(MemoryOrderingSemantics, memory_order),
+        memory_scope=memory_scope === nothing ? nothing : convert_enum(MemoryScope, memory_scope),
+        optimization_hints, inbounds=fill(!check_bounds, actual_ndim)
     )
 
     # Store result token for TokenResultNode
@@ -223,7 +250,8 @@ order and is reversed/zero-padded to match `pv`'s index space rank
 before emission. The token argument is appended by `token_order_pass!`
 and is not part of the user-visible signature.
 """
-@intrinsic load_partition_view(pv, latency, allow_tma, indices, check_bounds)
+@intrinsic load_partition_view(pv, latency, allow_tma, indices, check_bounds,
+                               memory_order, memory_scope)
 tfunc(𝕃, ::typeof(Intrinsics.load_partition_view), @nospecialize(pv), @nospecialize args...) =
     view_load_return_type(pv, 3)
 emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_partition_view), args) =
@@ -236,7 +264,8 @@ Token-ordered load from a `StridedView`. It uses the same Tile IR load op as
 `load_partition_view`, but has a distinct intrinsic identity so analyses never
 assume that distinct tile indices access disjoint memory.
 """
-@intrinsic load_strided_view(sv, latency, allow_tma, indices, check_bounds)
+@intrinsic load_strided_view(sv, latency, allow_tma, indices, check_bounds,
+                             memory_order, memory_scope)
 tfunc(𝕃, ::typeof(Intrinsics.load_strided_view), @nospecialize(sv), @nospecialize args...) =
     view_load_return_type(sv, 4)
 emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_strided_view), args) =
@@ -249,7 +278,8 @@ Token-ordered load from a GatherScatterView. Its indices deliberately accept
 one one-dimensional tile plus scalar tiles, unlike PartitionView's homogeneous
 index tuple.
 """
-@intrinsic load_gather_scatter_view(view, latency, allow_tma, indices, check_bounds)
+@intrinsic load_gather_scatter_view(view, latency, allow_tma, indices, check_bounds,
+                                    memory_order, memory_scope)
 tfunc(𝕃, ::typeof(Intrinsics.load_gather_scatter_view), @nospecialize(view), @nospecialize args...) =
     view_load_return_type(view, 4)
 emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.load_gather_scatter_view), args) =
@@ -703,7 +733,9 @@ views require at least 1-D. The token argument is appended by
                                           latency::Union{Int, Nothing},
                                           allow_tma::Bool,
                                           indices::NTuple{M, <:Integer},
-                                          check_bounds::Bool) where {T, N, Shape, M}
+                                          check_bounds::Bool,
+                                          memory_order,
+                                          memory_scope) where {T, N, Shape, M}
 tfunc(𝕃, ::typeof(Intrinsics.store_partition_view), @nospecialize args...) = Nothing
 efunc(::typeof(Intrinsics.store_partition_view), effects::CC.Effects) =
     CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
@@ -722,7 +754,9 @@ their loop-carried token dependency even when their tile indices differ.
                               latency::Union{Int, Nothing},
                               allow_tma::Bool,
                               indices::NTuple{M, <:Integer},
-                              check_bounds::Bool) where {T, N, Shape, Steps, M}
+                              check_bounds::Bool,
+                              memory_order,
+                              memory_scope) where {T, N, Shape, Steps, M}
 tfunc(𝕃, ::typeof(Intrinsics.store_strided_view), @nospecialize args...) = Nothing
 efunc(::typeof(Intrinsics.store_strided_view), effects::CC.Effects) =
     CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
@@ -741,7 +775,9 @@ indices as injective.
                                      latency::Union{Int, Nothing},
                                      allow_tma::Bool,
                                      indices,
-                                     check_bounds::Bool) where {T, N, Shape, SparseDim}
+                                     check_bounds::Bool,
+                                     memory_order,
+                                     memory_scope) where {T, N, Shape, SparseDim}
 tfunc(𝕃, ::typeof(Intrinsics.store_gather_scatter_view), @nospecialize args...) = Nothing
 efunc(::typeof(Intrinsics.store_gather_scatter_view), effects::CC.Effects) =
     CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)

--- a/src/compiler/transform/token_order.jl
+++ b/src/compiler/transform/token_order.jl
@@ -87,11 +87,9 @@ function compute_block_memory_effects!(block::Block, alias_info::AliasInfo,
             mem_effect == MEM_NONE && continue
             alias_set = alias_class(alias_info, first(operands))
             effects.effects[alias_set] = max(get(effects.effects, alias_set, MEM_NONE), mem_effect)
-            if is_atomic_intrinsic(resolved_func)
-                mo = extract_memory_order(resolved_func, operands)
-                if has_acquire_order(mo)
-                    effects = MemoryEffects(effects.effects, true)
-                end
+            mo = extract_memory_order(resolved_func, operands)
+            if has_acquire_order(mo)
+                effects = MemoryEffects(effects.effects, true)
             end
         end
     end
@@ -149,13 +147,24 @@ end
 """
     extract_memory_order(resolved_func, operands) -> Union{MemoryOrder.T, Nothing}
 
-Extract the compile-time memory_order from an atomic intrinsic's operands.
+Extract the compile-time `memory_order` from an ordered memory intrinsic.
 """
 function extract_memory_order(resolved_func, operands)
-    is_atomic_intrinsic(resolved_func) || return nothing
-    # CAS: (ptr, expected, desired, mask, memory_order, memory_scope)
-    # RMW: (ptr, val, mask, memory_order, memory_scope)
-    mo_idx = resolved_func === Intrinsics.atomic_cas ? 5 : 4
+    mo_idx = if resolved_func === Intrinsics.atomic_cas
+        5
+    elseif is_atomic_intrinsic(resolved_func)
+        4
+    elseif resolved_func === Intrinsics.load_partition_view ||
+           resolved_func === Intrinsics.load_strided_view ||
+           resolved_func === Intrinsics.load_gather_scatter_view
+        6
+    elseif resolved_func === Intrinsics.store_partition_view ||
+           resolved_func === Intrinsics.store_strided_view ||
+           resolved_func === Intrinsics.store_gather_scatter_view
+        7
+    else
+        return nothing
+    end
     mo_idx > length(operands) && return nothing
     mo_arg = operands[mo_idx]
     # The memory_order is typically a compile-time constant (QuoteNode or literal)
@@ -450,10 +459,12 @@ function transform_statement!(block::Block, inst::Instruction,
     mem_effect == MEM_NONE && return
 
     alias_set = alias_class(alias_info, first(operands))
+    memory_order = extract_memory_order(resolved_func, operands)
 
     if mem_effect == MEM_LOAD
         input_token = get_input_token_ir!(block, SSAValue(inst),
-                                           last_store_key(alias_set), token_map)
+                                           last_store_key(alias_set), token_map,
+                                           memory_order)
         push!(s.args, input_token)
 
         result_inst = insert_after!(block, SSAValue(inst), TokenResultNode(inst.ssa_idx), TOKEN_TYPE)
@@ -466,9 +477,14 @@ function transform_statement!(block::Block, inst::Instruction,
                        JoinTokensNode([last_op_tok, result_token]), TOKEN_TYPE)
         token_map[lop_key] = SSAValue(join_inst)
 
+        if has_acquire_order(memory_order)
+            token_map[ACQUIRE_TOKEN_KEY] = result_token
+        end
+
     elseif mem_effect == MEM_STORE
         # Loop parallel store optimization (Python _try_loop_parallel_store, lines 499-541)
-        if parallel_info !== nothing && inst.ssa_idx in parallel_info.parallel_stores
+        if parallel_info !== nothing && inst.ssa_idx in parallel_info.parallel_stores &&
+           !has_release_order(memory_order)
             lop_key = last_op_key(alias_set)
             lst_key = last_store_key(alias_set)
             parent_tok = parallel_info.parent_token_map[lop_key]
@@ -498,8 +514,7 @@ function transform_statement!(block::Block, inst::Instruction,
             return
         end
 
-        # For release-ordered atomics, join with ALL LAST_OP tokens (memory fence)
-        memory_order = extract_memory_order(resolved_func, operands)
+        # Release ordering joins with all prior memory operations.
         input_token = get_input_token_ir!(block, SSAValue(inst),
                                            last_op_key(alias_set), token_map,
                                            memory_order)
@@ -511,8 +526,7 @@ function transform_statement!(block::Block, inst::Instruction,
         token_map[last_op_key(alias_set)] = result_token
         token_map[last_store_key(alias_set)] = result_token
 
-        # Only acquire/acq_rel atomics update the ACQUIRE token
-        if is_atomic_intrinsic(resolved_func) && has_acquire_order(memory_order)
+        if has_acquire_order(memory_order)
             token_map[ACQUIRE_TOKEN_KEY] = result_token
         end
     end

--- a/src/language/atomics.jl
+++ b/src/language/atomics.jl
@@ -7,28 +7,6 @@ public atomic_cas, atomic_xchg, atomic_add, atomic_max, atomic_min, atomic_or, a
 public atomic_store_add, atomic_store_max, atomic_store_min,
        atomic_store_or, atomic_store_and, atomic_store_xor
 
-"""
-Memory ordering constants. Atomic operations accept `Relaxed`, `Acquire`,
-`Release`, and `AcqRel`. `Weak` is reserved for non-atomic loads and stores and
-is rejected by the atomic APIs.
-"""
-@enumx MemoryOrder begin
-    Weak = 0
-    Relaxed = 1
-    Acquire = 2
-    Release = 3
-    AcqRel = 4
-end
-
-"""
-Memory scope for atomic operations.
-"""
-@enumx MemScope begin
-    Block = 0
-    Device = 1
-    System = 2
-end
-
 # ============================================================================
 # Pointer/mask helpers
 #

--- a/src/language/broadcast.jl
+++ b/src/language/broadcast.jl
@@ -66,16 +66,34 @@ end
 @inline _materialize_args(args::Tuple) =
     (_materialize_arg(args[1]), _materialize_args(Base.tail(args))...)
 
-# Promote Number arguments to 0-dimensional Tiles. Each Number is wrapped
-# using its own type (e.g., 0.0f0 → Tile(Float32(0.0))), preserving the
-# type that Julia's broadcast promotion chose. This avoids the pitfall of
-# using the first Tile's eltype (which could be Bool for ifelse conditions).
-# Base.RefValue arguments pass through unchanged — they carry no tile shape.
-@inline _promote_to_tiles() = ()
-@inline _promote_to_tiles(a::Tile, rest...) = (a, _promote_to_tiles(rest...)...)
-@inline _promote_to_tiles(a::T, rest...) where {T <: Number} =
-    (Tile(a), _promote_to_tiles(rest...)...)
-@inline _promote_to_tiles(a::Base.RefValue, rest...) = (a, _promote_to_tiles(rest...)...)
+# Promote scalars to the first same-category Tile element type. This keeps
+# integer and floating literals from widening narrower tiles; unrelated Tile
+# arguments such as an `ifelse` condition are skipped.
+@inline _promote_to_tiles(args...) = _promote_to_tiles(args, args)
+@inline _promote_to_tiles(::Tuple{}, ::Tuple) = ()
+@inline function _promote_to_tiles(args::Tuple, all::Tuple)
+    (_promote_to_tile(args[1], all), _promote_to_tiles(Base.tail(args), all)...)
+end
+
+@inline _promote_to_tile(a::Tile, ::Tuple) = a
+@inline _promote_to_tile(a::Base.RefValue, ::Tuple) = a
+@inline function _promote_to_tile(a::T, args::Tuple) where {T <: Number}
+    U = _loose_scalar_type(T, args)
+    Tile(convert(U, a))
+end
+
+@inline _loose_scalar_type(::Type{T}, ::Tuple{}) where {T} = T
+@inline function _loose_scalar_type(::Type{T}, args::Tuple{A, Vararg}) where {T, A<:Tile}
+    U = eltype(A)
+    if (T <: AbstractFloat && U <: AbstractFloat) ||
+       (T <: Integer && T !== Bool && U <: Integer && U !== Bool) ||
+       (T === Bool && U === Bool)
+        return U
+    end
+    _loose_scalar_type(T, Base.tail(args))
+end
+@inline _loose_scalar_type(::Type{T}, args::Tuple{Any, Vararg}) where {T} =
+    _loose_scalar_type(T, Base.tail(args))
 
 # Compute combined broadcast shape across all Tile arguments via tuple peeling.
 # Shape is always a tuple TYPE (e.g., Tuple{16, 32}). Convert to value for broadcast_shape.

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -1383,6 +1383,12 @@ end
     return bt > bs ? Base.tail(sz) : (div(bs, bt), sz...)
 end
 
+@inline function check_reinterpret_eltypes(::Type{T}, ::Type{S}) where {T, S}
+    (T === Bool || S === Bool) &&
+        throw(ArgumentError("reinterpret does not support Bool tile elements"))
+    return
+end
+
 """
     Base.reinterpret(::Type{T}, x::Tile) -> Tile{T}
 
@@ -1398,6 +1404,7 @@ in a `UInt8` array. The total bit-width is preserved, so it must divide evenly.
 
 Note `reinterpret.(T, x)` (with a dot) is the unrelated *element-wise* broadcast,
 which keeps the shape and requires `T` to be the same width as `eltype(x)`.
+`Bool` is not supported as either element type.
 
 ```julia
 bytes = ct.load(a, pid, (8,))                 # Tile{UInt8,Tuple{8}}
@@ -1406,6 +1413,7 @@ vals  = convert(ct.Tile{Float32}, fp4)        # widen for compute
 ```
 """
 @inline function Base.reinterpret(::Type{T}, x::Tile) where {T}
+    check_reinterpret_eltypes(T, eltype(x))
     rshape = reinterpret_scaled_shape(T, eltype(x), size(x))
     flat = Intrinsics.reshape(x, (prod(size(x)),))
     return Intrinsics.reshape(reinterpret_width(T, flat), rshape)
@@ -1420,6 +1428,7 @@ dimension it *removes* it when widening (the leading dim must equal
 `bitwidth(T) ÷ bitwidth(eltype(x))`) and *prepends* one when narrowing.
 """
 @inline function Base.reinterpret(::typeof(reshape), ::Type{T}, x::Tile) where {T}
+    check_reinterpret_eltypes(T, eltype(x))
     rshape = reinterpret_reshape_shape(T, eltype(x), size(x))
     flat = Intrinsics.reshape(x, (prod(size(x)),))
     return Intrinsics.reshape(reinterpret_width(T, flat), rshape)

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -102,7 +102,7 @@ function sliced_arraytype(@nospecialize(SrcT::Type{<:TileArray});
     # happens to be one; constprop of a literal step could recover it later.
     new_contiguous = spec.contiguous && stepped_axis !== 1
     new_spec = ArraySpec{N, 0, new_contiguous, spec.stride_div_by, ntuple(_ -> 0, N),
-                         spec.may_alias_internally}()
+                         spec.may_alias_internally, ntuple(_ -> false, N)}()
     return TileArray{elem_T, N, I, new_spec}
 end
 
@@ -207,9 +207,10 @@ function permuted_arraytype(@nospecialize(SrcT::Type{<:TileArray}),
     new_contiguous = spec.contiguous && Perm[1] == 1
     new_stride_div_by = ntuple(i -> spec.stride_div_by[Perm[i]], Val(N))
     new_shape_div_by  = ntuple(i -> spec.shape_div_by[Perm[i]],  Val(N))
+    new_singleton = ntuple(i -> spec.singleton[Perm[i]], Val(N))
     new_spec = ArraySpec{N, spec.alignment, new_contiguous,
                          new_stride_div_by, new_shape_div_by,
-                         spec.may_alias_internally}()
+                         spec.may_alias_internally, new_singleton}()
     return TileArray{elem_T, N, I, new_spec}
 end
 
@@ -242,13 +243,16 @@ function reshaped_arraytype(@nospecialize(SrcT::Type{<:TileArray}),
     I = indextype(SrcT)
     M = length(NewShape)
     new_shape_div_by = ntuple(i -> NewShape[i], Val(M))
+    new_singleton = ntuple(i -> NewShape[i] == 1, Val(M))
     # Reshape recomputes dense column-major strides, so the result layout is
     # injective regardless of the source's internal-aliasing flag.
     if spec === nothing
-        new_spec = ArraySpec{M, 0, true, ntuple(_ -> 0, Val(M)), new_shape_div_by, false}()
+        new_spec = ArraySpec{M, 0, true, ntuple(_ -> 0, Val(M)), new_shape_div_by,
+                             false, new_singleton}()
     else
         new_spec = ArraySpec{M, spec.alignment, true,
-                             ntuple(_ -> 0, Val(M)), new_shape_div_by, false}()
+                             ntuple(_ -> 0, Val(M)), new_shape_div_by,
+                             false, new_singleton}()
     end
     return TileArray{elem_T, M, I, new_spec}
 end

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -566,19 +566,20 @@ end
     load(tiles, index; kwargs...)
 end
 
-@inline function store(tiles::TiledView{A}, index::NTuple{N, <:Integer}, tile::Tile{T};
+@inline function store(tiles::TiledView{A}, index::NTuple{N, <:Integer}, tile::Tile;
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
                        allow_tma::Union{Bool, Nothing}=nothing,
                        memory_order::MemoryOrder.T=MemoryOrder.Weak,
-                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {A, N, T}
+                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {T, A<:TileArray{T}, N}
     N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
-    reshaped = _reshape_to_rank(tile, Val(ndims(tiles)))
+    stored = convert(Tile{T}, tile)
+    reshaped = _reshape_to_rank(stored, Val(ndims(tiles)))
     view = make_tile_view(tiles)
     store_tile_view(view, reshaped, latency, allow_tma,
                     zero_based_indices(tiles.parent, index), check_bounds,
                     memory_order, memory_scope)
-    return tile
+    return stored
 end
 @inline function store(tiles::TiledView, index::Integer, tile::Tile; kwargs...)
     store(tiles, (index,), tile; kwargs...)
@@ -845,9 +846,15 @@ behavior is undefined.
         zero_based_indices(arr, index))
     return tile  # XXX: enables constant folding; remove when possible (see "constant folding" test)
 end
+@inline function store(arr::TileArray{T}, index, tile::Tile; kwargs...) where {T}
+    store(arr, index, convert(Tile{T}, tile); kwargs...)
+end
 
 # Scalar index → wrap in tuple
 @inline function store(arr::TileArray{T}, index::Integer, tile::Tile{T}; kwargs...) where {T}
+    store(arr, (index,), tile; kwargs...)
+end
+@inline function store(arr::TileArray, index::Integer, tile::Tile; kwargs...)
     store(arr, (index,), tile; kwargs...)
 end
 
@@ -858,13 +865,14 @@ end
 Store through a Julia gather/scatter view. Repeated sparse indices retain Tile
 IR's undefined conflicting-store semantics and are conservatively token-ordered.
 """
-@inline function store(view::GatherScatterTileView{A}, tile::Tile{T};
+@inline function store(view::GatherScatterTileView{A}, tile::Tile;
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
                        allow_tma::Union{Bool, Nothing}=nothing,
                        memory_order::MemoryOrder.T=MemoryOrder.Weak,
                        memory_scope::Union{MemScope.T, Nothing}=nothing) where {T, A<:TileArray{T}}
-    shape = size(tile)
+    stored = convert(Tile{T}, tile)
+    shape = size(stored)
     _check_gather_scatter_shape(view, shape)
     parent_array = parent(view)
     tensor_view = Intrinsics.make_tensor_view(typeof(parent_array), parent_array.ptr,
@@ -872,18 +880,18 @@ IR's undefined conflicting-store semantics and are conservatively token-ordered.
     gather_view = Intrinsics.make_gather_scatter_view(
         tensor_view, shape, gather_scatter_sparse_dim(view), PaddingMode.Undetermined)
     Intrinsics.store_gather_scatter_view(
-        gather_view, tile, latency, allow_tma, _gather_scatter_indices(view), check_bounds,
+        gather_view, stored, latency, allow_tma, _gather_scatter_indices(view), check_bounds,
         memory_order, memory_scope)
-    return tile
+    return stored
 end
 
 # Scalar value → wrap in 1-element tile and store
-@inline function store(arr::TileArray{T}, index, val::T; kwargs...) where {T}
+@inline function store(arr::TileArray{T}, index, val::Number; kwargs...) where {T}
     shape = ntuple(_ -> 1, Val(ndims(arr)))
-    tile = reshape(Intrinsics.from_scalar(val, Tuple{}), shape)
+    tile = reshape(Intrinsics.from_scalar(convert(T, val), Tuple{}), shape)
     store(arr, index, tile; kwargs...)
 end
-@inline function store(arr::TileArray{T}, index::Integer, val::T; kwargs...) where {T}
+@inline function store(arr::TileArray, index::Integer, val::Number; kwargs...)
     store(arr, (index,), val; kwargs...)
 end
 
@@ -898,13 +906,13 @@ end
 end
 
 # Keyword argument version - dispatch to positional version
-@inline function store(arr::TileArray{T}; index, tile::Tile{T},
+@inline function store(arr::TileArray; index, tile::Tile,
                        order::Union{NTuple{<:Any, Int}, Nothing}=nothing,
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
                        allow_tma::Union{Bool, Nothing}=nothing,
                        memory_order::MemoryOrder.T=MemoryOrder.Weak,
-                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {T}
+                       memory_scope::Union{MemScope.T, Nothing}=nothing)
     store(arr, index, tile; order, check_bounds, latency, allow_tma,
           memory_order, memory_scope)
 end
@@ -913,9 +921,9 @@ end
 # NOTE: Cannot use @overlay (which adds @assume_effects :foldable) because
 # setindex! is a side-effecting operation returning nothing — the compiler
 # would DCE the entire call as a pure function with unused result.
-Base.Experimental.@consistent_overlay cuTileMethodTable function Base.setindex!(arr::TileArray{T, N}, val::T, indices::Vararg{Integer, N}) where {T, N}
+Base.Experimental.@consistent_overlay cuTileMethodTable function Base.setindex!(arr::TileArray{T, N}, val::Number, indices::Vararg{Integer, N}) where {T, N}
     shape = ntuple(_ -> 1, Val(N))
-    tile = reshape(Intrinsics.from_scalar(val, Tuple{}), shape)
+    tile = reshape(Intrinsics.from_scalar(convert(T, val), Tuple{}), shape)
     store(arr, indices, tile)
     return
 end
@@ -1061,18 +1069,19 @@ indices = base .+ ct.arange(TILE)
 ct.scatter(arr, indices, result_tile; mask=valid_mask)
 ```
 """
-@inline function scatter(array::TileArray{T, 1, I}, indices::Tile{J, S}, tile::Tile{T, S};
+@inline function scatter(array::TileArray{T, 1, I}, indices::Tile{J, S}, tile::Tile{<:Any, S};
                          mask=nothing,
                          check_bounds::Bool=true,
                          latency::Union{Int, Nothing}=nothing) where
         {T, I, J <: Integer, S}
+    stored = convert(Tile{T}, tile)
     indices_0 = indices .- one(J)
     array_indices = convert(Tile{I}, indices_0)
     ptr_tile = Intrinsics.offset(Tile(array.ptr), array_indices)
 
     bounds_mask = check_bounds ? _bounds_mask_1d(array_indices, array) : nothing
     final_mask = _combine_masks(bounds_mask, mask)
-    _scatter_store(ptr_tile, tile, latency, final_mask)
+    _scatter_store(ptr_tile, stored, latency, final_mask)
 end
 
 """
@@ -1087,20 +1096,22 @@ Indices are 1-indexed. Index tiles and value tile must broadcast to same shape.
   when indices are known to be in-bounds to skip the comparisons.
 - `latency`: Optional latency hint (1-10), or nothing for compiler default
 """
-@inline function scatter(array::TileArray{T, 2, I}, indices::Tuple{Tile{J0}, Tile{J1}}, tile::Tile{T};
+@inline function scatter(array::TileArray{T, 2, I}, indices::Tuple{Tile{J0}, Tile{J1}}, tile::Tile;
                          mask=nothing,
                          check_bounds::Bool=true,
                          latency::Union{Int, Nothing}=nothing) where
         {T, I, J0 <: Integer, J1 <: Integer}
+    stored = convert(Tile{T}, tile)
+
     # Convert to 0-indexed
     idx0_0 = indices[1] .- one(J0)
     idx1_0 = indices[2] .- one(J1)
 
     # Broadcast indices to common shape
-    S = broadcast_shape(broadcast_shape(size(indices[1]), size(indices[2])), size(tile))
+    S = broadcast_shape(broadcast_shape(size(indices[1]), size(indices[2])), size(stored))
     idx0_bc = broadcast_to(idx0_0, S)
     idx1_bc = broadcast_to(idx1_0, S)
-    tile_bc = broadcast_to(tile, S)
+    tile_bc = broadcast_to(stored, S)
 
     idx0_array = convert(Tile{I}, idx0_bc)
     idx1_array = convert(Tile{I}, idx1_bc)

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -524,24 +524,35 @@ end
                                  tiled_view_order(tiles))
 end
 
-@inline load_tile_view(view::PartitionView, latency, allow_tma, indices, check_bounds) =
-    Intrinsics.load_partition_view(view, latency, allow_tma, indices, check_bounds)
-@inline load_tile_view(view::StridedView, latency, allow_tma, indices, check_bounds) =
-    Intrinsics.load_strided_view(view, latency, allow_tma, indices, check_bounds)
-@inline store_tile_view(view::PartitionView, tile, latency, allow_tma, indices, check_bounds) =
-    Intrinsics.store_partition_view(view, tile, latency, allow_tma, indices, check_bounds)
-@inline store_tile_view(view::StridedView, tile, latency, allow_tma, indices, check_bounds) =
-    Intrinsics.store_strided_view(view, tile, latency, allow_tma, indices, check_bounds)
+@inline load_tile_view(view::PartitionView, latency, allow_tma, indices, check_bounds,
+                       memory_order, memory_scope) =
+    Intrinsics.load_partition_view(view, latency, allow_tma, indices, check_bounds,
+                                   memory_order, memory_scope)
+@inline load_tile_view(view::StridedView, latency, allow_tma, indices, check_bounds,
+                       memory_order, memory_scope) =
+    Intrinsics.load_strided_view(view, latency, allow_tma, indices, check_bounds,
+                                 memory_order, memory_scope)
+@inline store_tile_view(view::PartitionView, tile, latency, allow_tma, indices, check_bounds,
+                        memory_order, memory_scope) =
+    Intrinsics.store_partition_view(view, tile, latency, allow_tma, indices, check_bounds,
+                                    memory_order, memory_scope)
+@inline store_tile_view(view::StridedView, tile, latency, allow_tma, indices, check_bounds,
+                        memory_order, memory_scope) =
+    Intrinsics.store_strided_view(view, tile, latency, allow_tma, indices, check_bounds,
+                                  memory_order, memory_scope)
 
 @inline function load(tiles::TiledView{A}, index::NTuple{N, <:Integer};
                       check_bounds::Bool=true,
                       latency::Union{Int, Nothing}=nothing,
-                      allow_tma::Union{Bool, Nothing}=nothing) where {A, N}
+                      allow_tma::Union{Bool, Nothing}=nothing,
+                      memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                      memory_scope::Union{MemScope.T, Nothing}=nothing) where {A, N}
     N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
     view = check_bounds ? make_tile_view(tiles) :
                           make_tile_view(tiles, PaddingMode.Undetermined)
     tile = load_tile_view(view, latency, allow_tma,
-                          zero_based_indices(tiles.parent, index), check_bounds)
+                          zero_based_indices(tiles.parent, index), check_bounds,
+                          memory_order, memory_scope)
     reshape(tile, tiled_view_requested_shape(tiles))
 end
 @inline function load(tiles::TiledView, index::Integer; kwargs...)
@@ -554,12 +565,15 @@ end
 @inline function store(tiles::TiledView{A}, index::NTuple{N, <:Integer}, tile::Tile{T};
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
-                       allow_tma::Union{Bool, Nothing}=nothing) where {A, N, T}
+                       allow_tma::Union{Bool, Nothing}=nothing,
+                       memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {A, N, T}
     N == ndims(tiles) || throw(ArgumentError("eachtile: expected $(ndims(tiles)) tile indices, got $N"))
     reshaped = _reshape_to_rank(tile, Val(ndims(tiles)))
     view = make_tile_view(tiles)
     store_tile_view(view, reshaped, latency, allow_tma,
-                    zero_based_indices(tiles.parent, index), check_bounds)
+                    zero_based_indices(tiles.parent, index), check_bounds,
+                    memory_order, memory_scope)
     return tile
 end
 @inline function store(tiles::TiledView, index::Integer, tile::Tile; kwargs...)
@@ -600,7 +614,8 @@ end
 
 """
     load(arr::TileArray, index, shape; order=nothing, padding_mode=PaddingMode.Undetermined,
-         check_bounds=true, latency=nothing, allow_tma=nothing) -> Tile
+         check_bounds=true, latency=nothing, allow_tma=nothing,
+         memory_order=MemoryOrder.Weak, memory_scope=nothing) -> Tile
 
 Load a tile from a TileArray at the given index with the specified shape.
 Index is 1-indexed. Shape must be compile-time constant.
@@ -629,6 +644,8 @@ outside the array, the behavior is undefined regardless of `padding_mode`.
 - `check_bounds`: Set to `false` to promise the entire tile is in bounds. Requires Tile IR v13.4+.
 - `latency`: Optional latency hint (1-10), or nothing for compiler default
 - `allow_tma`: Whether TMA (Tensor Memory Accelerator) is allowed (default: nothing, compiler decides)
+- `memory_order`: `Weak`, `Relaxed`, or `Acquire`
+- `memory_scope`: Required for non-weak ordering; one of [`MemScope`](@ref)
 
 # Example
 ```julia
@@ -643,14 +660,17 @@ tile = ct.load(arr, (bidy, bidx), (TN, TM); order=(2, 1))
                       padding_mode::PaddingMode.T=PaddingMode.Undetermined,
                       check_bounds::Bool=true,
                       latency::Union{Int, Nothing}=nothing,
-                      allow_tma::Union{Bool, Nothing}=nothing)
+                      allow_tma::Union{Bool, Nothing}=nothing,
+                      memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                      memory_scope::Union{MemScope.T, Nothing}=nothing)
     matched = _match_shape(Val(shape), Val(ndims(arr)))
     tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
     pv = check_bounds ?
          Intrinsics.make_partition_view(tv, matched, padding_mode, order) :
          Intrinsics.make_partition_view(tv, matched, PaddingMode.Undetermined, order)
     tile = Intrinsics.load_partition_view(
-        pv, latency, allow_tma, zero_based_indices(arr, index), check_bounds)
+        pv, latency, allow_tma, zero_based_indices(arr, index), check_bounds,
+        memory_order, memory_scope)
     reshape(tile, shape)
 end
 
@@ -724,7 +744,9 @@ The sparse tile index and dense range starts are one-based at this boundary.
                       padding_mode::PaddingMode.T=PaddingMode.Undetermined,
                       check_bounds::Bool=true,
                       latency::Union{Int, Nothing}=nothing,
-                      allow_tma::Union{Bool, Nothing}=nothing)
+                      allow_tma::Union{Bool, Nothing}=nothing,
+                      memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                      memory_scope::Union{MemScope.T, Nothing}=nothing)
     _check_gather_scatter_shape(view, shape)
     parent_array = parent(view)
     tensor_view = Intrinsics.make_tensor_view(typeof(parent_array), parent_array.ptr,
@@ -735,7 +757,8 @@ The sparse tile index and dense range starts are one-based at this boundary.
         Intrinsics.make_gather_scatter_view(tensor_view, shape, sparse_dim,
                                             PaddingMode.Undetermined)
     Intrinsics.load_gather_scatter_view(
-        gather_view, latency, allow_tma, _gather_scatter_indices(view), check_bounds)
+        gather_view, latency, allow_tma, _gather_scatter_indices(view), check_bounds,
+        memory_order, memory_scope)
 end
 
 # Scalar indexing: arr[i, j, ...] → scalar T
@@ -744,7 +767,8 @@ end
     shape = ntuple(_ -> 1, Val(N))
     pv = Intrinsics.make_partition_view(tv, shape, PaddingMode.Undetermined, nothing)
     tile = Intrinsics.load_partition_view(
-        pv, nothing, nothing, zero_based_indices(arr, indices), true)
+        pv, nothing, nothing, zero_based_indices(arr, indices), true,
+        MemoryOrder.Weak, nothing)
     Intrinsics.to_scalar(reshape(tile, ()))
 end
 
@@ -781,7 +805,8 @@ end
 
 """
     store(arr::TileArray, index, tile::Tile; order=nothing, check_bounds=true,
-          latency=nothing, allow_tma=nothing) -> Tile
+          latency=nothing, allow_tma=nothing, memory_order=MemoryOrder.Weak,
+          memory_scope=nothing) -> Tile
 
 Store a tile to a TileArray at the given index. Index is 1-indexed.
 Returns the stored tile (enables chaining and helps constant folding).
@@ -800,15 +825,19 @@ behavior is undefined.
 - `check_bounds`: Set to `false` to promise the entire tile is in bounds. Requires Tile IR v13.4+.
 - `latency`: Optional latency hint (1-10), or nothing for compiler default
 - `allow_tma`: Whether TMA (Tensor Memory Accelerator) is allowed (default: nothing, compiler decides)
+- `memory_order`: `Weak`, `Relaxed`, or `Release`
+- `memory_scope`: Required for non-weak ordering; one of [`MemScope`](@ref)
 """
 @inline function store(arr::TileArray{T}, index, tile::Tile{T};
                        order::Union{NTuple{<:Any, Int}, Nothing}=nothing,
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
-                       allow_tma::Union{Bool, Nothing}=nothing) where {T}
+                       allow_tma::Union{Bool, Nothing}=nothing,
+                       memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {T}
     reshaped = _reshape_to_rank(tile, Val(ndims(arr)))
     _store_reshaped(
-        arr, reshaped, order, check_bounds, latency, allow_tma,
+        arr, reshaped, order, check_bounds, latency, allow_tma, memory_order, memory_scope,
         zero_based_indices(arr, index))
     return tile  # XXX: enables constant folding; remove when possible (see "constant folding" test)
 end
@@ -828,7 +857,9 @@ IR's undefined conflicting-store semantics and are conservatively token-ordered.
 @inline function store(view::GatherScatterTileView{A}, tile::Tile{T};
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
-                       allow_tma::Union{Bool, Nothing}=nothing) where {T, A<:TileArray{T}}
+                       allow_tma::Union{Bool, Nothing}=nothing,
+                       memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {T, A<:TileArray{T}}
     shape = size(tile)
     _check_gather_scatter_shape(view, shape)
     parent_array = parent(view)
@@ -837,7 +868,8 @@ IR's undefined conflicting-store semantics and are conservatively token-ordered.
     gather_view = Intrinsics.make_gather_scatter_view(
         tensor_view, shape, gather_scatter_sparse_dim(view), PaddingMode.Undetermined)
     Intrinsics.store_gather_scatter_view(
-        gather_view, tile, latency, allow_tma, _gather_scatter_indices(view), check_bounds)
+        gather_view, tile, latency, allow_tma, _gather_scatter_indices(view), check_bounds,
+        memory_order, memory_scope)
     return tile
 end
 
@@ -853,10 +885,12 @@ end
 
 @inline function _store_reshaped(arr::TileArray{T}, tile::Tile{T},
                                  order, check_bounds, latency, allow_tma,
+                                 memory_order, memory_scope,
                                  indices::NTuple{<:Any, <:Integer}) where {T}
     tv = Intrinsics.make_tensor_view(typeof(arr), arr.ptr, arr.sizes, arr.strides)
     pv = Intrinsics.make_partition_view(tv, size(tile), PaddingMode.Undetermined, order)
-    Intrinsics.store_partition_view(pv, tile, latency, allow_tma, indices, check_bounds)
+    Intrinsics.store_partition_view(pv, tile, latency, allow_tma, indices, check_bounds,
+                                    memory_order, memory_scope)
 end
 
 # Keyword argument version - dispatch to positional version
@@ -864,8 +898,11 @@ end
                        order::Union{NTuple{<:Any, Int}, Nothing}=nothing,
                        check_bounds::Bool=true,
                        latency::Union{Int, Nothing}=nothing,
-                       allow_tma::Union{Bool, Nothing}=nothing) where {T}
-    store(arr, index, tile; order, check_bounds, latency, allow_tma)
+                       allow_tma::Union{Bool, Nothing}=nothing,
+                       memory_order::MemoryOrder.T=MemoryOrder.Weak,
+                       memory_scope::Union{MemScope.T, Nothing}=nothing) where {T}
+    store(arr, index, tile; order, check_bounds, latency, allow_tma,
+          memory_order, memory_scope)
 end
 
 # Scalar store: arr[i, j, ...] = val

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -16,6 +16,22 @@ Base.ndims(::Type{<:AbstractTileArray{<:Any,N}}) where N = N
 Base.eltype(arr::AbstractTileArray) = eltype(typeof(arr))
 Base.ndims(arr::AbstractTileArray) = ndims(typeof(arr))
 
+"""Memory ordering for loads, stores, and atomic operations."""
+@enumx MemoryOrder begin
+    Weak = 0
+    Relaxed = 1
+    Acquire = 2
+    Release = 3
+    AcqRel = 4
+end
+
+"""Scope of threads participating in an ordered memory operation."""
+@enumx MemScope begin
+    Block = 0
+    Device = 1
+    System = 2
+end
+
 
 """
     ArraySpec{N}

--- a/src/language/types.jl
+++ b/src/language/types.jl
@@ -44,6 +44,7 @@ parameter to enable kernel specialization based on array properties.
 - `contiguous::Bool`: Whether stride[1] == 1 (contiguous in first dimension)
 - `stride_div_by::NTuple{N,Int}`: Per-dimension stride divisibility (0 = unknown)
 - `shape_div_by::NTuple{N,Int}`: Per-dimension shape divisibility (0 = unknown)
+- `singleton::NTuple{N,Bool}`: Axes whose size and stride are both one
 - `may_alias_internally::Bool`: Whether two distinct in-bounds indices may
   refer to the same memory location (e.g. a zero or repeated stride).
   `false` asserts the layout is internally non-overlapping, which enables
@@ -59,15 +60,21 @@ Divisibility values enable optimizations:
 - `stride_div_by[i] = 4` means `stride[i]` is divisible by 4 (enables vectorized access)
 - `shape_div_by[i] = 16` means `shape[i]` is divisible by 16 (no tile boundary handling needed)
 """
-struct ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally}
+struct ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally,
+                 Singleton}
     # Validate invariants once per concrete spec type (this struct is a
     # singleton, so the inner constructor runs on every instantiation but
     # the result is then cached as a type parameter). Catches synthetic
-    # specs that combine `contiguous=true` with a `stride_div_by[1]` that
-    # contradicts `stride[1] == 1` — `1 % d == 0` only for `d ∈ {0, 1}`.
-    function ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally}() where
-            {N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally}
-        if Contiguous && N >= 1
+    # specs that combine `contiguous=true` with a contradictory divisor on
+    # the first stride. Singleton axes are exempt because their stride has no
+    # address contribution.
+    function ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy,
+                       MayAliasInternally, Singleton}() where
+            {N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally,
+             Singleton}
+        Singleton isa NTuple{N, Bool} || throw(ArgumentError(
+            "ArraySpec: singleton must be an NTuple{$N, Bool}; got $Singleton"))
+        if Contiguous && N >= 1 && !Singleton[1]
             sdb1 = StrideDivBy[1]
             (sdb1 == 0 || sdb1 == 1) || throw(ArgumentError(
                 "ArraySpec: contiguous=true requires stride_div_by[1] ∈ {0, 1} " *
@@ -75,20 +82,23 @@ struct ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInte
         end
         MayAliasInternally isa Bool || throw(ArgumentError(
             "ArraySpec: MayAliasInternally must be a Bool; got $MayAliasInternally"))
-        new{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally}()
+        new{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally,
+            Singleton}()
     end
 end
 
 # Constructors
 function ArraySpec{N}(alignment::Int, contiguous::Bool,
                       stride_div_by::NTuple{N,Int}, shape_div_by::NTuple{N,Int},
-                      may_alias_internally::Bool=false) where N
-    ArraySpec{N, alignment, contiguous, stride_div_by, shape_div_by, may_alias_internally}()
+                      may_alias_internally::Bool=false,
+                      singleton::NTuple{N,Bool}=ntuple(_ -> false, N)) where N
+    ArraySpec{N, alignment, contiguous, stride_div_by, shape_div_by,
+              may_alias_internally, singleton}()
 end
 
 function ArraySpec(alignment::Int, contiguous::Bool)
     # 0-dimensional fallback (scalar pointers)
-    ArraySpec{0, alignment, contiguous, (), (), false}()
+    ArraySpec{0, alignment, contiguous, (), (), false, ()}()
 end
 
 function ArraySpec{N}(alignment::Int, contiguous::Bool) where N
@@ -97,18 +107,21 @@ function ArraySpec{N}(alignment::Int, contiguous::Bool) where N
 end
 
 # Property access — preserves existing dot-syntax (spec.alignment, etc.)
-function Base.getproperty(spec::ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally},
-                          s::Symbol) where {N, Alignment, Contiguous, StrideDivBy, ShapeDivBy, MayAliasInternally}
+function Base.getproperty(spec::ArraySpec{N, Alignment, Contiguous, StrideDivBy, ShapeDivBy,
+                                         MayAliasInternally, Singleton},
+                          s::Symbol) where {N, Alignment, Contiguous, StrideDivBy, ShapeDivBy,
+                                           MayAliasInternally, Singleton}
     s === :alignment            && return Alignment
     s === :contiguous           && return Contiguous
     s === :stride_div_by        && return StrideDivBy
     s === :shape_div_by         && return ShapeDivBy
     s === :may_alias_internally && return MayAliasInternally
+    s === :singleton            && return Singleton
     getfield(spec, s)
 end
 
 Base.propertynames(::ArraySpec) = (:alignment, :contiguous, :stride_div_by, :shape_div_by,
-                                   :may_alias_internally)
+                                   :may_alias_internally, :singleton)
 Base.ndims(::ArraySpec{N}) where N = N
 
 """
@@ -216,6 +229,7 @@ function compute_array_spec(ptr::Ptr{T}, sizes::NTuple{N, <:Integer},
     # For stride to enable 16-byte vectorization, stride * elem_size must be divisible by 16
     # E.g., for Float32 (4 bytes): stride must be divisible by 4 to get 16-byte alignment
     stride_div_by = ntuple(N) do i
+        sizes[i] == 1 && strides[i] == 1 && return 16 ÷ elem_size
         stride_bytes = strides[i] * elem_size
         # Check if stride in bytes is 16-byte divisible
         if stride_bytes % 16 == 0
@@ -230,8 +244,10 @@ function compute_array_spec(ptr::Ptr{T}, sizes::NTuple{N, <:Integer},
         compute_divisibility(sizes[i], 16)
     end
 
+    singleton = ntuple(i -> sizes[i] == 1 && strides[i] == 1, N)
+
     ArraySpec{N}(alignment, contiguous, stride_div_by, shape_div_by,
-                 layout_may_alias_internally(sizes, strides))
+                 layout_may_alias_internally(sizes, strides), singleton)
 end
 
 function validate_axis_order(order, rank::Integer, first_axis::Integer, context::AbstractString)

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -135,6 +135,35 @@ const bytecode_version_override = let s = @load_preference("bytecode_version", n
     s === nothing ? nothing : VersionNumber(s)
 end
 
+function parse_compiler_timeout(value)
+    value === nothing && return nothing
+    value isa Real && !(value isa Bool) ||
+        throw(ArgumentError("compiler_timeout_seconds must be a positive number"))
+    timeout = Float64(value)
+    isfinite(timeout) && timeout > 0 ||
+        throw(ArgumentError("compiler_timeout_seconds must be a positive number"))
+    return timeout
+end
+
+const compiler_timeout =
+    parse_compiler_timeout(@load_preference("compiler_timeout_seconds", nothing))
+
+"""
+    TileCompilerTimeoutError
+
+The external Tile IR compiler exceeded the configured timeout.
+"""
+struct TileCompilerTimeoutError <: Exception
+    seconds::Float64
+end
+
+function Base.showerror(io::IO, err::TileCompilerTimeoutError)
+    print(io, "tileiras exceeded the ", err.seconds, " second compiler timeout; ",
+          "reducing the tile size may reduce compilation time")
+end
+
+public TileCompilerTimeoutError
+
 """
     tileiras_path() -> String
 
@@ -183,13 +212,29 @@ function tileir_disassembler(; debuginfo::Bool=false)
     return debuginfo ? `$translate --mlir-print-debuginfo` : translate
 end
 
-function run_and_collect(cmd)
+function run_and_collect(cmd; timeout=compiler_timeout)
     stdout = Pipe()
     proc = run(pipeline(ignorestatus(cmd); stdout, stderr=stdout), wait=false)
     close(stdout.in)
     reader = Threads.@spawn String(read(stdout))
-    Base.wait(proc)
+    timed_out = Ref(false)
+    timer = if timeout === nothing
+        nothing
+    else
+        Timer(timeout) do _
+            if process_running(proc)
+                timed_out[] = true
+                kill(proc, Base.SIGKILL)
+            end
+        end
+    end
+    try
+        Base.wait(proc)
+    finally
+        timer === nothing || close(timer)
+    end
     log = strip(fetch(reader))
+    timed_out[] && throw(TileCompilerTimeoutError(timeout))
     return proc, log
 end
 

--- a/test/codegen/gather_scatter_view.jl
+++ b/test/codegen/gather_scatter_view.jl
@@ -17,7 +17,8 @@ AT2d = ct.TileArray{Float32,2,Int32,spec2d}
             view = ct.Intrinsics.make_gather_scatter_view(tv, (4, 8), 1, ct.PaddingMode.Zero)
             rows = ct.arange(4; start=0)
             tile = ct.Intrinsics.load_gather_scatter_view(
-                view, nothing, nothing, (rows, Int32(0)), true)
+                view, nothing, nothing, (rows, Int32(0)), true,
+                ct.MemoryOrder.Weak, nothing)
             Base.donotdelete(tile)
             return
         end
@@ -38,7 +39,8 @@ end
             for _ in 1:n
                 tile = ct.load(a, (1, 1), (4, 4))
                 ct.Intrinsics.store_gather_scatter_view(
-                    view, tile, nothing, nothing, (Int32(0), cols), true)
+                    view, tile, nothing, nothing, (Int32(0), cols), true,
+                    ct.MemoryOrder.Weak, nothing)
             end
             return
         end

--- a/test/codegen/gather_scatter_view.jl
+++ b/test/codegen/gather_scatter_view.jl
@@ -4,6 +4,7 @@
 
 spec2d = ct.ArraySpec{2}(16, true)
 AT2d = ct.TileArray{Float32,2,Int32,spec2d}
+AT2d_f16 = ct.TileArray{Float16,2,Int32,spec2d}
 
 @testset "GatherScatterView — row-major dimension conversion" begin
     @test @filecheck begin
@@ -20,6 +21,20 @@ AT2d = ct.TileArray{Float32,2,Int32,spec2d}
                 view, nothing, nothing, (rows, Int32(0)), true,
                 ct.MemoryOrder.Weak, nothing)
             Base.donotdelete(tile)
+            return
+        end
+    end
+end
+
+@testset "GatherScatterView — implicit store conversion" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "ftof"
+        @check "store_view_tko"
+        code_tiled(Tuple{AT2d, AT2d_f16}; bytecode_version=v"13.3") do a, b
+            rows = ct.arange(4)
+            dst = @view b[rows, Int32(1):Int32(4)]
+            ct.store(dst, ct.load(a, (1, 1), (4, 4)))
             return
         end
     end

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -638,8 +638,8 @@ end
         @testset "independent errors all reported, in program order" begin
             err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int, Int}) do a, n, m
                 pid = ct.bid(1)
-                ct.store(a; index=pid, tile=ct.fill(1f0, (n,)))
-                ct.store(a; index=pid, tile=ct.fill(2f0, (m,)))
+                ct.store(a, pid, ct.fill(1f0, (n,)))
+                ct.store(a, pid, ct.fill(2f0, (m,)))
                 return
             end
             @test err isa ct.CodegenErrors
@@ -655,7 +655,7 @@ end
             err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int}) do a, n
                 pid = ct.bid(1)
                 t = ct.fill(1f0, (n,))
-                ct.store(a; index=pid, tile=t + t)
+                ct.store(a, pid, t + t)
                 return
             end
             @test err isa ct.CodegenErrors
@@ -667,8 +667,8 @@ end
             # The same problem hit on several inlined lines of a single kernel
             # statement is reported once.
             fill_twice(a, pid, n) = begin
-                ct.store(a; index=pid, tile=ct.fill(1f0, (n,)))
-                ct.store(a; index=pid, tile=ct.fill(2f0, (n,)))
+                ct.store(a, pid, ct.fill(1f0, (n,)))
+                ct.store(a, pid, ct.fill(2f0, (n,)))
                 nothing
             end
             err = trycompile(Tuple{ct.TileArray{Float32,1,Int32,spec}, Int}) do a, n

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1466,7 +1466,7 @@ end
             @check "do not evenly divide"
             code_tiled(Tuple{ct.TileArray{UInt8,1,Int32,spec1d}, ct.TileArray{UInt16,1,Int32,spec1d}}) do a, b
                 pid = ct.bid(1)
-                ct.store(b, pid, reinterpret(UInt16, ct.load(a, pid, (1,))))
+                Base.donotdelete(reinterpret(UInt16, ct.load(a, pid, (1,))))
                 return
             end
         end
@@ -1476,7 +1476,7 @@ end
             @check "same number of elements"
             code_tiled(Tuple{ct.TileArray{UInt8,2,Int32,spec2d}, ct.TileArray{UInt16,2,Int32,spec2d}}) do a, b
                 pid = ct.bid(1)
-                ct.store(b, pid, reinterpret(reshape, UInt16, ct.load(a, pid, (1, 4))))
+                Base.donotdelete(reinterpret(reshape, UInt16, ct.load(a, pid, (1, 4))))
                 return
             end
         end
@@ -1836,6 +1836,17 @@ end
                 tile = ct.load(a, pid, (16,))
                 @check "store_view_tko"
                 ct.store(b, pid, tile)
+                return
+            end
+        end
+
+        @test @filecheck begin
+            @check_label "entry"
+            @check "ftof"
+            @check "store_view_tko"
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d},
+                             ct.TileArray{Float16,1,Int32,spec1d}}) do a, b
+                ct.store(b; index=1, tile=ct.load(a, 1, (16,)))
                 return
             end
         end

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2041,6 +2041,28 @@ end
         end
     end
 
+    @testset "scalar literal promotion" begin
+        @test @filecheck begin
+            @check_label "entry"
+            @check "addf {{.*}} : tile<16xf16>"
+            code_tiled(Tuple{ct.TileArray{Float16,1,Int32,spec1d}}) do a
+                tile = ct.load(a, 1, (16,))
+                ct.store(a, 1, tile .+ 2.5)
+                return
+            end
+        end
+
+        @test @filecheck begin
+            @check_label "entry"
+            @check "addi {{.*}} : tile<16xi32>"
+            code_tiled(Tuple{ct.TileArray{Int32,1,Int32,spec1d}}) do a
+                tile = ct.load(a, 1, (16,))
+                ct.store(a, 1, tile .+ 1)
+                return
+            end
+        end
+    end
+
     @testset "remf" begin
         @test @filecheck begin
             @check_label "entry"

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -2020,6 +2020,20 @@ end
     end
 
     @testset "nested broadcast" begin
+        # Reusing the product must keep the multiply separate.
+        @test @filecheck begin
+            @check_label "entry"
+            @check "mulf"
+            @check_not "fma"
+            @check "addf"
+            code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec1d}}) do a
+                tile = ct.load(a, 1, (16,))
+                product = tile .* tile
+                ct.store(a, 1, product .+ product)
+                return
+            end
+        end
+
         # a .+ b .* c → fma (fused by fma_fusion_pass!)
         @test @filecheck begin
             @check_label "entry"

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1461,6 +1461,17 @@ end
             end
         end
 
+        @test_throws "reinterpret does not support Bool" code_tiled(
+            Tuple{ct.TileArray{UInt8,1,Int32,spec1d}}) do a
+            Base.donotdelete(reinterpret(Bool, ct.load(a, 1, (16,))))
+            return
+        end
+        @test_throws "reinterpret does not support Bool" code_tiled(
+            Tuple{ct.TileArray{Bool,1,Int32,spec1d}}) do a
+            Base.donotdelete(reinterpret(UInt8, ct.load(a, 1, (16,))))
+            return
+        end
+
         # Rank-1 scaled: one UInt8 (8 bits) can't fill a UInt16; caught by unpack.
         @test @filecheck throws=ct.CodegenErrors begin
             @check "do not evenly divide"

--- a/test/codegen/token_order.jl
+++ b/test/codegen/token_order.jl
@@ -14,6 +14,35 @@ spec1d_aliasing = ct.ArraySpec{1}(16, true, (0,), (16,), true)
 AT = ct.TileArray{Float32, 1, Int32, spec1d}
 AT_aliasing = ct.TileArray{Float32, 1, Int32, spec1d_aliasing}
 
+@testset "token_order — load/store memory ordering" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "load_view_tko acquire device"
+        @check "store_view_tko release device"
+        code_tiled(Tuple{AT, AT}) do a, b
+            tile = ct.load(a, 1, (16,); memory_order=ct.MemoryOrder.Acquire,
+                           memory_scope=ct.MemScope.Device)
+            ct.store(b, 1, tile; memory_order=ct.MemoryOrder.Release,
+                     memory_scope=ct.MemScope.Device)
+            return
+        end
+    end
+
+    @test_throws "invalid memory order" code_tiled(Tuple{AT}) do a
+        Base.donotdelete(ct.load(a, 1, (16,); memory_order=ct.MemoryOrder.Release,
+                                 memory_scope=ct.MemScope.Device))
+        return
+    end
+    @test_throws "requires a memory scope" code_tiled(Tuple{AT}) do a
+        ct.store(a, 1, ct.load(a, 1, (16,)); memory_order=ct.MemoryOrder.Release)
+        return
+    end
+    @test_throws "cannot specify a memory scope" code_tiled(Tuple{AT}) do a
+        Base.donotdelete(ct.load(a, 1, (16,); memory_scope=ct.MemScope.Device))
+        return
+    end
+end
+
 @testset "token_order — identity IV store is loop-parallel" begin
     # `store(b, i, _)` lowers the index as `subi(iv, 1)` — injective, so the
     # store consumes the pre-loop token and the loop carries no tokens.

--- a/test/codegen/views.jl
+++ b/test/codegen/views.jl
@@ -5,6 +5,19 @@
 
 spec1d = ct.ArraySpec{1}(16, true)
 spec2d = ct.ArraySpec{2}(16, true)
+singleton_spec2d = ct.ArraySpec{2}(16, true, (0, 4), (16, 0), false, (false, true))
+
+@testset "make_tensor_view — singleton stride specialization" begin
+    @test @filecheck begin
+        @check_label "entry"
+        @check "tensor_view<1x?xf32, strides=[4,1]>"
+        code_tiled(Tuple{ct.TileArray{Float32,2,Int32,singleton_spec2d}}) do a
+            tile = ct.load(a, (1, 1), (16, 1))
+            ct.store(a, (1, 1), tile)
+            return
+        end
+    end
+end
 
 @testset "make_tensor_view — imprecise type argument" begin
     # The public codegen path normally keeps this argument precise in the test

--- a/test/device/broadcast.jl
+++ b/test/device/broadcast.jl
@@ -872,3 +872,18 @@ end # type argument broadcasting
         @test Array(c) ≈ max.(Array(a), Array(b))
     end
 end
+@testset "scalar literal promotion" begin
+    function loose_literals(a::ct.TileArray{Float16,1}, b::ct.TileArray{Int32,1})
+        a_tile = ct.load(a, 1, (16,))
+        b_tile = ct.load(b, 1, (16,))
+        ct.store(a, 1, a_tile .+ 2.5)
+        ct.store(b, 1, b_tile .+ 1)
+        return
+    end
+
+    a = CUDA.fill(Float16(1), 16)
+    b = CUDA.fill(Int32(1), 16)
+    @cuda backend=cuTile loose_literals(a, b)
+    @test Array(a) == fill(Float16(3.5), 16)
+    @test Array(b) == fill(Int32(2), 16)
+end

--- a/test/device/gather_scatter.jl
+++ b/test/device/gather_scatter.jl
@@ -47,6 +47,25 @@ end
     @test Array(b) ≈ Array(a)
 end
 
+@testset "implicit store and scatter conversion" begin
+    function convert_store_kernel(a::ct.TileArray{Float32,1},
+                                  b::ct.TileArray{Float16,1},
+                                  c::ct.TileArray{Float16,1})
+        tile = ct.load(a, 1, (16,))
+        ct.store(b, 1, tile)
+        ct.scatter(c, ct.arange(16), tile)
+        return
+    end
+
+    a = CUDA.rand(Float32, 16)
+    b = CUDA.zeros(Float16, 16)
+    c = CUDA.zeros(Float16, 16)
+    @cuda backend=cuTile convert_store_kernel(a, b, c)
+    expected = Float16.(Array(a))
+    @test Array(b) == expected
+    @test Array(c) == expected
+end
+
 #=========================================================================
  Gather/scatter with OOB bounds checking (regression: mask emission bug
  meant bounds checks were silently skipped — load_ptr_tko always loaded

--- a/test/host/cache.jl
+++ b/test/host/cache.jl
@@ -10,26 +10,16 @@ const DC = cuTile.DiskCache
     end
 
     @testset "configuration" begin
-        @test DC.cache_setting_disabled("")
-        @test DC.cache_setting_disabled("0")
-        @test DC.cache_setting_disabled(" OFF ")
-        @test DC.cache_setting_disabled("none")
-        @test !DC.cache_setting_disabled("cache-dir")
-
-        @test DC.parse_cache_size("4096") == 4096
+        @test DC.parse_cache_size(4096) == 4096
         @test_throws ArgumentError DC.parse_cache_size("0")
-        @test_throws ArgumentError DC.parse_cache_size("not-a-size")
+        @test_throws ArgumentError DC.parse_cache_size(true)
+        @test_throws ArgumentError DC.parse_cache_size(0)
+        @test_throws ArgumentError DC.parse_cache_dir("")
 
         mktempdir() do dir
-            withenv("JULIA_CUTILE_CACHE_DIR" => dir) do
-                @test DC.configured_cache_dir() == abspath(dir)
-            end
-            withenv("JULIA_CUTILE_CACHE_DIR" => "off") do
-                @test DC.configured_cache_dir() === nothing
-            end
-            withenv("JULIA_CUTILE_CACHE_SIZE" => "8192") do
-                @test DC.configured_mapsize() == 8192
-            end
+            @test DC.configured_cache_dir(true, dir) == abspath(dir)
+            @test DC.configured_cache_dir(false, dir) === nothing
+            @test DC.configured_mapsize(8192) == 8192
 
             write(joinpath(dir, "data.mdb"), "stale")
             write(joinpath(dir, "lock.mdb"), "stale")

--- a/test/host/launch.jl
+++ b/test/host/launch.jl
@@ -1,0 +1,15 @@
+@testset "compiler timeout" begin
+    @test cuTile.parse_compiler_timeout(nothing) === nothing
+    @test cuTile.parse_compiler_timeout(1) == 1.0
+    @test_throws ArgumentError cuTile.parse_compiler_timeout(true)
+    @test_throws ArgumentError cuTile.parse_compiler_timeout(0)
+
+    err = try
+        cuTile.run_and_collect(`$(Base.julia_cmd()) -e 'sleep(10)'`; timeout=0.1)
+        nothing
+    catch err
+        err
+    end
+    @test err isa cuTile.TileCompilerTimeoutError
+    @test occursin("reducing the tile size", sprint(showerror, err))
+end

--- a/test/types.jl
+++ b/test/types.jl
@@ -79,6 +79,12 @@ end
     @test ct.array_spec(ct.sliced_arraytype(T; stepped_axis=2)).contiguous
     @test ct.array_spec(ct.sliced_arraytype(T; stepped_axis=1)).stride_div_by == (1, 4)
 
+    host_ptr = reinterpret(Ptr{Float32}, C_NULL + 128)
+    singleton = ct.compute_array_spec(host_ptr, (1, 16), (1, 1))
+    @test singleton.contiguous
+    @test singleton.singleton == (true, false)
+    @test singleton.stride_div_by == (4, 0)
+
     ptr = CUDA.CuPtr{Float32}(0)
     small = TestDeviceArray(ptr, (Int64(16), Int64(8)), (Int64(1), Int64(16)))
     wide = TestDeviceArray(ptr, (Int64(16), Int64(8)),


### PR DESCRIPTION
This fills several small gaps in the cuTile API before the next breaking release.

Loads and stores now support explicit memory ordering and scope. Stores and
scatters also convert values to the destination element type, while scalar
broadcasts stay in the tile element type.

Singleton dimensions now carry more useful stride information, allowing
`tileiras` to select better memory operations.

Compiler configuration is now more Julian: the new `tileiras` timeout and the
persistent disk-cache settings use package preferences instead of environment
variables.

Finally, this adds clearer handling for unsupported `Bool` reinterpretation and
covers an edge case in FMA rewriting where a multiplication has multiple uses.

This intentionally changes `ArraySpec` and replaces the previous cache
environment variables without compatibility shims.