### PR TITLE
Unify Tile IR toolchain version handling

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -49,9 +49,11 @@ cuTile toolchain:
 ```
 
 The bytecode version is probed from the `tileiras` binary in use, and can be
-overridden with the `bytecode_version` preference; `cuTile.bytecode_version()`
-returns the value on its own. Which features are available at which version is
-documented in [Compatibility](man/compatibility.md).
+set to an older supported version with the `bytecode_version` preference;
+`cuTile.bytecode_version()` returns the selected target and
+`cuTile.tileiras_version()` returns the compiler version. Which features are
+available at which version is documented in
+[Compatibility](man/compatibility.md).
 
 To run the test suite:
 

--- a/docs/src/lib/essentials.md
+++ b/docs/src/lib/essentials.md
@@ -33,6 +33,7 @@ TileOrFloat
 ## Toolchain
 
 ```@docs
+tileiras_version
 bytecode_version
 versioninfo
 ```

--- a/docs/src/man/compatibility.md
+++ b/docs/src/man/compatibility.md
@@ -25,7 +25,9 @@ artifacts, including `tileiras`.
 
 cuTile.jl can emit bytecode versions **v13.1 through v13.4**. By default it
 probes the `tileiras` binary in use and emits the newest version that binary
-accepts; the `bytecode_version` preference overrides this.
+accepts; the `bytecode_version` preference selects a version accepted by
+that binary. cuTile rejects preferences unsupported by either the package or
+the selected `tileiras`.
 `cuTile.versioninfo()` reports what will be used.
 
 Each architecture has a minimum bytecode version below which Tile IR is not

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -160,7 +160,7 @@ corresponding compiled result.
 
 Across sessions, the Tile IR → CUBIN step is cached on disk, so the second run
 of a program skips the `tileiras` invocation entirely. The cache is
-content-addressed on the bytecode plus the toolkit version, architecture and
+content-addressed on the bytecode plus the compiler identity, architecture and
 optimization level, so a toolchain upgrade simply produces new entries rather
 than stale hits. The `disk_cache` preference disables it when set to `false`;
 `cache_dir` overrides its scratch directory, and `cache_size_bytes` overrides

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -370,23 +370,23 @@ function encode_PrintTkoOp!(cb::CodeBuilder,
                              format_string::String)
     encode_varint!(cb.buf, Opcode.PrintOp)
     # Variadic result types: [token] in v13.2+, empty in v13.1
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_typeid_seq!(cb.buf, [token_type])
     else
         encode_typeid_seq!(cb.buf, TypeId[])
     end
     # Flags: bit 0 = has input token (v13.2+ only)
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_varint!(cb.buf, token !== nothing ? 1 : 0)
     end
     # Attributes: format string
     encode_opattr_str!(cb, format_string)
     # Operands: sized variadic args + optional token
     encode_sized_operands!(cb.buf, args)
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_optional_operand!(cb.buf, token)
     end
-    num_results = cb.version >= v"13.2" ? 1 : 0
+    num_results = bytecode_version(cb) >= v"13.2" ? 1 : 0
     result = new_op!(cb, num_results)
     return result  # Value for v13.2+, nothing for v13.1
 end
@@ -477,8 +477,8 @@ Opcode: 115 (Tile IR v13.3+)
 """
 function encode_MakeGatherScatterViewOp!(cb::CodeBuilder, result_type::TypeId,
                                          tensor_view::Value)
-    cb.version >= v"13.3" ||
-        throw(IRError("MakeGatherScatterViewOp requires Tile IR v13.3+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.3" ||
+        throw(IRError("MakeGatherScatterViewOp requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.MakeGatherScatterViewOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, tensor_view)
@@ -492,8 +492,8 @@ Create a strided view from a tensor view.
 Opcode: 116 (Tile IR v13.3+)
 """
 function encode_MakeStridedViewOp!(cb::CodeBuilder, result_type::TypeId, tensor_view::Value)
-    cb.version >= v"13.3" ||
-        throw(IRError("MakeStridedViewOp requires Tile IR v13.3+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.3" ||
+        throw(IRError("MakeStridedViewOp requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.MakeStridedViewOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, tensor_view)
@@ -583,10 +583,10 @@ function encode_LoadViewTkoOp!(cb::CodeBuilder,
     if optimization_hints !== nothing
         encode_opattr_optimization_hints!(cb, optimization_hints)
     end
-    if cb.version >= v"13.4"
+    if bytecode_version(cb) >= v"13.4"
         encode_dense_bool_array!(cb, inbounds)
     elseif any(inbounds)
-        throw(IRError("load: check_bounds=false requires Tile IR v13.4+, got v$(cb.version)"))
+        throw(IRError("load: check_bounds=false requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
     end
 
     # Operands
@@ -638,10 +638,10 @@ function encode_StoreViewTkoOp!(cb::CodeBuilder,
     if optimization_hints !== nothing
         encode_opattr_optimization_hints!(cb, optimization_hints)
     end
-    if cb.version >= v"13.4"
+    if bytecode_version(cb) >= v"13.4"
         encode_dense_bool_array!(cb, inbounds)
     elseif any(inbounds)
-        throw(IRError("store: check_bounds=false requires Tile IR v13.4+, got v$(cb.version)"))
+        throw(IRError("store: check_bounds=false requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
     end
 
     # Operands
@@ -911,8 +911,8 @@ Floating-point power with an integer exponent (base^exponent).
 Opcode: 130
 """
 function encode_FPowIOp!(cb::CodeBuilder, result_type::TypeId, base::Value, exponent::Value)
-    cb.version >= v"13.4" ||
-        throw(IRError("cuda_tile.fpowi requires Tile IR v13.4+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.4" ||
+        throw(IRError("cuda_tile.fpowi requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.FPowIOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, base)
@@ -927,8 +927,8 @@ Floating-point element-wise atan2(x, y). Available in Tile IR v13.2+.
 Opcode: 110
 """
 function encode_Atan2Op!(cb::CodeBuilder, result_type::TypeId, x::Value, y::Value)
-    cb.version >= v"13.2" ||
-        throw(IRError("cuda_tile.atan2 requires Tile IR v13.2+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.2" ||
+        throw(IRError("cuda_tile.atan2 requires Tile IR v13.2+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.Atan2Op)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, x)
@@ -1013,11 +1013,11 @@ function encode_ExpOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
     encode_typeid!(cb.buf, result_type)
     # v13.3 added a `rounding_mode` attribute (approx/full). Prior versions
     # only support `full`, so refuse to silently downgrade `approx`.
-    if cb.version >= v"13.3"
+    if bytecode_version(cb) >= v"13.3"
         encode_enum!(cb.buf, rounding_mode)
     else
         rounding_mode == RoundingMode.Full ||
-            throw(IRError("ExpOp rounding_mode != Full requires Tile IR v13.3+, got v$(cb.version)"))
+            throw(IRError("ExpOp rounding_mode != Full requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     end
     encode_operand!(cb.buf, source)
     return new_op!(cb)
@@ -1300,7 +1300,7 @@ function encode_ForOp!(body::Function, cb::CodeBuilder,
     encode_varint!(cb.buf, Opcode.ForOp)
     encode_typeid_seq!(cb.buf, result_types)
     # Flags
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_varint!(cb.buf, unsigned_cmp ? 1 : 0)
     end
     # Operands: lower, upper, step, init_values...
@@ -1346,10 +1346,10 @@ function encode_MmaFOp!(cb::CodeBuilder, result_type::TypeId, lhs::Value, rhs::V
     encode_typeid!(cb.buf, result_type)
     # v13.3 added `fast_acc` flag (Hopper FP8 fast accumulation hint),
     # encoded as a varint flags field between the result type and operands.
-    if cb.version >= v"13.3"
+    if bytecode_version(cb) >= v"13.3"
         encode_varint!(cb.buf, fast_acc ? 1 : 0)
     else
-        fast_acc && throw(IRError("MmaFOp fast_acc requires Tile IR v13.3+, got v$(cb.version)"))
+        fast_acc && throw(IRError("MmaFOp fast_acc requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     end
     encode_operand!(cb.buf, lhs)
     encode_operand!(cb.buf, rhs)
@@ -1391,8 +1391,8 @@ Opcode: 114
 function encode_MmaFScaledOp!(cb::CodeBuilder, result_type::TypeId,
                               lhs::Value, rhs::Value, acc::Value,
                               lhs_scale::Value, rhs_scale::Value)
-    cb.version >= v"13.3" ||
-        throw(IRError("MmaFScaledOp requires Tile IR v13.3+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.3" ||
+        throw(IRError("MmaFScaledOp requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.MmaFScaledOp)
     encode_typeid!(cb.buf, result_type)
     encode_operand!(cb.buf, lhs)
@@ -1790,7 +1790,7 @@ function encode_NegIOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
                         overflow::IntegerOverflow.T=IntegerOverflow.None)
     encode_varint!(cb.buf, Opcode.NegIOp)
     encode_typeid!(cb.buf, result_type)
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_enum!(cb.buf, overflow)
     end
     encode_operand!(cb.buf, source)
@@ -1857,7 +1857,7 @@ function encode_FToIOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
                         rounding_mode::RoundingMode.T=RoundingMode.NearestIntToZero)
     encode_varint!(cb.buf, Opcode.FToIOp)
     encode_typeid!(cb.buf, result_type)
-    cb.version >= v"13.4" && encode_varint!(cb.buf, 0) # saturating=false
+    bytecode_version(cb) >= v"13.4" && encode_varint!(cb.buf, 0) # saturating=false
     encode_enum!(cb.buf, signedness)
     encode_enum!(cb.buf, rounding_mode)
     encode_operand!(cb.buf, source)
@@ -1971,8 +1971,8 @@ end
 
 function encode_InsertOp!(cb::CodeBuilder, result_type::TypeId, source::Value,
                           destination::Value, indices::Vector{Value})
-    cb.version >= v"13.4" ||
-        throw(IRError("cuda_tile.insert requires Tile IR v13.4+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.4" ||
+        throw(IRError("cuda_tile.insert requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.InsertOp)
     encode_typeid_seq!(cb.buf, [result_type])
     encode_varint!(cb.buf, 2 + length(indices))
@@ -2163,8 +2163,8 @@ function encode_AtomicRedViewTkoOp!(cb::CodeBuilder,
                                     memory_ordering::MemoryOrderingSemantics.T=MemoryOrderingSemantics.Relaxed,
                                     memory_scope::MemoryScope.T=MemoryScope.Device,
                                     mode::AtomicRMWMode.T=AtomicRMWMode.ADD)
-    cb.version >= v"13.3" ||
-        throw(IRError("AtomicRedViewTkoOp requires Tile IR v13.3+, got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.3" ||
+        throw(IRError("AtomicRedViewTkoOp requires Tile IR v13.3+, got v$(bytecode_version(cb))"))
     encode_varint!(cb.buf, Opcode.AtomicRedViewTkoOp)
     encode_typeid_seq!(cb.buf, [token_type])
     flags = token !== nothing ? 1 : 0
@@ -2285,7 +2285,7 @@ function encode_TanHOp!(cb::CodeBuilder, result_type::TypeId, source::Value;
                         rounding_mode::RoundingMode.T=RoundingMode.Full)
     encode_varint!(cb.buf, Opcode.TanHOp)
     encode_typeid!(cb.buf, result_type)
-    if cb.version >= v"13.2"
+    if bytecode_version(cb) >= v"13.2"
         encode_enum!(cb.buf, rounding_mode)
     end
     encode_operand!(cb.buf, source)

--- a/src/bytecode/types.jl
+++ b/src/bytecode/types.jl
@@ -1,5 +1,14 @@
 # Type system for Tile IR bytecode
 
+const SUPPORTED_BYTECODE_VERSIONS = (v"13.1", v"13.2", v"13.3", v"13.4")
+
+function validate_bytecode_version(version::VersionNumber)
+    version in SUPPORTED_BYTECODE_VERSIONS || throw(ArgumentError(
+        "unsupported Tile IR bytecode version v$version; supported versions are " *
+        join(("v$v" for v in SUPPORTED_BYTECODE_VERSIONS), ", ")))
+    return version
+end
+
 # Type ID wrapper
 struct TypeId
     id::Int
@@ -99,12 +108,15 @@ mutable struct TypeTable
 end
 
 function TypeTable(; version::VersionNumber)
+    validate_bytecode_version(version)
     table = TypeTable(Dict{Vector{UInt8}, TypeId}(), 0, version)
     # Pre-register I1 and I32 at fixed positions
     _predefine!(table, [SimpleType.I1], I1_TYPE_ID)
     _predefine!(table, [SimpleType.I32], I32_TYPE_ID)
     return table
 end
+
+bytecode_version(table::TypeTable) = table.version
 
 function _predefine!(table::TypeTable, tag::Vector{UInt8}, expected_id::TypeId)
     actual = _get_or_create!(table, tag)
@@ -177,13 +189,13 @@ F64(table::TypeTable) = simple_type!(table, SimpleType.F64)
 F8E4M3FN(table::TypeTable) = simple_type!(table, SimpleType.F8E4M3FN)
 F8E5M2(table::TypeTable) = simple_type!(table, SimpleType.F8E5M2)
 function F8E8M0FNU(table::TypeTable)
-    table.version >= v"13.2" ||
-        throw(IRError("Float8_E8M0FNU requires Tile IR bytecode v13.2+, got v$(table.version)"))
+    bytecode_version(table) >= v"13.2" ||
+        throw(IRError("Float8_E8M0FNU requires Tile IR bytecode v13.2+, got v$(bytecode_version(table))"))
     simple_type!(table, SimpleType.F8E8M0FNU)
 end
 function F4E2M1FN(table::TypeTable)
-    table.version >= v"13.3" ||
-        throw(IRError("Float4_E2M1FN requires Tile IR bytecode v13.3+, got v$(table.version)"))
+    bytecode_version(table) >= v"13.3" ||
+        throw(IRError("Float4_E2M1FN requires Tile IR bytecode v13.3+, got v$(bytecode_version(table))"))
     simple_type!(table, SimpleType.F4E2M1FN)
 end
 Token(table::TypeTable) = simple_type!(table, SimpleType.Token)
@@ -197,7 +209,7 @@ end
 
 function pointer_type!(table::TypeTable, pointee::TypeId)
     buf = UInt8[CompositeType.Pointer]
-    table.version >= v"13.4" && encode_varint!(buf, 0) # no PtrAttr
+    bytecode_version(table) >= v"13.4" && encode_varint!(buf, 0) # no PtrAttr
     encode_varint!(buf, pointee.id)
     _get_or_create!(table, buf)
 end
@@ -206,7 +218,7 @@ function tensor_view_type!(table::TypeTable, dtype::TypeId,
                            shape::TileShape,
                            strides::AbstractVector{<:Integer})
     buf = UInt8[CompositeType.TensorView]
-    table.version >= v"13.4" && encode_varint!(buf, 0) # no PtrAttr
+    bytecode_version(table) >= v"13.4" && encode_varint!(buf, 0) # no PtrAttr
     encode_varint!(buf, dtype.id)
     encode_int_list!(buf, collect(shape), 8)
     encode_int_list!(buf, strides, 8)
@@ -219,7 +231,7 @@ function partition_view_type!(table::TypeTable,
                               dim_map::AbstractVector{<:Integer},
                               padding_value::PaddingValue.T)
     buf = UInt8[CompositeType.PartitionView]
-    if table.version >= v"13.3"
+    if bytecode_version(table) >= v"13.3"
         # Unified bitfield encoding: an `optional_flags` varint up front
         # gates a bare padding byte at the tail (no separate present flag).
         encode_optional_flags!(buf, padding_value)
@@ -242,8 +254,8 @@ function strided_view_type!(table::TypeTable,
                             tensor_view::TypeId,
                             dim_map::AbstractVector{<:Integer},
                             padding_value::PaddingValue.T)
-    table.version >= v"13.3" ||
-        throw(IRError("StridedView requires Tile IR bytecode v13.3+, got v$(table.version)"))
+    bytecode_version(table) >= v"13.3" ||
+        throw(IRError("StridedView requires Tile IR bytecode v13.3+, got v$(bytecode_version(table))"))
     buf = UInt8[CompositeType.StridedView]
     encode_optional_flags!(buf, padding_value)
     encode_int_list!(buf, collect(tile_shape), 4)
@@ -259,8 +271,8 @@ function gather_scatter_view_type!(table::TypeTable,
                                    tensor_view::TypeId,
                                    sparse_dim::Integer,
                                    padding_value::PaddingValue.T)
-    table.version >= v"13.3" ||
-        throw(IRError("GatherScatterView requires Tile IR bytecode v13.3+, got v$(table.version)"))
+    bytecode_version(table) >= v"13.3" ||
+        throw(IRError("GatherScatterView requires Tile IR bytecode v13.3+, got v$(bytecode_version(table))"))
     sparse_dim >= 0 || throw(IRError("GatherScatterView sparse dimension must be non-negative, got $sparse_dim"))
     sparse_dim < length(tile_shape) ||
         throw(IRError("GatherScatterView sparse dimension $sparse_dim is outside rank $(length(tile_shape))"))

--- a/src/bytecode/writer.jl
+++ b/src/bytecode/writer.jl
@@ -157,11 +157,10 @@ mutable struct CodeBuilder
     next_value_id::Int
     cur_debug_attr::DebugAttrId
     num_ops::Int
-    version::VersionNumber
 end
 
-function CodeBuilder(string_table::StringTable, constant_table::ConstantTable, type_table::TypeTable;
-                     version::VersionNumber)
+function CodeBuilder(string_table::StringTable, constant_table::ConstantTable,
+                     type_table::TypeTable)
     CodeBuilder(
         UInt8[],
         string_table,
@@ -170,10 +169,11 @@ function CodeBuilder(string_table::StringTable, constant_table::ConstantTable, t
         DebugAttrId[],
         0,
         DebugAttrId(0),  # No debug info
-        0,
-        version
+        0
     )
 end
+
+bytecode_version(cb::CodeBuilder) = bytecode_version(cb.type_table)
 
 """
 Create a new SSA value(s) for an operation result.
@@ -443,7 +443,6 @@ mutable struct BytecodeWriter
     debug_attr_table::DebugAttrTable
     debug_info::Vector{Vector{DebugAttrId}}
     num_functions::Int
-    version::VersionNumber
 end
 
 function BytecodeWriter(; version::VersionNumber)
@@ -455,10 +454,11 @@ function BytecodeWriter(; version::VersionNumber)
         TypeTable(; version),
         DebugAttrTable(string_table),
         Vector{Vector{DebugAttrId}}[],
-        0,
-        version
+        0
     )
 end
+
+bytecode_version(writer::BytecodeWriter) = bytecode_version(writer.type_table)
 
 """
 Write the bytecode header.
@@ -645,8 +645,7 @@ function add_function!(writer::BytecodeWriter, func_buf::Vector{UInt8},
     end
 
     # Create code builder for function body
-    cb = CodeBuilder(writer.string_table, writer.constant_table, writer.type_table;
-                     version=writer.version)
+    cb = CodeBuilder(writer.string_table, writer.constant_table, writer.type_table)
 
     return cb
 end
@@ -775,9 +774,10 @@ function encode_entry_hints(writer::BytecodeWriter, sm_arch::Union{VersionNumber
             "$(format_sm_arch(sm_arch))"))
     end
 
-    if hints.num_worker_warps !== nothing && writer.version < v"13.3"
+    version = bytecode_version(writer)
+    if hints.num_worker_warps !== nothing && version < v"13.3"
         throw(ArgumentError(
-            "num_worker_warps requires Tile IR bytecode v13.3+, got v$(writer.version)"))
+            "num_worker_warps requires Tile IR bytecode v13.3+, got v$version"))
     end
 
     # Build items list (only non-nothing values)
@@ -791,7 +791,7 @@ function encode_entry_hints(writer::BytecodeWriter, sm_arch::Union{VersionNumber
     # so the CUBIN compiler knows the target architecture. On v13.3+ the hints
     # are keyed under "default" instead, applying them to every architecture.
     sm_arch === nothing && isempty(items) && return nothing
-    arch = if writer.version >= v"13.3"
+    arch = if version >= v"13.3"
         "default"
     else
         arch_ver = @something sm_arch throw(ArgumentError("sm_arch must be specified when entry hints are present"))

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -15,8 +15,8 @@ entirely.
   that directory or `Scratch.delete_scratch!`.
 - The `disk_cache`, `cache_dir`, and `cache_size_bytes` preferences configure
   or disable the cache. The default map size is 1 GiB.
-- Keys: `sha256(SCHEMA_VERSION || toolkit_version || sm_arch || opt_level || bytecode)`.
-  Any input change produces a fresh key, so old-toolkit entries never
+- Keys: `sha256(SCHEMA_VERSION || compiler_identity || sm_arch || opt_level || bytecode)`.
+  Any input change produces a fresh key, so entries from other compiler builds never
   match on lookup. Bump [`SCHEMA_VERSION`](@ref) to invalidate every
   existing entry on the next access (e.g. after a value-framing change).
 - Values: prefixed records in the LMDB keyspace. Data records hold CUBIN
@@ -533,23 +533,22 @@ and LRU eventually evicts them.
 const SCHEMA_VERSION = UInt32(3)
 
 """
-    compute_key(bytecode, sm_arch, opt_level, toolkit_version) -> Vector{UInt8}
+    compute_key(bytecode, sm_arch, opt_level, compiler_identity) -> Vector{UInt8}
 
 Derive a SHA-256 content-addressable cache key for a Tile IR compilation.
 The key covers the bytecode plus every input that changes the resulting
-CUBIN: target arch, opt level, and the `tileiras` toolkit version
-(typically the full `--version` stdout; see `cuTile.toolkit_version()`).
+CUBIN: target arch, opt level, and the complete `tileiras --version` output.
 
-Any change to those inputs produces a fresh key. Old-toolkit entries no
-longer match on lookup, and eventually evict via LRU. The
+Any change to those inputs produces a fresh key. Entries from other compiler
+builds no longer match on lookup, and eventually evict via LRU. The
 [`SCHEMA_VERSION`](@ref) prefix lets us invalidate every entry at once
 when the value layout changes.
 """
 function compute_key(bytecode::Vector{UInt8}, sm_arch::VersionNumber,
-                     opt_level::Integer, toolkit_version::AbstractString)
+                     opt_level::Integer, compiler_identity::AbstractString)
     data = UInt8[]
     append_uint32_be!(data, SCHEMA_VERSION)
-    append_field!(data, codeunits(toolkit_version))
+    append_field!(data, codeunits(compiler_identity))
     append_field!(data, codeunits(string(sm_arch)))
     append_uint32_be!(data, opt_level)
     append_field!(data, bytecode)

--- a/src/compiler/codegen/kernel.jl
+++ b/src/compiler/codegen/kernel.jl
@@ -21,12 +21,12 @@ function emit_kernel!(writer::BytecodeWriter, func_buf::Vector{UInt8},
                       cache::CacheView,
                       const_argtypes::Union{Vector{Any}, Nothing} = nothing)
     tt = writer.type_table
-    cb = CodeBuilder(writer.string_table, writer.constant_table, tt; version=writer.version)
+    cb = CodeBuilder(writer.string_table, writer.constant_table, tt)
 
     # Create debug info emitter
     debug_emitter = DebugInfoEmitter(writer.debug_attr_table)
 
-    ctx = CGCtx(; cb, tt, sci, sm_arch, cache, debug_emitter, linkage_name=name)
+    ctx = CGCtx(; cb, sci, sm_arch, cache, debug_emitter, linkage_name=name)
 
     # Determine which argument positions are const-seeded
     # const_argtypes is 1-indexed: [Const(f), arg2, arg3, ...]
@@ -401,7 +401,7 @@ function emit_subprogram!(ctx::CGCtx, func, arg_types::Vector,
     sub_divby, sub_bounds = run_passes!(sci)
 
     # 3. Create sub-context (inherits active fpmode from caller)
-    sub_ctx = CGCtx(; ctx.cb, ctx.tt, sci,
+    sub_ctx = CGCtx(; cb=ctx.cb, sci,
                       ctx.token_type,
                       ctx.type_cache, ctx.sm_arch,
                       ctx.cache)

--- a/src/compiler/intrinsics.jl
+++ b/src/compiler/intrinsics.jl
@@ -68,7 +68,7 @@ function create_optimization_hints(ctx::CGCtx, latency::Union{Int, Nothing}, all
     isnothing(latency) && allow_tma && return nothing
     isnothing(latency) || 1 <= latency <= 10 || throw(IRError("latency must be between 1 and 10, got $latency"))
     hints = LoadStoreHints(; latency, allow_tma)
-    return make_load_store_hints(ctx.sm_arch, ctx.cb.version, hints)
+    return make_load_store_hints(ctx.sm_arch, bytecode_version(ctx), hints)
 end
 
 # Check if an intrinsic argument is a mask (Tile{Bool}) or nothing.

--- a/src/compiler/intrinsics/atomics.jl
+++ b/src/compiler/intrinsics/atomics.jl
@@ -222,10 +222,10 @@ function check_atomic_bf16_support(ctx::CGCtx, mode::AtomicRMWMode.T, @nospecial
             "atomic add on BFloat16 requires Hopper (sm_90) or newer, got " *
             format_sm_arch(ctx.sm_arch)))
     end
-    if ctx.cb.version < v"13.3"
+    if bytecode_version(ctx) < v"13.3"
         throw(IRError(
             "atomic add on BFloat16 requires Tile IR bytecode ≥ 13.3, got " *
-            "v$(ctx.cb.version)"))
+            "v$(bytecode_version(ctx))"))
     end
 end
 
@@ -234,8 +234,8 @@ function emit_atomic_red_view!(ctx::CGCtx, args::AbstractVector,
     cb = ctx.cb
     tt = ctx.tt
 
-    cb.version >= v"13.3" ||
-        throw(IRError("$name requires Tile IR bytecode ≥ 13.3 (tileiras too old), got v$(cb.version)"))
+    bytecode_version(cb) >= v"13.3" ||
+        throw(IRError("$name requires Tile IR bytecode v13.3+, got v$(bytecode_version(cb))"))
 
     input_token = extract_token_arg!(ctx, args)
 

--- a/src/compiler/intrinsics/conversions.jl
+++ b/src/compiler/intrinsics/conversions.jl
@@ -81,8 +81,8 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.pack), args)
     tt = ctx.tt
 
     source = @something emit_value!(ctx, args[1]) throw(IRError("pack: cannot resolve source"))
-    tt.version >= v"13.3" ||
-        throw(IRError("cuda_tile.pack requires Tile IR bytecode v13.3+, got v$(tt.version)"))
+    bytecode_version(tt) >= v"13.3" ||
+        throw(IRError("cuda_tile.pack requires Tile IR bytecode v13.3+, got v$(bytecode_version(tt))"))
     length(source.shape) == 1 ||
         throw(IRError("pack: requires a rank-1 tile, got a $(length(source.shape))-D tile"))
 
@@ -130,8 +130,8 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.unpack), args)
 
     source = @something emit_value!(ctx, args[1]) throw(IRError("unpack: cannot resolve source"))
     target_type = @something get_constant(ctx, args[2]) throw(IRError("unpack: requires compile-time target type"))
-    tt.version >= v"13.3" ||
-        throw(IRError("cuda_tile.unpack requires Tile IR bytecode v13.3+, got v$(tt.version)"))
+    bytecode_version(tt) >= v"13.3" ||
+        throw(IRError("cuda_tile.unpack requires Tile IR bytecode v13.3+, got v$(bytecode_version(tt))"))
     length(source.shape) == 1 ||
         throw(IRError("unpack: requires a rank-1 tile, got a $(length(source.shape))-D tile"))
 
@@ -302,7 +302,7 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.ftof), args)
     end
     source_tag = simple_type_tag(tt, tile_eltype_id(tt, source.type_id))
     target_tag = simple_type_tag(tt, dtype)
-    validate_ftof_rounding(source_tag, target_tag, rounding_mode, tt.version)
+    validate_ftof_rounding(source_tag, target_tag, rounding_mode, bytecode_version(tt))
     result_v = encode_FToFOp!(cb, result_type_id, source.v; rounding_mode)
     src_type = CC.widenconst(source.jltype)
     result_jltype = similar_type(src_type, target_type)

--- a/src/compiler/intrinsics/views.jl
+++ b/src/compiler/intrinsics/views.jl
@@ -485,8 +485,8 @@ end
 function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_gather_scatter_view), args)
     tensor_view = emit_value!(ctx, args[1])
     tensor_view === nothing && throw(IRError("make_gather_scatter_view() requires a TensorView argument"))
-    ctx.tt.version >= v"13.3" ||
-        throw(IRError("make_gather_scatter_view requires Tile IR bytecode v13.3+, got v$(ctx.tt.version)"))
+    bytecode_version(ctx) >= v"13.3" ||
+        throw(IRError("make_gather_scatter_view requires Tile IR bytecode v13.3+, got v$(bytecode_version(ctx))"))
 
     shape = @something get_constant(ctx, args[2]) throw(IRError("make_gather_scatter_view() shape must be a compile-time constant"))
     shape isa Tuple || throw(IRError("make_gather_scatter_view() shape must be a tuple, got $(typeof(shape))"))
@@ -607,8 +607,8 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.make_tensor_view), args
     ndim = ndims(T)
     spec = array_spec(T)
     I = indextype(T)
-    I === Int64 && tt.version < v"13.3" &&
-        throw(IRError("Int64-indexed TileArray requires Tile IR bytecode v13.3+, got v$(tt.version)"))
+    I === Int64 && bytecode_version(tt) < v"13.3" &&
+        throw(IRError("Int64-indexed TileArray requires Tile IR bytecode v13.3+, got v$(bytecode_version(tt))"))
     dtype = lookup_dtype!(tt, elem_T)
 
     # Resolve operands. ptr is a single Value; sizes/strides expand to N values.

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -5,10 +5,14 @@
 export code_tiled
 public code_typed, code_ircode, code_structured
 
-function disassemble_tileir(bytecode::Vector{UInt8}; debuginfo::Bool=false)::String
-    disasm = @something tileir_disassembler(; debuginfo) throw(ErrorException(
-        "no `tileirdisasm` next to $(tileiras_path()); disassembling Tile IR " *
-        "requires a CUDA 13.4+ toolkit when the `tileiras` preference is set"))
+function disassemble_tileir(bytecode::Vector{UInt8}, version::VersionNumber;
+                            debuginfo::Bool=false)::String
+    validate_bytecode_version(version)
+    disassembler_version = tileir_disassembler_version()
+    version <= disassembler_version || throw(ArgumentError(
+        "Tile IR bytecode v$version cannot be decoded by the selected v$disassembler_version " *
+        "disassembler"))
+    disasm = tileir_disassembler(; debuginfo)
     mktempdir() do dir
         input_path = joinpath(dir, "kernel.tile")
         write(input_path, bytecode)
@@ -116,7 +120,7 @@ Analogous to `code_llvm`/`code_native`. Calls the driver directly without
 caching in CuTileResults, so reflection never pollutes the compilation cache.
 
 Set `remarks=true` to also run `tileiras` and print its optimization remarks.
-This requires Tile IR 13.4 or newer. When no GPU is available, pass `sm_arch`
+This requires `tileiras` 13.4 or newer. When no GPU is available, pass `sm_arch`
 explicitly.
 """
 function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
@@ -140,10 +144,11 @@ function code_tiled(io::IO, @nospecialize(f), @nospecialize(argtypes);
     bytecode = emit_tile(sci, rettype, kernel_meta;
                          name=sanitize_name(string(mi.def.name)),
                          opts, cache, const_argtypes)
-    print(io, disassemble_tileir(bytecode; debuginfo))
+    print(io, disassemble_tileir(bytecode, bytecode_version; debuginfo))
     if remarks
-        tileiras_supports_remarks() || throw(ArgumentError(
+        tileiras_version() >= v"13.4" || throw(ArgumentError(
             "tileiras optimization remarks require tileiras 13.4 or newer"))
+        validate_tileiras_target(bytecode_version)
         target = if sm_arch === nothing
             try
                 default_sm_arch()

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -371,13 +371,14 @@ mutable struct CGCtx
     touched_poison::Bool
 end
 
-function CGCtx(; cb::CodeBuilder, tt::TypeTable, sci::StructuredIRCode,
+function CGCtx(; cb::CodeBuilder, sci::StructuredIRCode,
                  token_type::Union{TypeId, Nothing} = nothing,
                  type_cache::Dict{Type, TypeId} = Dict{Type, TypeId}(),
                  sm_arch::Union{VersionNumber, Nothing} = nothing,
                  cache::CacheView,
                  debug_emitter = nothing,
                  linkage_name::String = "")
+    tt = cb.type_table
     CGCtx(
         Dict{Int, CGVal}(),
         Dict{Int, CGVal}(),
@@ -407,6 +408,8 @@ function CGCtx(; cb::CodeBuilder, tt::TypeTable, sci::StructuredIRCode,
         false,                           # touched_poison
     )
 end
+
+bytecode_version(ctx::CGCtx) = bytecode_version(ctx.tt)
 
 """
     current_fpmode(ctx::CGCtx) -> FPMode

--- a/src/cuTile.jl
+++ b/src/cuTile.jl
@@ -93,7 +93,7 @@ include("launch.jl")
 
 public launch, cufunction, TileKernel, TileBackend, DefaultBackend, Tiled, ByTarget,
        @compiler_options, @fpmode, @.,
-       bytecode_version, versioninfo
+       tileiras_version, bytecode_version, versioninfo
 
 # World age captured at __init__ time. The compilation pipeline
 # (typeinf!, codegen, bytecode emission) is invoked in this world via

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -6,9 +6,9 @@
 # `(MethodInstance, sm_arch, opt_level, num_ctas, occupancy, num_worker_warps, bytecode_version)`.
 
 using CUDACore: CUDACore, CuArray, CuModule, CuFunction, cudacall, device, capability,
-                deviceid, AbstractBackend, AbstractKernel, kernel_convert, kernel_compile
+                AbstractBackend, AbstractKernel, kernel_convert, kernel_compile
 using CUDA_Compiler_jll
-using GPUToolbox: @memoize
+using GPUToolbox: LazyInitialized
 using Preferences: @load_preference
 
 using Adapt: Adapt, adapt
@@ -126,7 +126,7 @@ TileCacheKey(sm_arch::VersionNumber, bytecode_version::VersionNumber,
 
 
 #=============================================================================
- Toolkit / device validation (cached: once per `(capability, cuda_version)`).
+ Toolchain and target validation.
 =============================================================================#
 
 # User overrides from `LocalPreferences.toml`.
@@ -197,19 +197,42 @@ function tileiras_cmd(args...)
 end
 
 """
-    tileir_disassembler(; debuginfo=false) -> Union{Cmd, Nothing}
+    tileir_disassembler(; debuginfo=false) -> Cmd
 
-Return a disassembler matching the selected `tileiras`. An override requires
-`tileirdisasm` in the same directory.
+Return the lazily-resolved Tile IR disassembler. An override requires
+`tileirdisasm` from the same toolkit.
 """
 function tileir_disassembler(; debuginfo::Bool=false)
+    info = get!(discover_tileir_disassembler, tileir_disassembler_cache)
+    cmd = info.command
+    return debuginfo ? `$cmd $(info.debuginfo_flag)` : cmd
+end
+
+tileir_disassembler_version() =
+    get!(discover_tileir_disassembler, tileir_disassembler_cache).version
+
+struct TileIRDisassembler
+    command::Cmd
+    debuginfo_flag::String
+    version::VersionNumber
+end
+
+const tileir_disassembler_cache = LazyInitialized{TileIRDisassembler}()
+
+function discover_tileir_disassembler()
     if tileiras_override !== nothing
         disasm = joinpath(dirname(tileiras_override), "tileirdisasm")
-        isfile(disasm) || return nothing
-        return debuginfo ? `$disasm --print-debug-info` : `$disasm`
+        isfile(disasm) || error("no `tileirdisasm` next to $(tileiras_path())")
+        proc, log = run_and_collect(`$disasm --version`)
+        success(proc) || error("tileirdisasm --version failed with exit code " *
+                               "$(proc.exitcode):\n$log")
+        return TileIRDisassembler(`$disasm`, "--print-debug-info",
+                                  parse_tileiras_version(log))
     end
+    CUDA_Tile_jll.is_available() || error("CUDA_Tile_jll is not available")
     translate = `$(CUDA_Tile_jll.cuda_tile_translate()) --cudatilebc-to-mlir`
-    return debuginfo ? `$translate --mlir-print-debuginfo` : translate
+    return TileIRDisassembler(translate, "--mlir-print-debuginfo",
+                              Base.pkgversion(CUDA_Tile_jll))
 end
 
 function run_and_collect(cmd; timeout=compiler_timeout)
@@ -313,114 +336,24 @@ function run_tileiras(bytecode::Vector{UInt8}, sm_arch::VersionNumber,
     end
 end
 
-const toolkit_version_cache =
-    Base.Lockable(Base.RefValue{Union{Nothing, Some{Union{Nothing, String}}}}(nothing))
-
-# Bytecode versions cuTile.jl can emit, in ascending order. Each version listed
-# here is one we have explicit `cb.version >= v"X.Y"` handling for in
-# `bytecode/encodings.jl`. `bytecode_version()` probes `tileiras` to find the
-# highest entry it accepts (or returns the user's preference override).
-const SUPPORTED_BYTECODE_VERSIONS = (v"13.1", v"13.2", v"13.3", v"13.4")
-
-const max_bytecode_version_cache = Base.Lockable(Base.RefValue{Union{Nothing, VersionNumber}}(nothing))
-
-# Matches the `V<major>.<minor>.<patch>` component of `tileiras --version`,
-# e.g. `V13.2.78`. That's the part that actually identifies the compiler;
-# the surrounding `Built on …` / `Build local.local.…` lines vary across
-# rebuilds of the same logical version and would over-invalidate the cache.
 const TILEIRAS_VERSION_REGEX = r"V(\d+\.\d+\.\d+)"
 
-"""
-    toolkit_version() -> Union{String, Nothing}
-
-Lazy-cached `tileiras` toolkit identity, used as the toolkit-identity
-component of the disk-cache key so distinct CUDA Toolkit patches
-(e.g. `13.2.51` vs `13.2.78`) produce distinct cubins.
-
-We invoke `tileiras --version` once per process and pull out the
-`V<major>.<minor>.<patch>` token (the only thing that actually
-identifies the compiler — `Built on …` and `Build local.local.…`
-lines also vary across rebuilds of the same logical version, which
-would over-invalidate the cache).
-
-`CUDA_Compiler_jll.cuda_version` is not enough on its own: it only
-exposes major.minor, so different patches would alias. cuTile Python
-sidesteps the parsing problem by hashing the entire `--version`
-stdout (`_get_compiler_version_string` in `_compile.py`); we extract
-the V-token instead and fall back to the full stdout only if the
-regex misses, so a future format change degrades to Python-style
-over-invalidation rather than aliasing distinct compilers.
-
-Failure to invoke `tileiras --version` returns `nothing`; callers should
-skip disk-cache use rather than collapsing distinct compilers into an
-unknown bucket.
-"""
-function toolkit_version()
-    Base.@lock toolkit_version_cache begin
-        ref = toolkit_version_cache[]
-        ref[] === nothing || return ref[].value
-
-        version = try
-            proc, log = run_and_collect(tileiras_cmd("--version"))
-            if success(proc)
-                parse_toolkit_version(log)
-            else
-                @debug "tileiras --version failed; disabling disk cache" exitcode=proc.exitcode log
-                nothing
-            end
-        catch err
-            @debug "tileiras --version failed; disabling disk cache" exception=(err, catch_backtrace())
-            nothing
-        end
-        ref[] = Some(version)
-        return version
-    end
-end
-
-function parse_toolkit_version(log::AbstractString)
+function parse_tileiras_version(log::AbstractString)
     m = match(TILEIRAS_VERSION_REGEX, log)
-    m === nothing ? (isempty(log) ? nothing : String(log)) : m.captures[1]
+    m === nothing && throw(ArgumentError(
+        "version output does not contain a V<major>.<minor>.<patch> token:\n$log"))
+    return VersionNumber(m.captures[1])
 end
 
-function tileiras_supports_remarks()
-    version = toolkit_version()
-    version === nothing && return false
-    parsed = tryparse(VersionNumber, version)
-    return parsed !== nothing && parsed >= v"13.4"
-end
-
-"""
-    bytecode_version() -> VersionNumber
-
-The Tile IR bytecode version that `cuTile` will emit by default. Either
-the highest version the current `tileiras` binary accepts (probed by
-emitting a minimal empty bytecode buffer at each entry of
-`SUPPORTED_BYTECODE_VERSIONS` newest-first and picking the first that
-compiles cleanly), or, if the `bytecode_version` preference is set, that
-value.
-
-Result is cached for the lifetime of the process.
-
-We probe rather than reading `CUDA_Compiler_jll.cuda_version` because
-users can override `tileiras` via JLL preferences, in which case the
-JLL's static `cuda_version` no longer reflects the actual binary's
-capabilities. Mirrors `_get_max_supported_bytecode_version` in cuTile
-Python's `_compile.py`.
-"""
-function bytecode_version()
-    Base.@lock max_bytecode_version_cache begin
-        ref = max_bytecode_version_cache[]
-        ref[] === nothing || return ref[]::VersionNumber
-        if bytecode_version_override !== nothing
-            bytecode_version_override in SUPPORTED_BYTECODE_VERSIONS ||
-                error("preference bytecode_version=v$bytecode_version_override " *
-                      "is not in $SUPPORTED_BYTECODE_VERSIONS")
-            ref[] = bytecode_version_override
-        else
-            ref[] = probe_max_bytecode_version()
-        end
-        return ref[]::VersionNumber
-    end
+function select_bytecode_version(max_version::VersionNumber,
+                                 requested::Union{VersionNumber, Nothing})
+    validate_bytecode_version(max_version)
+    requested === nothing && return max_version
+    validate_bytecode_version(requested)
+    requested <= max_version || throw(ArgumentError(
+        "bytecode_version=v$requested was requested, but the selected tileiras only " *
+        "accepts through v$max_version"))
+    return requested
 end
 
 function probe_max_bytecode_version()
@@ -446,6 +379,59 @@ function probe_max_bytecode_version()
           "($(join(reverse(SUPPORTED_BYTECODE_VERSIONS), ", "))); last log:\n$last_log")
 end
 
+struct TileIRToolchain
+    tileiras_version::VersionNumber
+    compiler_identity::String
+    max_bytecode_version::VersionNumber
+    bytecode_version::VersionNumber
+end
+
+const tileir_toolchain_cache = LazyInitialized{TileIRToolchain}()
+
+function discover_tileir_toolchain()
+    bytecode_version_override === nothing ||
+        validate_bytecode_version(bytecode_version_override)
+    if tileiras_override === nothing && !CUDA_Compiler_jll.is_available()
+        error("CUDA_Compiler_jll is not available and no `tileiras` preference is set")
+    end
+
+    proc, identity = run_and_collect(tileiras_cmd("--version"))
+    success(proc) || error("tileiras --version failed with exit code " *
+                           "$(proc.exitcode):\n$identity")
+    version = parse_tileiras_version(identity)
+    max_version = probe_max_bytecode_version()
+    selected_version = select_bytecode_version(max_version, bytecode_version_override)
+    return TileIRToolchain(version, identity, max_version, selected_version)
+end
+
+tileir_toolchain() = get!(discover_tileir_toolchain, tileir_toolchain_cache)
+
+"""
+    tileiras_version() -> VersionNumber
+
+Version of the selected `tileiras` executable. The executable is resolved and
+queried lazily, once per process.
+"""
+tileiras_version() = tileir_toolchain().tileiras_version
+
+"""
+    bytecode_version() -> VersionNumber
+
+The validated Tile IR bytecode version emitted by default. This is either the
+highest version accepted by the selected `tileiras`, or the `bytecode_version`
+preference after checking that both cuTile and `tileiras` support it.
+"""
+bytecode_version() = tileir_toolchain().bytecode_version
+
+function validate_tileiras_target(version::VersionNumber)
+    validate_bytecode_version(version)
+    max_version = tileir_toolchain().max_bytecode_version
+    version <= max_version || throw(ArgumentError(
+        "Tile IR bytecode v$version cannot be compiled by the selected tileiras, which " *
+        "accepts through v$max_version"))
+    return nothing
+end
+
 """
     tile_ir_requirement(cap::VersionNumber) -> Union{Tuple{String,VersionNumber}, Nothing}
 
@@ -467,45 +453,29 @@ function tile_ir_requirement(cap::VersionNumber)
 end
 
 """
-    check_tile_ir_support()
+    check_tile_ir_support(sm_arch)
 
-Validate that the current `tileiras` toolkit supports Tile IR on the active
-device. Returns the bytecode version cuTile should emit for this device
-(per [`bytecode_version`]), provided it meets the device's minimum
-requirement (Blackwell ≥ v13.1, Hopper ≥ v13.3, Ampere/Ada ≥ v13.2).
+Validate that the selected bytecode version supports Tile IR on `sm_arch`.
+Returns the bytecode version cuTile should emit, provided it meets the target's
+minimum requirement (Blackwell ≥ v13.1, Hopper ≥ v13.3, Ampere/Ada ≥ v13.2).
 """
-function check_tile_ir_support()
-    if tileiras_override === nothing && !CUDA_Compiler_jll.is_available()
-        error("CUDA_Compiler_jll is not available and no `tileiras` preference is set; " *
-              "cannot compile Tile IR kernels")
-    end
-
-    dev = device()
-    ver = @memoize index=deviceid(dev)+1 begin
-        ver = bytecode_version()
-
-        cap = capability(dev)
-        sm_str = format_sm_arch(cap)
-        req = tile_ir_requirement(cap)
-        if req === nothing
-            @error "Tile IR is not supported on compute capability $cap ($sm_str)"
-            return nothing
-        end
-        arch, min_ver = req
-        if ver < min_ver
-            @error "Tile IR on $arch ($sm_str) requires bytecode ≥ v$min_ver, detected v$ver"
-            return nothing
-        end
-
-        return ver
-    end::Union{Nothing, VersionNumber}
-
-    if ver === nothing
-        error("CUDA Tile is not supported on the current device")
-    end
-    return ver::VersionNumber
+function check_tile_ir_support(sm_arch::VersionNumber)
+    version = bytecode_version()
+    validate_tile_ir_target(sm_arch, version)
+    return version
 end
 
+function validate_tile_ir_target(sm_arch::VersionNumber, version::VersionNumber)
+    validate_bytecode_version(version)
+    requirement = tile_ir_requirement(sm_arch)
+    requirement === nothing && throw(ArgumentError(
+        "Tile IR is not supported on compute capability $sm_arch ($(format_sm_arch(sm_arch)))"))
+    arch, min_version = requirement
+    version >= min_version || throw(ArgumentError(
+        "Tile IR on $arch ($(format_sm_arch(sm_arch))) requires bytecode v$min_version+, " *
+        "got v$version"))
+    return nothing
+end
 
 #=============================================================================
  Argument-type unwrapping for cufunction.
@@ -571,14 +541,14 @@ function emit_binary!(cache::CacheView, mi::Core.MethodInstance,
                                        kernel_meta, :opt_level, sm_arch), 3)
 
     # Disk cache lookup. The hash covers every input that changes the CUBIN
-    # — bytecode + sm_arch + opt_level + tileiras toolkit version — so
-    # different toolkit versions never collide. `bytecode_version` is encoded
+    # — bytecode + sm_arch + opt_level + tileiras identity — so different
+    # compiler builds never collide. `bytecode_version` is encoded
     # in the bytecode itself, so it's covered transitively by the bytecode hash.
     dc = DiskCache.global_cache()
     cache_key = nothing
-    toolkit_id = toolkit_version()
-    if dc !== nothing && toolkit_id !== nothing
-        cache_key = DiskCache.compute_key(bytecode, sm_arch, opt_level, toolkit_id)
+    if dc !== nothing
+        identity = tileir_toolchain().compiler_identity
+        cache_key = DiskCache.compute_key(bytecode, sm_arch, opt_level, identity)
         cubin = try
             DiskCache.get(dc, cache_key)
         catch err
@@ -666,8 +636,8 @@ function cufunction(@nospecialize(f), tt::Type{<:Tuple}=Tuple{};
                     occupancy::Union{Int, Nothing}=nothing,
                     num_worker_warps::Union{Int, Nothing}=nothing,
                     name::Union{String, Nothing}=nothing)
-    bytecode_version = check_tile_ir_support()
     resolved_sm_arch = sm_arch !== nothing ? sm_arch : default_sm_arch()
+    bytecode_version = check_tile_ir_support(resolved_sm_arch)
 
     key = TileCacheKey(resolved_sm_arch, bytecode_version, opt_level, num_ctas, occupancy,
                        num_worker_warps)
@@ -695,6 +665,8 @@ by [`link`](@ref) to load the result onto the GPU. No CUDA context required.
 function compile(@nospecialize(f), @nospecialize(argtypes),
                  const_argtypes::Union{Vector{Any}, Nothing},
                  key::TileCacheKey)
+    validate_tile_ir_target(unpack_version(key.sm_arch),
+                            unpack_version(key.bytecode_version))
     world = Base.get_world_counter()
     mi = method_instance(f, argtypes; world)
     mi === nothing && throw(MethodError(f, argtypes))
@@ -873,17 +845,20 @@ default_sm_arch() = capability(device())
 """
     versioninfo([io::IO=stdout])
 
-Print information about the active `tileiras` toolkit, the bytecode version
+Print information about the active `tileiras`, the bytecode version
 cuTile.jl will emit for it, and any user overrides set via
 `LocalPreferences.toml`.
 """
 function versioninfo(io::IO=stdout)
     println(io, "cuTile toolchain:")
 
+    toolchain = tileir_toolchain()
     install = tileiras_override === nothing ? "artifact installation" : "local installation"
-    println(io, "- tileiras $(something(toolkit_version(), "unknown")), $install")
+    println(io, "- tileiras $(toolchain.tileiras_version), $install")
 
-    bv = bytecode_version()
+    bv = toolchain.bytecode_version
     bv_src = bytecode_version_override === nothing ? "auto-detected" : "set via preference"
-    println(io, "- bytecode v$(bv.major).$(bv.minor), $bv_src")
+    max_bv = toolchain.max_bytecode_version
+    max_suffix = bv == max_bv ? "" : " (tileiras accepts through v$(max_bv.major).$(max_bv.minor))"
+    println(io, "- bytecode v$(bv.major).$(bv.minor), $bv_src$max_suffix")
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -44,6 +44,9 @@ import REPL
         bv = bytecode_version()
         for sm_arch in [v"8.0", v"8.6", v"8.7", v"8.9",
                         v"10.0", v"11.0", v"12.0", v"12.1"]
+            requirement = tile_ir_requirement(sm_arch)
+            requirement === nothing && continue
+            bv < requirement[2] && continue
             key = TileCacheKey(sm_arch, bv, nothing, nothing, nothing, nothing)
             compile(f, argtypes, const_argtypes, key)
         end

--- a/test/bytecode.jl
+++ b/test/bytecode.jl
@@ -1,6 +1,6 @@
 make_builder(version) = let strings = cuTile.StringTable(), constants = cuTile.ConstantTable()
     types = cuTile.TypeTable(; version)
-    cuTile.CodeBuilder(strings, constants, types; version)
+    cuTile.CodeBuilder(strings, constants, types)
 end
 
 @testset "Tile IR v13.3 GatherScatterView encodings" begin
@@ -27,6 +27,7 @@ end
 
 @testset "Tile IR v13.4 encodings" begin
     @test v"13.4" in cuTile.SUPPORTED_BYTECODE_VERSIONS
+    @test_throws ArgumentError cuTile.TypeTable(; version=v"13.5")
 
     tt33 = cuTile.TypeTable(; version=v"13.3")
     tt34 = cuTile.TypeTable(; version=v"13.4")

--- a/test/codegen/operations.jl
+++ b/test/codegen/operations.jl
@@ -1579,9 +1579,8 @@ end
             end
         end
 
-        # Directed rounding needs v13.4, which the disassembler only understands
-        # when the local toolkit is new enough.
-        if ct.bytecode_version() >= v"13.4"
+        # Directed rounding needs a disassembler that understands v13.4.
+        if ct.tileir_disassembler_version() >= v"13.4"
             for (mode, attr) in ((RoundToZero, "zero"),
                                  (RoundDown, "negative_inf"),
                                  (RoundUp, "positive_inf"))

--- a/test/codegen/reflection.jl
+++ b/test/codegen/reflection.jl
@@ -72,7 +72,7 @@ end
     end
 end
 
-if ct.tileiras_supports_remarks()
+if ct.tileiras_version() >= v"13.4"
     @testset "code_tiled remarks" begin
         output = sprint(io -> ct.code_tiled(io, reflect_vadd, TT3;
                                             sm_arch=v"10.0", remarks=true))

--- a/test/extensions/DLFP8Types.jl
+++ b/test/extensions/DLFP8Types.jl
@@ -33,7 +33,7 @@ end
 end
 
 # Float8_E5M2 -> Float32 with explicit rounding (needs v13.4 to disassemble)
-if ct.bytecode_version() >= v"13.4"
+if ct.tileir_disassembler_version() >= v"13.4"
     @test @filecheck begin
         @check_label "entry"
         code_tiled(Tuple{ct.TileArray{Float8_E5M2,1,Int32,spec1d},

--- a/test/host/cache.jl
+++ b/test/host/cache.jl
@@ -3,10 +3,16 @@ using SHA: sha256
 const DC = cuTile.DiskCache
 
 @testset "DiskCache" begin
-    @testset "toolkit version parsing" begin
-        @test cuTile.parse_toolkit_version("tileiras V13.2.78\nBuild local") == "13.2.78"
-        @test cuTile.parse_toolkit_version("future version format") == "future version format"
-        @test cuTile.parse_toolkit_version("") === nothing
+    @testset "toolchain versions" begin
+        @test cuTile.parse_tileiras_version("tileiras V13.2.78\nBuild local") == v"13.2.78"
+        @test_throws ArgumentError cuTile.parse_tileiras_version("future version format")
+        @test_throws ArgumentError cuTile.parse_tileiras_version("")
+
+        @test cuTile.select_bytecode_version(v"13.4", nothing) == v"13.4"
+        @test cuTile.select_bytecode_version(v"13.4", v"13.2") == v"13.2"
+        @test_throws ArgumentError cuTile.select_bytecode_version(v"13.3", v"13.4")
+        @test_throws ArgumentError cuTile.select_bytecode_version(v"13.4", v"13.5")
+        @test_throws ArgumentError cuTile.select_bytecode_version(v"13.5", nothing)
     end
 
     @testset "configuration" begin

--- a/test/host/launch.jl
+++ b/test/host/launch.jl
@@ -1,3 +1,17 @@
+@testset "lazy toolchain discovery" begin
+    script = """
+        using cuTile
+        @assert cuTile.tileir_toolchain_cache.value === nothing
+        @assert cuTile.tileir_disassembler_cache.value === nothing
+        cuTile.bytecode_version()
+        @assert cuTile.tileir_toolchain_cache.value !== nothing
+        @assert cuTile.tileir_disassembler_cache.value === nothing
+        """
+    project = dirname(Base.active_project())
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$project -e $script`
+    @test success(run(ignorestatus(cmd)))
+end
+
 @testset "compiler timeout" begin
     @test cuTile.parse_compiler_timeout(nothing) === nothing
     @test cuTile.parse_compiler_timeout(1) == 1.0

