### PR TITLE
Add programmatic dependent launch support

### DIFF
--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -14,6 +14,14 @@ particular Tile IR version or GPU architecture are noted inline and collected in
 [Compatibility](../man/compatibility.md).
 
 
+## Grid dependency control
+
+```@docs
+grid_dependency_control_launch_dependents
+grid_dependency_control_wait
+```
+
+
 ## Arithmetic
 
 | Operation | Description |

--- a/docs/src/man/comparison.md
+++ b/docs/src/man/comparison.md
@@ -65,7 +65,8 @@ end
 
 ## Launch syntax
 
-cuTile.jl implicitly uses the current task-bound stream from CUDA.jl:
+cuTile.jl uses the current task-bound CUDA.jl stream by default, or accepts it
+as a `stream` keyword:
 
 ```python
 # Python
@@ -75,8 +76,17 @@ ct.launch(cp.cuda.get_current_stream(), grid, vadd, (a, b, c))
 
 ```julia
 # Julia
-@cuda backend=cuTile blocks=grid vadd(a, b, c)
+@cuda backend=cuTile blocks=grid stream vadd(a, b, c)
 ```
+
+Programmatic dependent launch uses the shorter CUDA.jl launch keyword while
+keeping the same device-operation names:
+
+| cuTile Python | cuTile.jl |
+|---------------|-----------|
+| `ct.launch(..., programmatic_dependent_launch=True)` | `@cuda backend=cuTile dependent=true ...` |
+| `ct.grid_dependency_control_launch_dependents()` | `ct.grid_dependency_control_launch_dependents()` |
+| `ct.grid_dependency_control_wait()` | `ct.grid_dependency_control_wait()` |
 
 
 ## 1-based indexing

--- a/docs/src/man/compatibility.md
+++ b/docs/src/man/compatibility.md
@@ -80,6 +80,7 @@ Everything not listed here works at v13.1.
 | `check_bounds=false` | On `ct.load` and `ct.store` only; on `ct.gather`/`ct.scatter` it merely skips the bounds mask |
 | `ct.Intrinsics.powi` | Integer exponents through `cuda_tile.fpowi` |
 | Directed float conversion rounding | `RoundToZero`, `RoundDown`, `RoundUp`, or `RoundNearestTiesAway`; supported pairs vary |
+| Programmatic dependent launch | Also requires Hopper (sm_90) or newer |
 
 
 ## Features by architecture
@@ -89,6 +90,7 @@ Everything not listed here works at v13.1.
 | `ct.muladd_scaled` | Blackwell (≥ sm_100) | Error |
 | Atomic add on `BFloat16` | Hopper (≥ sm_90) | Error |
 | `fast_acc=true` | Hopper (sm_90) | Silently ignored |
+| Programmatic dependent launch | Hopper (≥ sm_90) | Error |
 
 `fast_acc` is the exception to the pattern: it is a throughput hint rather than
 a capability, so on architectures where it does nothing, it is accepted and

--- a/docs/src/man/execution.md
+++ b/docs/src/man/execution.md
@@ -45,15 +45,57 @@ ct.launch(vadd, grid, a, b, c, ct.Constant(tile_size))                   # funct
 is easier to call from generated code or when the argument list is built
 programmatically. Both accept the optimization hints described in
 [Performance](performance.md), and both use the current task-bound CUDA stream;
-cuTile has no stream argument of its own. To run a kernel on a different stream,
-set the task's stream as you would for any CUDA.jl operation; see CUDA.jl's
-[task and stream
-documentation](https://cuda.juliagpu.org/stable/usage/multitasking/).
+pass `stream=other_stream` to either form to choose a different one. See
+CUDA.jl's [task and stream
+documentation](https://cuda.juliagpu.org/stable/usage/multitasking/) for the
+stream model shared by both packages.
 
 `blocks` sizes the grid, in up to three dimensions. It counts *blocks*, so it is
 almost always a ceiling division of the problem size by the tile shape. Inside
 the kernel, a block finds its place in the grid with `ct.bid`; see [Programming
 Model](programming_model.md#The-grid).
+
+
+## Programmatic dependent launch
+
+[Programmatic dependent launch](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html)
+can overlap the tail of a producer kernel with an independent preamble in the
+next kernel on the same stream. The producer signals when the consumer may
+start, and the consumer waits before reading the producer's results:
+
+```julia
+function producer(a, producer_out)
+    ct.grid_dependency_control_launch_dependents()
+
+    # This work may overlap with the consumer's preamble.
+    tile = ct.load(a, 1, (32,))
+    ct.store(producer_out, 1, tile)
+    return
+end
+
+function consumer(b, producer_out, out)
+    tile = ct.load(b, 1, (32,)) # Independent work can run before the wait.
+
+    ct.grid_dependency_control_wait()
+    ct.store(out, 1, tile + ct.load(producer_out, 1, (32,)))
+    return
+end
+
+stream = CUDA.stream()
+@cuda backend=cuTile blocks=1 stream producer(a, producer_out)
+@cuda backend=cuTile blocks=1 dependent=true stream consumer(b, producer_out, out)
+```
+
+The `dependent=true` attribute belongs on the consumer launch. Every producer
+block should call `ct.grid_dependency_control_launch_dependents`; a block that
+exits without calling it triggers completion implicitly. The consumer must call
+`ct.grid_dependency_control_wait` before accessing any producer results because
+the producer's signal does not make its writes visible.
+
+Overlap is opportunistic. Correctness must not require the kernels to run
+concurrently, as doing so can deadlock. Without `dependent=true`, normal stream
+serialization still applies. Programmatic dependent launch requires Tile IR
+13.4 and compute capability 9.0 or newer.
 
 
 ## Argument conversion

--- a/src/bytecode/encodings.jl
+++ b/src/bytecode/encodings.jl
@@ -104,7 +104,9 @@ module Opcode
     const MakeStridedViewOp = 116 # since 13.3
     const AtomicRedViewTkoOp = 117 # since 13.3
     const InsertOp = 118     # since 13.4
-    # 119-121, 128-129 (Gdc*, Multimem*) not implemented
+    const GdcLaunchDependentsTkoOp = 119 # since 13.4
+    const GdcWaitTkoOp = 120 # since 13.4
+    # 121, 128-129 (Gdc*, Multimem*) not implemented
     const FPowIOp = 130      # since 13.4
     # 131 (MemoryFenceAliasTkoOp) not implemented
 end
@@ -389,6 +391,40 @@ function encode_PrintTkoOp!(cb::CodeBuilder,
     num_results = bytecode_version(cb) >= v"13.2" ? 1 : 0
     result = new_op!(cb, num_results)
     return result  # Value for v13.2+, nothing for v13.1
+end
+
+"""
+    encode_GdcLaunchDependentsTkoOp!(cb, token_type; token=nothing) -> Value
+
+Allow dependent kernels to start executing.
+Opcode: 119
+"""
+function encode_GdcLaunchDependentsTkoOp!(cb::CodeBuilder, token_type::TypeId;
+                                          token::Union{Value, Nothing}=nothing)
+    bytecode_version(cb) >= v"13.4" ||
+        throw(IRError("cuda_tile.gdc_launch_dependents_tko requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
+    encode_varint!(cb.buf, Opcode.GdcLaunchDependentsTkoOp)
+    encode_typeid!(cb.buf, token_type)
+    encode_varint!(cb.buf, token === nothing ? 0 : 1)
+    encode_optional_operand!(cb.buf, token)
+    return new_op!(cb)
+end
+
+"""
+    encode_GdcWaitTkoOp!(cb, token_type; token=nothing) -> Value
+
+Wait for prerequisite kernels to finish and make their writes visible.
+Opcode: 120
+"""
+function encode_GdcWaitTkoOp!(cb::CodeBuilder, token_type::TypeId;
+                              token::Union{Value, Nothing}=nothing)
+    bytecode_version(cb) >= v"13.4" ||
+        throw(IRError("cuda_tile.gdc_wait_tko requires Tile IR v13.4+, got v$(bytecode_version(cb))"))
+    encode_varint!(cb.buf, Opcode.GdcWaitTkoOp)
+    encode_typeid!(cb.buf, token_type)
+    encode_varint!(cb.buf, token === nothing ? 0 : 1)
+    encode_optional_operand!(cb.buf, token)
+    return new_op!(cb)
 end
 
 """

--- a/src/compiler/analysis/effects.jl
+++ b/src/compiler/analysis/effects.jl
@@ -16,8 +16,8 @@
 
 Return the memory effect of a resolved intrinsic call. `MEM_NONE` for pure
 ops, `MEM_LOAD` for reads, `MEM_STORE` for writes (including atomics, which
-are conservatively classified as stores, and `print_tko` which has an
-externally observable side effect).
+are conservatively classified as stores, and ordering-only operations with
+externally observable effects).
 """
 function classify_memory_op(resolved_func)
     if resolved_func === Intrinsics.load_partition_view ||
@@ -30,7 +30,7 @@ function classify_memory_op(resolved_func)
            resolved_func === Intrinsics.store_gather_scatter_view ||
            resolved_func === Intrinsics.store_ptr_tko
         return MEM_STORE
-    elseif resolved_func === Intrinsics.print_tko
+    elseif resolved_func === Intrinsics.print_tko || is_gdc_intrinsic(resolved_func)
         return MEM_STORE
     elseif is_atomic_intrinsic(resolved_func) || is_atomic_red_view(resolved_func)
         return MEM_STORE
@@ -38,6 +38,9 @@ function classify_memory_op(resolved_func)
         return MEM_NONE
     end
 end
+
+is_gdc_intrinsic(func) = func === Intrinsics.gdc_launch_dependents_tko ||
+                         func === Intrinsics.gdc_wait_tko
 
 function is_atomic_intrinsic(func)
     isdefined(Intrinsics, :atomic_cas) && func === Intrinsics.atomic_cas && return true

--- a/src/compiler/intrinsics/misc.jl
+++ b/src/compiler/intrinsics/misc.jl
@@ -200,6 +200,28 @@ function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.print_tko), args)
     nothing  # print returns Nothing
 end
 
+@intrinsic gdc_launch_dependents_tko()
+tfunc(𝕃, ::typeof(Intrinsics.gdc_launch_dependents_tko)) = Nothing
+efunc(::typeof(Intrinsics.gdc_launch_dependents_tko), effects::CC.Effects) =
+    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.gdc_launch_dependents_tko), args)
+    input_token = extract_token_arg!(ctx, args)
+    result = encode_GdcLaunchDependentsTkoOp!(ctx.cb, Token(ctx.tt); token=input_token)
+    ctx.result_tokens[ctx.current_ssa_idx] = result
+    return nothing
+end
+
+@intrinsic gdc_wait_tko()
+tfunc(𝕃, ::typeof(Intrinsics.gdc_wait_tko)) = Nothing
+efunc(::typeof(Intrinsics.gdc_wait_tko), effects::CC.Effects) =
+    CC.Effects(effects; effect_free=CC.ALWAYS_FALSE)
+function emit_intrinsic!(ctx::CGCtx, ::typeof(Intrinsics.gdc_wait_tko), args)
+    input_token = extract_token_arg!(ctx, args)
+    result = encode_GdcWaitTkoOp!(ctx.cb, Token(ctx.tt); token=input_token)
+    ctx.result_tokens[ctx.current_ssa_idx] = result
+    return nothing
+end
+
 """
     Intrinsics.format_string(xs...) -> String
 

--- a/src/compiler/transform/token_order.jl
+++ b/src/compiler/transform/token_order.jl
@@ -15,14 +15,14 @@
 # alias set:
 #   - LAST_OP:    token from the most recent load or store (RAW/WAR tracking)
 #   - LAST_STORE: token from the most recent store only (WAW tracking)
-# Plus a global ACQUIRE token for acquire-ordered atomics.
+# Plus a global ACQUIRE token for acquire operations.
 #
 # For loads, the input token comes from LAST_STORE of the same alias set
 # (read-after-write dependency). For stores, the input token joins all
 # LAST_OP tokens of overlapping alias sets (write-after-read + write-after-write).
 # Release-ordered atomics additionally join ALL LAST_OP tokens across all alias
-# sets (memory fence semantics). Acquire-ordered atomics update the global
-# ACQUIRE token.
+# sets (memory fence semantics). Acquire-ordered atomics and grid dependency
+# waits update the global ACQUIRE token.
 #
 # The pass adds token carries to loops (init_values + block args + terminator
 # operands) and token results to IfOp types, then inserts getfield extractions
@@ -85,10 +85,11 @@ function compute_block_memory_effects!(block::Block, alias_info::AliasInfo,
             resolved_func, operands = call
             mem_effect = classify_memory_op(resolved_func)
             mem_effect == MEM_NONE && continue
-            alias_set = alias_class(alias_info, first(operands))
+            alias_set = isempty(operands) ? ALIAS_UNIVERSE :
+                                           alias_class(alias_info, first(operands))
             effects.effects[alias_set] = max(get(effects.effects, alias_set, MEM_NONE), mem_effect)
             mo = extract_memory_order(resolved_func, operands)
-            if has_acquire_order(mo)
+            if has_acquire_order(mo) || resolved_func === Intrinsics.gdc_wait_tko
                 effects = MemoryEffects(effects.effects, true)
             end
         end
@@ -458,7 +459,8 @@ function transform_statement!(block::Block, inst::Instruction,
     mem_effect = classify_memory_op(resolved_func)
     mem_effect == MEM_NONE && return
 
-    alias_set = alias_class(alias_info, first(operands))
+    alias_set = isempty(operands) ? ALIAS_UNIVERSE :
+                                   alias_class(alias_info, first(operands))
     memory_order = extract_memory_order(resolved_func, operands)
 
     if mem_effect == MEM_LOAD
@@ -477,7 +479,7 @@ function transform_statement!(block::Block, inst::Instruction,
                        JoinTokensNode([last_op_tok, result_token]), TOKEN_TYPE)
         token_map[lop_key] = SSAValue(join_inst)
 
-        if has_acquire_order(memory_order)
+        if has_acquire_order(memory_order) || resolved_func === Intrinsics.gdc_wait_tko
             token_map[ACQUIRE_TOKEN_KEY] = result_token
         end
 

--- a/src/language/operations.jl
+++ b/src/language/operations.jl
@@ -2172,6 +2172,39 @@ ptr_offset = base + n  # compiler knows this is 128-divisible
     Intrinsics.assume(x, DivBy(Int(divisor)))
 
 #=============================================================================
+ Grid dependency control
+=============================================================================#
+
+public grid_dependency_control_launch_dependents, grid_dependency_control_wait
+
+"""
+    grid_dependency_control_launch_dependents()
+
+Allow dependent kernels later in the same stream to start executing. At least
+one thread in every block must call this function; blocks that exit without
+calling it trigger completion implicitly.
+
+This does not make the current kernel's writes visible to a dependent kernel.
+The dependent kernel must call [`grid_dependency_control_wait`](@ref) before
+accessing them.
+
+Requires Tile IR 13.4 or newer.
+"""
+@inline grid_dependency_control_launch_dependents() =
+    Intrinsics.gdc_launch_dependents_tko()
+
+"""
+    grid_dependency_control_wait()
+
+Wait for prerequisite kernels to complete and make their global-memory writes
+visible to the current kernel. All accesses to their results must occur after
+this call.
+
+Requires Tile IR 13.4 or newer.
+"""
+@inline grid_dependency_control_wait() = Intrinsics.gdc_wait_tko()
+
+#=============================================================================
  Assert
 =============================================================================#
 

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -821,12 +821,18 @@ end
 
 """
     launch(f, grid, args...; sm_arch=nothing, opt_level=nothing,
-           num_ctas=nothing, occupancy=nothing, num_worker_warps=nothing, name=nothing)
+           num_ctas=nothing, occupancy=nothing, num_worker_warps=nothing,
+           dependent=false, stream=CUDACore.stream(), name=nothing)
 
 Compile and launch a Tile IR kernel. `args` are converted via
 `cuTileconvert` (CuArray → TileArray, Type → Constant). Equivalent to
 `@cuda backend=cuTile blocks=grid f(args...)` modulo
 slight kwarg naming.
+
+Set `dependent=true` on a consumer kernel to allow it to overlap with the
+preceding kernel in `stream`. The producer should call
+[`grid_dependency_control_launch_dependents`](@ref), and the consumer must call
+[`grid_dependency_control_wait`](@ref) before accessing the producer's results.
 
 # Example
 ```julia
