### PR TITLE
Apply in-place rewrites only if there are no other uses

### DIFF
--- a/src/compiler/transform/pipeline.jl
+++ b/src/compiler/transform/pipeline.jl
@@ -207,7 +207,10 @@ const COMPARISON_RULES = RewriteRule[
 
     # Nested: cmpi(addi(a, addi(b, 1)), y, <=, signed) → cmpi(addi(a, b), y, <, signed)
     # Uses inplace=true to modify the existing addi and cmpi ops' operands rather
-    # than creating new ones (which would cascade the worklist).
+    # than creating new ones (which would cascade the worklist). When the addi
+    # chain has users besides the cmpi — e.g. the same 1-based index tile also
+    # feeds a gather, whose lowering subtracts the 1 itself — the driver applies
+    # the rule in standard mode instead, leaving the chain intact for them.
     @rewrite(inplace=true,
              Intrinsics.cmpi(Intrinsics.addi(~a, Intrinsics.addi(~b, $(1))), ~y,
                               $(ComparisonPredicate.LessThanOrEqual), $(Signedness.Signed)) =>

--- a/src/compiler/transform/pipeline.jl
+++ b/src/compiler/transform/pipeline.jl
@@ -207,10 +207,8 @@ const COMPARISON_RULES = RewriteRule[
 
     # Nested: cmpi(addi(a, addi(b, 1)), y, <=, signed) → cmpi(addi(a, b), y, <, signed)
     # Uses inplace=true to modify the existing addi and cmpi ops' operands rather
-    # than creating new ones (which would cascade the worklist). When the addi
-    # chain has users besides the cmpi — e.g. the same 1-based index tile also
-    # feeds a gather, whose lowering subtracts the 1 itself — the driver applies
-    # the rule in standard mode instead, leaving the chain intact for them.
+    # than creating new ones (which would cascade the worklist), but only if the same
+    # tile is not used elsewhere.
     @rewrite(inplace=true,
              Intrinsics.cmpi(Intrinsics.addi(~a, Intrinsics.addi(~b, $(1))), ~y,
                               $(ComparisonPredicate.LessThanOrEqual), $(Signedness.Signed)) =>

--- a/src/compiler/transform/rewrite.jl
+++ b/src/compiler/transform/rewrite.jl
@@ -78,6 +78,9 @@ rather than creating new ops. The LHS and RHS trees are walked in parallel: wher
 they share the same function, the existing op is modified in-place; where the RHS
 has a different binding or constant, the operand is replaced. This avoids the
 worklist cascade that occurs when the standard mode creates new instructions.
+When an op that would be mutated has users outside the match, the driver applies
+the rule in standard (op-building) mode instead, so shared sub-expressions keep
+their value for the other users.
 """
 macro rewrite(args...)
     # Parse keyword arguments
@@ -491,9 +494,31 @@ function find_matched_ssa(driver, pat::PCall, bindings)
     return nothing
 end
 
+"""
+An in-place rewrite mutates every matched inner op (an LHS `PCall` paired with
+an RHS `RCall` below the root). That is only sound when each such op's single
+use is the match itself — any other user keeps referring to the mutated op and
+silently sees the new value. Returns `false` when an op that would be mutated
+is shared (or cannot be located).
+"""
+function inplace_mutation_sound(driver::RewriteDriver, rhs::RCall, lhs::PCall, bindings)
+    for (sub_rhs, sub_lhs) in zip(rhs.operands, lhs.operands)
+        sub_rhs isa RCall && sub_lhs isa PCall || continue
+        ssa = find_matched_ssa(driver, sub_lhs, bindings)
+        ssa isa SSAValue && use_count(driver, ssa) == 1 || return false
+        inplace_mutation_sound(driver, sub_rhs, sub_lhs, bindings) || return false
+    end
+    return true
+end
+
 function apply_rewrite!(driver::RewriteDriver, block, val::SSAValue, rule, match)
-    # In-place mode: modify matched ops' operands without creating new instructions
-    if rule.inplace
+    # In-place mode: modify matched ops' operands without creating new
+    # instructions. Only sound when the match is the single user of every op it
+    # mutates — e.g. a 1-based index tile feeding both a mask comparison and a
+    # gather (whose lowering subtracts 1) must keep its value for the gather.
+    # Shared matches fall through to the standard path below, which builds
+    # fresh ops and replaces only the root.
+    if rule.inplace && inplace_mutation_sound(driver, rule.rhs::RCall, rule.lhs, match.bindings)
         return apply_inplace_rewrite!(driver, block, val, rule, match)
     end
 

--- a/src/compiler/transform/rewrite.jl
+++ b/src/compiler/transform/rewrite.jl
@@ -495,11 +495,8 @@ function find_matched_ssa(driver, pat::PCall, bindings)
 end
 
 """
-An in-place rewrite mutates every matched inner op (an LHS `PCall` paired with
-an RHS `RCall` below the root). That is only sound when each such op's single
-use is the match itself — any other user keeps referring to the mutated op and
-silently sees the new value. Returns `false` when an op that would be mutated
-is shared (or cannot be located).
+Return true if an in-place rewrite is sound for the given match, return false
+if the op to be mutated is shared and referenced elsewhere.
 """
 function inplace_mutation_sound(driver::RewriteDriver, rhs::RCall, lhs::PCall, bindings)
     for (sub_rhs, sub_lhs) in zip(rhs.operands, lhs.operands)
@@ -512,13 +509,10 @@ function inplace_mutation_sound(driver::RewriteDriver, rhs::RCall, lhs::PCall, b
 end
 
 function apply_rewrite!(driver::RewriteDriver, block, val::SSAValue, rule, match)
-    # In-place mode: modify matched ops' operands without creating new
-    # instructions. Only sound when the match is the single user of every op it
-    # mutates — e.g. a 1-based index tile feeding both a mask comparison and a
-    # gather (whose lowering subtracts 1) must keep its value for the gather.
-    # Shared matches fall through to the standard path below, which builds
-    # fresh ops and replaces only the root.
-    if rule.inplace && inplace_mutation_sound(driver, rule.rhs::RCall, rule.lhs, match.bindings)
+    # In-place mode: modify matched ops' operands without creating new instructions.
+    # Needs to check `inplace_mutation_sound` to ensure the matched ops are not used
+    # anywhere else.
+    if rule.inplace && inplace_mutation_sound(driver, rule.rhs, rule.lhs, match.bindings)
         return apply_inplace_rewrite!(driver, block, val, rule, match)
     end
 

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -566,12 +566,9 @@ end
         end
 
         @testset "masked gather: shared 1-based index survives comparison rewrite" begin
-            # `c` feeds both the mask comparison and the gather (whose lowering
-            # subtracts the 1 itself). The comparison strength reduction
-            # (x+1 ≤ y → x < y) must not mutate the shared addi chain in place:
-            # the gather would then subtract 1 from an already 0-based index and
-            # read every lane one element too low. The mask's 0-based operand
-            # must never itself be decremented again.
+            # `c` is used in both the mask comparison and the gather. The rewrite
+            # rule `x + 1 ≤ y => x < y` must not mutate the shared addi in place,
+            # otherwise the gather sees the wrong index
             @test @filecheck begin
                 @check_label "entry"
                 @check_not "less_than_or_equal"

--- a/test/codegen/integration.jl
+++ b/test/codegen/integration.jl
@@ -565,6 +565,33 @@ end
             end
         end
 
+        @testset "masked gather: shared 1-based index survives comparison rewrite" begin
+            # `c` feeds both the mask comparison and the gather (whose lowering
+            # subtracts the 1 itself). The comparison strength reduction
+            # (x+1 ≤ y → x < y) must not mutate the shared addi chain in place:
+            # the gather would then subtract 1 from an already 0-based index and
+            # read every lane one element too low. The mask's 0-based operand
+            # must never itself be decremented again.
+            @test @filecheck begin
+                @check_label "entry"
+                @check_not "less_than_or_equal"
+                @check "cmpi less_than [[C:%[^,]+]], {{[^,]+}}, signed"
+                @check_not "subi [[C]],"
+                @check "load_ptr_tko"
+                code_tiled(Tuple{ct.TileArray{Float32,1,Int32,spec},
+                                 ct.TileArray{Float32,1,Int32,spec},
+                                 Int32}) do a, b, lim
+                    pid = ct.bid(1)
+                    off = (pid - Int32(1)) * Int32(16)
+                    c = off .+ ct.arange(16)
+                    mask = c .≤ lim
+                    tile = ct.gather(a, c; mask)
+                    ct.store(b, pid, tile)
+                    return
+                end
+            end
+        end
+
         @testset "contiguous-axis stride folds out of 2D gather offset" begin
             spec_out = ct.ArraySpec{1}(16, true)
 


### PR DESCRIPTION
Previously, the inplace rewrite rule would miscompile code like:

```julia
c = ct.arange(n)
mask = c .≤ lim
tile = ct.gather(a, c; mask)
```

since the gather would now see `c` after it has been rewritten