--- a/test/types.jl
+++ b/test/types.jl
@@ -246,7 +246,7 @@ end
 
     # Scalar TFloat32 must resolve to a 0-D tile; `tile_type_for_julia!`
     # used to skip it, breaking any call site that fed a bare scalar to codegen.
-    let tt = cuTile.TypeTable(; version=cuTile.bytecode_version())
+    let tt = cuTile.TypeTable(; version=v"13.1")
         tid = cuTile.tile_type_for_julia!(tt, ct.TFloat32)
         @test tid !== nothing
     end
@@ -325,6 +325,11 @@ end
     # Pre-Ampere is unsupported
     @test cuTile.tile_ir_requirement(v"7.5") === nothing
     @test cuTile.tile_ir_requirement(v"7.0") === nothing
+
+    @test isnothing(cuTile.validate_tile_ir_target(v"10.0", v"13.1"))
+    @test isnothing(cuTile.validate_tile_ir_target(v"9.0", v"13.3"))
+    @test_throws ArgumentError cuTile.validate_tile_ir_target(v"9.0", v"13.2")
+    @test_throws ArgumentError cuTile.validate_tile_ir_target(v"7.5", v"13.4")
 end
 
 @testset "@compiler_options validation" begin


### PR DESCRIPTION
Version-dependent code drew from several overlapping sources: an optional toolkit identity, a separately probed bytecode target, duplicated writer state, and ad-hoc test gates. That made it unclear which version governed compiler features, bytecode emission, disassembly, and cache identity.

Resolve tileiras into a strict, lazily initialized process-local toolchain record containing its version, compiler identity, maximum accepted bytecode, and selected target. Validate preferences and compilation targets, make TypeTable the single bytecode-version source during emission, and keep disassembler capability separate for reflection.

Use the compiler identity for disk-cache keys and update tests and documentation to query the selected bytecode, tileiras, or disassembler according to the capability under test.