@@ -852,11 +858,13 @@ function launch(@nospecialize(f), grid, args...;
                 num_ctas::Union{Int, Nothing}=nothing,
                 occupancy::Union{Int, Nothing}=nothing,
                 num_worker_warps::Union{Int, Nothing}=nothing,
+                dependent::Bool=false,
+                stream=CUDACore.stream(),
                 name::Union{String, Nothing}=nothing)
     converted = map(cuTileconvert, args)
     tt = Tuple{map(Core.Typeof, converted)...}
     kernel = cufunction(f, tt; sm_arch, opt_level, num_ctas, occupancy, num_worker_warps, name)
-    kernel(converted...; blocks=grid)
+    kernel(converted...; blocks=grid, dependent, stream)
     return nothing
 end
 

--- a/test/bytecode.jl
+++ b/test/bytecode.jl
@@ -66,6 +66,15 @@ end
         cuTile.encode_InsertOp!(cb, cuTile.TypeId(1), cuTile.Value(0),
                                cuTile.Value(1), cuTile.Value[])
     end
+
+    cb = make_builder(v"13.4")
+    @test cuTile.encode_GdcLaunchDependentsTkoOp!(cb, cuTile.TypeId(1)) == cuTile.Value(0)
+    @test cuTile.encode_GdcWaitTkoOp!(cb, cuTile.TypeId(1); token=cuTile.Value(7)) == cuTile.Value(1)
+    @test cb.buf == UInt8[119, 1, 0, 120, 1, 1, 7]
+    @test_throws "requires Tile IR v13.4+" cuTile.encode_GdcLaunchDependentsTkoOp!(
+        make_builder(v"13.3"), cuTile.TypeId(1))
+    @test_throws "requires Tile IR v13.4+" cuTile.encode_GdcWaitTkoOp!(
+        make_builder(v"13.3"), cuTile.TypeId(1))
 end
 
 @testset "Tile IR v13.3 StridedView encodings" begin

