### PR TITLE
Untrack CUDA main, set compat to v6.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,9 +25,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
-[sources]
-CUDACore = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDACore"}
-
 [weakdeps]
 DLFP8Types = "f4c16678-4a16-415b-82ef-ed337c5d6c7c"
 Microfloats = "31c70f10-a750-4521-b13c-797315ae2933"
@@ -39,7 +36,7 @@ MicrofloatsExt = "Microfloats"
 [compat]
 Adapt = "4.4"
 BFloat16s = "0.6"
-CUDACore = "6.1"
+CUDACore = "6.3"
 CUDA_Compiler_jll = "0.5"
 CUDA_Tile_jll = "13.3"
 CompilerCaching = "0.3.1, 0.4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,30 +1,11 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
-CUDATools = "9ec180c6-1c07-47c7-9e6e-ebefa4d1f6d0"
-CUPTI = "9e67e8f6-ba02-4b6c-a7db-3b11ae1e7ab7"
 DLFP8Types = "f4c16678-4a16-415b-82ef-ed337c5d6c7c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Microfloats = "31c70f10-a750-4521-b13c-797315ae2933"
-NVML = "611af6d1-644e-4c5d-bd58-854d7d1254b9"
-cuBLAS = "182d3088-87b7-4494-8cad-fc6afaa545bc"
-cuFFT = "533571aa-0936-420e-b4be-9c66f5f626ca"
-cuRAND = "20fd9a0b-12d5-4c2f-a8af-7c34e9e60431"
-cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
-cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 cuTile = "0dea8319-8c4a-4662-a73d-20234d115b9a"
 
 [sources]
-CUDA = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main"}
-CUDACore = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDACore"}
-CUDATools = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDATools"}
-CUPTI = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cupti"}
-NVML = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/nvml"}
-cuBLAS = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cublas"}
-cuFFT = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cufft"}
-cuRAND = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/curand"}
-cuSOLVER = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusolver"}
-cuSPARSE = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusparse"}
 cuTile = {path = ".."}
 
 [compat]

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,33 +1,14 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
-CUDATools = "9ec180c6-1c07-47c7-9e6e-ebefa4d1f6d0"
-CUPTI = "9e67e8f6-ba02-4b6c-a7db-3b11ae1e7ab7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-NVML = "611af6d1-644e-4c5d-bd58-854d7d1254b9"
 NVTX = "5da4648a-3479-48b8-97b9-01cb529c0a1f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-cuBLAS = "182d3088-87b7-4494-8cad-fc6afaa545bc"
-cuFFT = "533571aa-0936-420e-b4be-9c66f5f626ca"
-cuRAND = "20fd9a0b-12d5-4c2f-a8af-7c34e9e60431"
-cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
-cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 cuTile = "0dea8319-8c4a-4662-a73d-20234d115b9a"
 
 [sources]
-CUDA = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main"}
-CUDACore = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDACore"}
-CUDATools = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDATools"}
-CUPTI = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cupti"}
-NVML = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/nvml"}
-cuBLAS = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cublas"}
-cuFFT = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cufft"}
-cuRAND = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/curand"}
-cuSOLVER = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusolver"}
-cuSPARSE = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusparse"}
 cuTile = {path = ".."}
 
 [compat]
-CUDA = "6.2.1"
+CUDA = "6.3"
 FFTW = "1.10.0"
 NVTX = "1.0.3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
-CUDATools = "9ec180c6-1c07-47c7-9e6e-ebefa4d1f6d0"
-CUPTI = "9e67e8f6-ba02-4b6c-a7db-3b11ae1e7ab7"
 DLFP8Types = "f4c16678-4a16-415b-82ef-ed337c5d6c7c"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FileCheck = "4e644321-382b-4b05-b0b6-5d23c3d944fb"
@@ -18,30 +15,13 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-cuBLAS = "182d3088-87b7-4494-8cad-fc6afaa545bc"
-cuFFT = "533571aa-0936-420e-b4be-9c66f5f626ca"
-cuRAND = "20fd9a0b-12d5-4c2f-a8af-7c34e9e60431"
-cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
-cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 cuTile = "0dea8319-8c4a-4662-a73d-20234d115b9a"
 
-[sources]
-CUDA = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main"}
-CUDACore = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDACore"}
-CUDATools = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "CUDATools"}
-CUPTI = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cupti"}
-NVML = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/nvml"}
-cuBLAS = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cublas"}
-cuFFT = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cufft"}
-cuRAND = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/curand"}
-cuSOLVER = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusolver"}
-cuSPARSE = {url = "https://github.com/JuliaGPU/CUDA.jl", rev = "main", subdir = "lib/cusparse"}
-
 [compat]
-CUDA = "6.1"
+CUDA = "6.3"
 FFTW = "1.10.0"
 FileCheck = "1.0"
 Microfloats = "0.2.3"
-NVML = "6.1"
+NVML = "6.3"
 NVTX = "1.0"
 ParallelTestRunner = "2.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,11 +69,7 @@ args = parse_args(ARGS)
 # (Set `CUDA_VISIBLE_DEVICES` to choose which device is used.)
 gpu_jobs = if device_tests
     first_gpu = first(CUDA.devices())
-    gpu_free = CUDA.device!(first_gpu) do
-        mem = CUDA.free_memory()
-        CUDA.device_reset!()
-        mem
-    end
+    gpu_free = CUDA.device!(CUDA.free_memory, first_gpu)
     max(1, Int(gpu_free) ÷ (2 * 2^30))
 else
     typemax(Int)


### PR DESCRIPTION
- Undo https://github.com/JuliaGPU/cuTile.jl/pull/300/changes/5fae4eefc00ff580ec6a44a28aee70ecbed6ac74
- Adjust CUDA compat to v6.3 in order to reflect requirements implied by #300
- Fix `device_reset!` depwarn in tests since https://github.com/JuliaGPU/CUDA.jl/pull/3178.