--- a/test/codegen/pdl.jl
+++ b/test/codegen/pdl.jl
@@ -2,37 +2,39 @@ spec1d = ct.ArraySpec{1}(16, true, (0,), (16,))
 AT = ct.TileArray{Float32, 1, Int32, spec1d}
 
 @testset "programmatic dependent launch" begin
-    @test @filecheck begin
-        @check "[[STORE:%.+]] = store_view_tko"
-        @check "[[JOIN:%.+]] = join_tokens{{.*}}[[STORE]]"
-        @check "gdc_launch_dependents_tko token = [[JOIN]]"
-        code_tiled(Tuple{AT, AT}; bytecode_version=v"13.4") do a, b
-            ct.store(b, 1, ct.load(a, 1, (16,)))
-            ct.grid_dependency_control_launch_dependents()
-            return
-        end
-    end
-
-    @test @filecheck begin
-        @check "[[WAIT:%.+]] = gdc_wait_tko"
-        @check "[[JOIN:%.+]] = join_tokens{{.*}}[[WAIT]]"
-        @check "load_view_tko{{.*}} token = [[JOIN]]"
-        code_tiled(Tuple{AT, AT, AT}; bytecode_version=v"13.4") do a, b, c
-            Base.donotdelete(ct.load(a, 1, (16,)))
-            ct.grid_dependency_control_wait()
-            ct.store(c, 1, ct.load(b, 1, (16,)))
-            return
-        end
-    end
-
-    @test @filecheck begin
-        @check "if"
-        @check "gdc_wait_tko"
-        code_tiled(Tuple{Bool}; bytecode_version=v"13.4") do condition
-            if condition
-                ct.grid_dependency_control_wait()
+    if ct.tileir_disassembler_version() >= v"13.4"
+        @test @filecheck begin
+            @check "[[STORE:%.+]] = store_view_tko"
+            @check "[[JOIN:%.+]] = join_tokens{{.*}}[[STORE]]"
+            @check "gdc_launch_dependents_tko token = [[JOIN]]"
+            code_tiled(Tuple{AT, AT}; bytecode_version=v"13.4") do a, b
+                ct.store(b, 1, ct.load(a, 1, (16,)))
+                ct.grid_dependency_control_launch_dependents()
+                return
             end
-            return
+        end
+
+        @test @filecheck begin
+            @check "[[WAIT:%.+]] = gdc_wait_tko"
+            @check "[[JOIN:%.+]] = join_tokens{{.*}}[[WAIT]]"
+            @check "load_view_tko{{.*}} token = [[JOIN]]"
+            code_tiled(Tuple{AT, AT, AT}; bytecode_version=v"13.4") do a, b, c
+                Base.donotdelete(ct.load(a, 1, (16,)))
+                ct.grid_dependency_control_wait()
+                ct.store(c, 1, ct.load(b, 1, (16,)))
+                return
+            end
+        end
+
+        @test @filecheck begin
+            @check "if"
+            @check "gdc_wait_tko"
+            code_tiled(Tuple{Bool}; bytecode_version=v"13.4") do condition
+                if condition
+                    ct.grid_dependency_control_wait()
+                end
+                return
+            end
         end
     end
 

--- a/test/codegen/pdl.jl
+++ b/test/codegen/pdl.jl
@@ -1,0 +1,44 @@
+spec1d = ct.ArraySpec{1}(16, true, (0,), (16,))
+AT = ct.TileArray{Float32, 1, Int32, spec1d}
+
+@testset "programmatic dependent launch" begin
+    @test @filecheck begin
+        @check "[[STORE:%.+]] = store_view_tko"
+        @check "[[JOIN:%.+]] = join_tokens{{.*}}[[STORE]]"
+        @check "gdc_launch_dependents_tko token = [[JOIN]]"
+        code_tiled(Tuple{AT, AT}; bytecode_version=v"13.4") do a, b
+            ct.store(b, 1, ct.load(a, 1, (16,)))
+            ct.grid_dependency_control_launch_dependents()
+            return
+        end
+    end
+
+    @test @filecheck begin
+        @check "[[WAIT:%.+]] = gdc_wait_tko"
+        @check "[[JOIN:%.+]] = join_tokens{{.*}}[[WAIT]]"
+        @check "load_view_tko{{.*}} token = [[JOIN]]"
+        code_tiled(Tuple{AT, AT, AT}; bytecode_version=v"13.4") do a, b, c
+            Base.donotdelete(ct.load(a, 1, (16,)))
+            ct.grid_dependency_control_wait()
+            ct.store(c, 1, ct.load(b, 1, (16,)))
+            return
+        end
+    end
+
+    @test @filecheck begin
+        @check "if"
+        @check "gdc_wait_tko"
+        code_tiled(Tuple{Bool}; bytecode_version=v"13.4") do condition
+            if condition
+                ct.grid_dependency_control_wait()
+            end
+            return
+        end
+    end
+
+    @test_throws "requires Tile IR v13.4+" code_tiled(
+        Tuple{}; bytecode_version=v"13.3") do
+        ct.grid_dependency_control_wait()
+        return
+    end
+end

--- a/test/device/pdl.jl
+++ b/test/device/pdl.jl
@@ -1,0 +1,42 @@
+if ct.bytecode_version() >= v"13.4" && CUDA.capability(CUDA.device()) >= v"9.0"
+    @testset "programmatic dependent launch" begin
+        function producer(a::ct.TileArray{Float32,1}, out::ct.TileArray{Float32,1})
+            ct.grid_dependency_control_launch_dependents()
+            tile = ct.load(a, 1, (32,))
+            for _ in 1:10_000
+                tile = tile .+ 1f0
+            end
+            ct.store(out, 1, tile)
+            return
+        end
+
+        function consumer(b::ct.TileArray{Float32,1}, producer_out::ct.TileArray{Float32,1},
+                          out::ct.TileArray{Float32,1})
+            tile = ct.load(b, 1, (32,))
+            for _ in 1:10_000
+                tile = tile .+ 1f0
+            end
+            ct.grid_dependency_control_wait()
+            ct.store(out, 1, tile + ct.load(producer_out, 1, (32,)))
+            return
+        end
+
+        a = CuArray(Float32.(0:31))
+        b = copy(a)
+        producer_out = CUDA.zeros(Float32, 32)
+        consumer_out = CUDA.zeros(Float32, 32)
+        stream = CUDA.stream()
+
+        ct.launch(producer, 1, a, producer_out; stream)
+        ct.launch(consumer, 1, b, producer_out, consumer_out; dependent=true, stream)
+        CUDA.synchronize(stream)
+        @test Array(consumer_out) == Array(a) + Array(b) .+ 20_000
+
+        fill!(producer_out, 0)
+        fill!(consumer_out, 0)
+        @cuda backend=cuTile blocks=1 stream producer(a, producer_out)
+        @cuda backend=cuTile blocks=1 dependent=true stream consumer(b, producer_out, consumer_out)
+        CUDA.synchronize(stream)
+        @test Array(consumer_out) == Array(a) + Array(b) .+ 20_000
+    end
+end


### PR DESCRIPTION
Add support for programmatic dependent launches (PDL), based on https://github.com/JuliaGPU/CUDA.jl/pull/3225. This allows the independent beginning of a consumer kernel to overlap with the tail of the preceding producer kernel.

The consumer is launched with `dependent=true`. The producer signals when the consumer may start, and the consumer waits before accessing the producer’s results.

```julia
function producer(a, producer_out)
  ct.grid_dependency_control_launch_dependents()

  tile = ct.load(a, 1, (32,))
  ct.store(producer_out, 1, tile)
  return
end

function consumer(b, producer_out, out)
  tile = ct.load(b, 1, (32,))  # May overlap with the producer.

  ct.grid_dependency_control_wait()
  ct.store(out, 1, tile + ct.load(producer_out, 1, (32,)))
  return
end

stream = CUDA.stream()
@cuda backend=cuTile blocks=1 stream producer(a, producer_out)
@cuda backend=cuTile blocks=1 dependent=true stream consumer(b, producer_out, out)
```